### PR TITLE
#528 Add visibility check for timereport rows in Excel export

### DIFF
--- a/src/main/java/org/tb/invoice/service/ExcelExportService.java
+++ b/src/main/java/org/tb/invoice/service/ExcelExportService.java
@@ -100,7 +100,9 @@ public class ExcelExportService {
                 List<InvoiceTimereport> invoiceTimereports = invoiceSuborder.getTimereports();
                 if (invoiceData.getInvoiceOptions().isShowTimereports()) {
                     for (var invoiceTimereport : invoiceTimereports) {
-                        rowIndex = addTimereportDataRow(workbook, rowIndex, invoiceTimereport, invoiceData.getInvoiceOptions(), factory);
+                        if(invoiceTimereport.isVisible()) {
+                            rowIndex = addTimereportDataRow(workbook, rowIndex, invoiceTimereport, invoiceData.getInvoiceOptions(), factory);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Only include timereports marked as visible when generating invoice suborder data in Excel.