### PR TITLE
Refactor: move determineTimesToDisplay to WorkingdayService

### DIFF
--- a/src/main/java/org/tb/dailyreport/action/CreateDailyReportAction.java
+++ b/src/main/java/org/tb/dailyreport/action/CreateDailyReportAction.java
@@ -11,8 +11,8 @@ import static org.tb.common.util.DateTimeUtils.now;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -110,9 +110,9 @@ public class CreateDailyReportAction extends DailyReportAction<AddDailyReportFor
 
         // set the begin time as the end time of the latest existing timereport of current employee
         // for current day. If no other reports exist so far, set standard begin time (0800).
-        Duration beginTime = workingdayService.determineBeginTimeToDisplay(ec.getId(), selectedDate, workingday);
-        form.setSelectedHourBegin(beginTime.toHours());
-        form.setSelectedMinuteBegin(beginTime.toMinutesPart());
+        LocalTime beginTime = workingdayService.determineBeginTimeToDisplay(ec.getId(), selectedDate, workingday);
+        form.setSelectedHourBegin(beginTime.getHour());
+        form.setSelectedMinuteBegin(beginTime.getMinute());
         //		TimereportHelper.refreshHours(reportForm);
 
         if (workingDayIsAvailable) {
@@ -125,8 +125,8 @@ public class CreateDailyReportAction extends DailyReportAction<AddDailyReportFor
             // propose minutes with quarter hour precision
             minute = minute - minute % GlobalConstants.QUARTER_HOUR_IN_MINUTES;
 
-            long beginHours = beginTime.toHours();
-            long beginMinutes = beginTime.toMinutesPart();
+            long beginHours = beginTime.getHour();
+            long beginMinutes = beginTime.getMinute();
             if ((beginHours < hour || beginHours == hour && beginMinutes < minute) && selectedDate.equals(today)) {
                 form.setSelectedMinuteEnd(minute);
                 form.setSelectedHourEnd(hour);

--- a/src/main/java/org/tb/dailyreport/action/EditDailyReportAction.java
+++ b/src/main/java/org/tb/dailyreport/action/EditDailyReportAction.java
@@ -130,13 +130,15 @@ public class EditDailyReportAction extends DailyReportAction<AddDailyReportForm>
         }
 
         request.getSession().setAttribute("workingDayIsAvailable", workingDayIsAvailable);
-        long[] displayTime = timereportHelper.determineTimesToDisplay(ec.getId(), reportDate, workingday, tr);
+        var displayTime = workingdayService.determineTimesToDisplay(ec.getId(), reportDate, workingday, tr);
 
         if (workingDayIsAvailable) {
-            reportForm.setSelectedHourBegin(displayTime[0]);
-            reportForm.setSelectedMinuteBegin(displayTime[1]);
-            reportForm.setSelectedHourEnd(displayTime[2]);
-            reportForm.setSelectedMinuteEnd(displayTime[3]);
+            displayTime.ifPresent(dt -> {
+                reportForm.setSelectedHourBegin(dt.begin().getHour());
+                reportForm.setSelectedMinuteBegin(dt.begin().getMinute());
+                reportForm.setSelectedHourEnd(dt.end().getHour());
+                reportForm.setSelectedMinuteEnd(dt.end().getMinute());
+            });
             reportForm.setSelectedHourBeginDay(workingday.getStarttimehour());
             reportForm.setSelectedMinuteBeginDay(workingday.getStarttimeminute());
             timereportHelper.refreshHours(reportForm);

--- a/src/main/java/org/tb/dailyreport/action/StoreDailyReportAction.java
+++ b/src/main/java/org/tb/dailyreport/action/StoreDailyReportAction.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -113,9 +114,9 @@ public class StoreDailyReportAction extends DailyReportAction<AddDailyReportForm
 
                 // set the begin time as the end time of the latest existing timereport of current employee
                 // for current day. If no other reports exist so far, set standard begin time (0800).
-                Duration beginTime = workingdayService.determineBeginTimeToDisplay(employeeContract.getId(), referenceDay, workingday);
-                long beginHours = beginTime.toHours();
-                long beginMinutes = beginTime.toMinutesPart();
+                LocalTime beginTime = workingdayService.determineBeginTimeToDisplay(employeeContract.getId(), referenceDay, workingday);
+                long beginHours = beginTime.getHour();
+                long beginMinutes = beginTime.getMinute();
                 form.setSelectedHourBegin(beginHours);
                 form.setSelectedMinuteBegin(beginMinutes);
 
@@ -310,9 +311,9 @@ public class StoreDailyReportAction extends DailyReportAction<AddDailyReportForm
                 form.setNumberOfSerialDays(0);
 
                 if (workingday != null) {
-                    Duration beginTime = workingdayService.determineBeginTimeToDisplay(form.getEmployeeContractId(), selectedDate, workingday);
-                    long beginHours = beginTime.toHours();
-                    long beginMinutes = beginTime.toMinutesPart();
+                    LocalTime beginTime = workingdayService.determineBeginTimeToDisplay(form.getEmployeeContractId(), selectedDate, workingday);
+                    long beginHours = beginTime.getHour();
+                    long beginMinutes = beginTime.getMinute();
                     form.setSelectedHourBegin(beginHours);
                     form.setSelectedMinuteBegin(beginMinutes);
                     form.setNumberOfSerialDays(0);

--- a/src/main/java/org/tb/dailyreport/service/TimesDisplay.java
+++ b/src/main/java/org/tb/dailyreport/service/TimesDisplay.java
@@ -1,0 +1,5 @@
+package org.tb.dailyreport.service;
+
+import java.time.LocalTime;
+
+public record TimesDisplay(LocalTime begin, LocalTime end) {}

--- a/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
+++ b/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
@@ -11,7 +11,9 @@ import static org.tb.dailyreport.domain.Workingday.WorkingDayType.NOT_WORKED;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -137,7 +139,7 @@ public class WorkingdayService {
     return workingdayDAO.getWorkingdaysByEmployeeContractId(employeeContractId, dateFirst, dateLast);
   }
 
-  public Duration determineBeginTimeToDisplay(long ecId, LocalDate date, Workingday workingday) {
+  public LocalTime determineBeginTimeToDisplay(long ecId, LocalDate date, Workingday workingday) {
     Duration elapsed = timereportDAO.getTimereportsByDateAndEmployeeContractId(ecId, date)
         .stream()
         .map(TimereportDTO::getDuration)
@@ -149,7 +151,25 @@ public class WorkingdayService {
           .plusHours(workingday.getBreakhours())
           .plusMinutes(workingday.getBreakminutes());
     }
-    return elapsed;
+    return LocalTime.MIDNIGHT.plus(elapsed);
+  }
+
+  public Optional<TimesDisplay> determineTimesToDisplay(long ecId, LocalDate date, Workingday workingday, TimereportDTO tr) {
+    if (workingday == null) return Optional.empty();
+    List<TimereportDTO> timereports = timereportDAO.getTimereportsByDateAndEmployeeContractId(ecId, date);
+    Duration beginDuration = Duration.ofHours(workingday.getStarttimehour())
+        .plusMinutes(workingday.getStarttimeminute())
+        .plusHours(workingday.getBreakhours())
+        .plusMinutes(workingday.getBreakminutes());
+    for (TimereportDTO timereport : timereports) {
+      if (Objects.equals(timereport.getId(), tr.getId())) break;
+      beginDuration = beginDuration.plus(timereport.getDuration());
+    }
+    Duration endDuration = beginDuration.plus(tr.getDuration());
+    return Optional.of(new TimesDisplay(
+        LocalTime.MIDNIGHT.plus(beginDuration),
+        LocalTime.MIDNIGHT.plus(endDuration)
+    ));
   }
 
   @EventListener

--- a/src/main/java/org/tb/dailyreport/viewhelper/TimereportHelper.java
+++ b/src/main/java/org/tb/dailyreport/viewhelper/TimereportHelper.java
@@ -97,33 +97,6 @@ public class TimereportHelper {
     return errors;
   }
 
-  public long[] determineTimesToDisplay(long ecId, LocalDate date, Workingday workingday, TimereportDTO tr) {
-    List<TimereportDTO> timereports = timereportService.getTimereportsByDateAndEmployeeContractId(ecId, date);
-    if (workingday != null) {
-      long hourBegin = workingday.getStarttimehour();
-      long minuteBegin = workingday.getStarttimeminute();
-      hourBegin += workingday.getBreakhours();
-      minuteBegin += workingday.getBreakminutes();
-      for (TimereportDTO timereport : timereports) {
-        if (Objects.equals(timereport.getId(), tr.getId())) {
-          break;
-        }
-        hourBegin += timereport.getDuration().toHours();
-        minuteBegin += timereport.getDuration().toMinutesPart();
-      }
-      long hourEnd = hourBegin + tr.getDuration().toHours();
-      long minuteEnd = minuteBegin + tr.getDuration().toMinutesPart();
-      hourBegin += minuteBegin / MINUTES_PER_HOUR;
-      minuteBegin = minuteBegin % MINUTES_PER_HOUR;
-      hourEnd += minuteEnd / MINUTES_PER_HOUR;
-      minuteEnd = minuteEnd % MINUTES_PER_HOUR;
-
-      return new long[]{hourBegin, minuteBegin, hourEnd, minuteEnd};
-    } else {
-      return new long[4];
-    }
-  }
-
   /**
    * Calculates the overall labortime for a list of {@link Timereport}s.
    *


### PR DESCRIPTION
## Summary
- Moves `TimereportHelper#determineTimesToDisplay` to `WorkingdayService` (listed in README under "Business-logic that should be refactored")
- Introduces `TimesDisplay(LocalTime begin, LocalTime end)` record to replace `long[4]` with magic indices
- Also changes `determineBeginTimeToDisplay` return type from `Duration` → `LocalTime` — both methods return clock times, not durations; `LocalTime` is the semantically correct type

Closes #602

## Test plan
- [x] `./mvnw compile` passes
- [x] `./mvnw test` passes
- [x] Manual smoke test: edit an existing daily report and verify begin/end times are pre-populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)