### PR TITLE
Refactor: move determineBeginTimeToDisplay to WorkingdayService

### DIFF
--- a/src/main/java/org/tb/dailyreport/action/CreateDailyReportAction.java
+++ b/src/main/java/org/tb/dailyreport/action/CreateDailyReportAction.java
@@ -11,6 +11,7 @@ import static org.tb.common.util.DateTimeUtils.now;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -109,9 +110,9 @@ public class CreateDailyReportAction extends DailyReportAction<AddDailyReportFor
 
         // set the begin time as the end time of the latest existing timereport of current employee
         // for current day. If no other reports exist so far, set standard begin time (0800).
-        long[] beginTime = timereportHelper.determineBeginTimeToDisplay(ec.getId(), selectedDate, workingday);
-        form.setSelectedHourBegin(beginTime[0]);
-        form.setSelectedMinuteBegin(beginTime[1]);
+        Duration beginTime = workingdayService.determineBeginTimeToDisplay(ec.getId(), selectedDate, workingday);
+        form.setSelectedHourBegin(beginTime.toHours());
+        form.setSelectedMinuteBegin(beginTime.toMinutesPart());
         //		TimereportHelper.refreshHours(reportForm);
 
         if (workingDayIsAvailable) {
@@ -124,12 +125,14 @@ public class CreateDailyReportAction extends DailyReportAction<AddDailyReportFor
             // propose minutes with quarter hour precision
             minute = minute - minute % GlobalConstants.QUARTER_HOUR_IN_MINUTES;
 
-            if ((beginTime[0] < hour || beginTime[0] == hour && beginTime[1] < minute) && selectedDate.equals(today)) {
+            long beginHours = beginTime.toHours();
+            long beginMinutes = beginTime.toMinutesPart();
+            if ((beginHours < hour || beginHours == hour && beginMinutes < minute) && selectedDate.equals(today)) {
                 form.setSelectedMinuteEnd(minute);
                 form.setSelectedHourEnd(hour);
             } else {
-                form.setSelectedMinuteEnd(beginTime[1]);
-                form.setSelectedHourEnd(beginTime[0]);
+                form.setSelectedMinuteEnd(beginMinutes);
+                form.setSelectedHourEnd(beginHours);
             }
 
             form.setSelectedHourBeginDay(workingday.getStarttimehour());

--- a/src/main/java/org/tb/dailyreport/action/StoreDailyReportAction.java
+++ b/src/main/java/org/tb/dailyreport/action/StoreDailyReportAction.java
@@ -113,9 +113,9 @@ public class StoreDailyReportAction extends DailyReportAction<AddDailyReportForm
 
                 // set the begin time as the end time of the latest existing timereport of current employee
                 // for current day. If no other reports exist so far, set standard begin time (0800).
-                long[] beginTime = timereportHelper.determineBeginTimeToDisplay(employeeContract.getId(), referenceDay, workingday);
-                long beginHours = beginTime[0];
-                long beginMinutes = beginTime[1];
+                Duration beginTime = workingdayService.determineBeginTimeToDisplay(employeeContract.getId(), referenceDay, workingday);
+                long beginHours = beginTime.toHours();
+                long beginMinutes = beginTime.toMinutesPart();
                 form.setSelectedHourBegin(beginHours);
                 form.setSelectedMinuteBegin(beginMinutes);
 
@@ -310,9 +310,9 @@ public class StoreDailyReportAction extends DailyReportAction<AddDailyReportForm
                 form.setNumberOfSerialDays(0);
 
                 if (workingday != null) {
-                    long[] beginTime = timereportHelper.determineBeginTimeToDisplay(form.getEmployeeContractId(), selectedDate, workingday);
-                    long beginHours = beginTime[0];
-                    long beginMinutes = beginTime[1];
+                    Duration beginTime = workingdayService.determineBeginTimeToDisplay(form.getEmployeeContractId(), selectedDate, workingday);
+                    long beginHours = beginTime.toHours();
+                    long beginMinutes = beginTime.toMinutesPart();
                     form.setSelectedHourBegin(beginHours);
                     form.setSelectedMinuteBegin(beginMinutes);
                     form.setNumberOfSerialDays(0);

--- a/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
+++ b/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
@@ -9,6 +9,7 @@ import static org.tb.common.exception.ErrorCode.WD_UPSERT_REQ_EMPLOYEE_OR_MANAGE
 import static org.tb.common.util.DateUtils.today;
 import static org.tb.dailyreport.domain.Workingday.WorkingDayType.NOT_WORKED;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +24,7 @@ import org.tb.common.exception.AuthorizationException;
 import org.tb.common.util.BusinessRuleCheckUtils;
 import org.tb.common.util.DateUtils;
 import org.tb.dailyreport.domain.Publicholiday;
+import org.tb.dailyreport.domain.TimereportDTO;
 import org.tb.dailyreport.domain.Workingday;
 import org.tb.dailyreport.persistence.PublicholidayRepository;
 import org.tb.dailyreport.persistence.TimereportDAO;
@@ -133,6 +135,21 @@ public class WorkingdayService {
       throw new AuthorizationException(WD_READ_REQ_EMPLOYEE_OR_MANAGER);
     }
     return workingdayDAO.getWorkingdaysByEmployeeContractId(employeeContractId, dateFirst, dateLast);
+  }
+
+  public Duration determineBeginTimeToDisplay(long ecId, LocalDate date, Workingday workingday) {
+    Duration elapsed = timereportDAO.getTimereportsByDateAndEmployeeContractId(ecId, date)
+        .stream()
+        .map(TimereportDTO::getDuration)
+        .reduce(Duration.ZERO, Duration::plus);
+    if (workingday != null) {
+      elapsed = elapsed
+          .plusHours(workingday.getStarttimehour())
+          .plusMinutes(workingday.getStarttimeminute())
+          .plusHours(workingday.getBreakhours())
+          .plusMinutes(workingday.getBreakminutes());
+    }
+    return elapsed;
   }
 
   @EventListener

--- a/src/main/java/org/tb/dailyreport/viewhelper/TimereportHelper.java
+++ b/src/main/java/org/tb/dailyreport/viewhelper/TimereportHelper.java
@@ -97,44 +97,6 @@ public class TimereportHelper {
     return errors;
   }
 
-  /**
-   * @return Returns the working time for one day as an int array with length 2. The hours are at index[0], the minutes
-   * at index[1].
-   */
-  private long[] getWorkingTimeForDateAndEmployeeContract(LocalDate date, long employeeContractId) {
-    long[] workingTime = new long[2];
-    List<TimereportDTO> timereports = timereportService.getTimereportsByDateAndEmployeeContractId(employeeContractId,
-        date);
-    long hours = 0;
-    long minutes = 0;
-    for (TimereportDTO timereport : timereports) {
-      hours += timereport.getDuration().toHours();
-      minutes += timereport.getDuration().toMinutesPart();
-    }
-    hours += minutes / MINUTES_PER_HOUR;
-    minutes = minutes % MINUTES_PER_HOUR;
-    workingTime[0] = hours;
-    workingTime[1] = minutes;
-
-    return workingTime;
-  }
-
-  /**
-   * @return Returns int[]  0=hours 1=minutes
-   */
-  public long[] determineBeginTimeToDisplay(long ecId, LocalDate date, Workingday workingday) {
-    long[] beginTime = getWorkingTimeForDateAndEmployeeContract(date, ecId);
-    if (workingday != null) {
-      beginTime[0] += workingday.getStarttimehour();
-      beginTime[1] += workingday.getStarttimeminute();
-      beginTime[0] += workingday.getBreakhours();
-      beginTime[1] += workingday.getBreakminutes();
-      beginTime[0] += beginTime[1] / MINUTES_PER_HOUR;
-      beginTime[1] = beginTime[1] % MINUTES_PER_HOUR;
-    }
-    return beginTime;
-  }
-
   public long[] determineTimesToDisplay(long ecId, LocalDate date, Workingday workingday, TimereportDTO tr) {
     List<TimereportDTO> timereports = timereportService.getTimereportsByDateAndEmployeeContractId(ecId, date);
     if (workingday != null) {


### PR DESCRIPTION
## Summary
- Moves `TimereportHelper#determineBeginTimeToDisplay` to `WorkingdayService` where it belongs as business logic (listed in README under "Business-logic that should be refactored")
- Replaces `long[]` return type with `Duration`, eliminating manual carry arithmetic and the private helper `getWorkingTimeForDateAndEmployeeContract`
- Updates all three call sites in `StoreDailyReportAction` and `CreateDailyReportAction`

Closes #601

## Test plan
- [x] `./mvnw compile` passes
- [x] `./mvnw test` passes
- [x] Manual smoke test: create a daily report and verify the suggested begin time populates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)