### PR TITLE
#479 Use correct sign field in Suborder creation form.

### DIFF
--- a/src/main/java/org/tb/order/service/SuborderService.java
+++ b/src/main/java/org/tb/order/service/SuborderService.java
@@ -177,7 +177,7 @@ public class SuborderService {
   private AddSuborderForm createForm(Suborder so, LocalDate newFrom, LocalDate newUntil) {
     AddSuborderForm soForm = new AddSuborderForm();
     soForm.setCustomerorderId(so.getCustomerorder().getId());
-    soForm.setSign(so.getCompleteOrderSign());
+    soForm.setSign(so.getSign());
     soForm.setDescription(so.getDescription());
     soForm.setShortdescription(so.getShortdescription());
     soForm.setInvoice(so.getInvoice());


### PR DESCRIPTION
Replaced the `getCompleteOrderSign` method call with `getSign` to ensure the proper sign field is used when creating a Suborder form. This change aligns with expected behavior and fixes potential mismatches in the form data.