### PR TITLE
#469 Clean up soft-deleted timereports during employee order deletion.

### DIFF
--- a/src/main/java/org/tb/dailyreport/persistence/TimereportRepository.java
+++ b/src/main/java/org/tb/dailyreport/persistence/TimereportRepository.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Optional;
 import org.hibernate.jpa.HibernateHints;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.NativeQuery;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.CrudRepository;
@@ -137,5 +139,9 @@ public interface TimereportRepository extends CrudRepository<Timereport, Long>, 
       where tr.employeeorder.id in (:ids) group by tr.employeeorder.id
   """)
   List<Long[]> getReportedMinutesForEmployeeordersAsMap(List<Long> ids);
+
+  @Modifying
+  @NativeQuery("DELETE FROM timereport t WHERE t.employeeorder_id = :employeeorderId and t.deleted = true")
+  int hardDeleteSoftDeletedByEmployeeorderId(Long employeeorderId);
 
 }

--- a/src/main/java/org/tb/dailyreport/service/TimereportService.java
+++ b/src/main/java/org/tb/dailyreport/service/TimereportService.java
@@ -625,6 +625,8 @@ public class TimereportService {
           .toList();
       event.veto(errors);
     }
+    var deletedCount = timereportRepository.hardDeleteSoftDeletedByEmployeeorderId(employeeorderId); // ensure no soft deleted timereport exists
+    log.info("{} soft deleted timereports were deleted to allow deletion of employee order {}.", deletedCount, employeeorderId);
   }
 
   @EventListener


### PR DESCRIPTION
Added a repository method to hard delete soft-deleted timereports by employee order ID. Ensured these records are removed before allowing the deletion of the associated employee order, improving data consistency.