### PR TITLE
Refactor: move checkLaborTimeMaximum to WorkingdayService

### DIFF
--- a/src/main/java/org/tb/dailyreport/action/ShowDailyReportAction.java
+++ b/src/main/java/org/tb/dailyreport/action/ShowDailyReportAction.java
@@ -402,7 +402,7 @@ public class ShowDailyReportAction extends DailyReportAction<ShowDailyReportForm
       List<TimereportDTO> timereports = (List<TimereportDTO>) request.getSession().getAttribute("timereports");
       request.getSession().setAttribute("labortime", timereportHelper.calculateLaborTime(timereports));
       request.getSession().setAttribute("maxlabortime",
-          timereportHelper.checkLaborTimeMaximum(timereports, GlobalConstants.MAX_HOURS_PER_DAY));
+          workingdayService.checkLaborTimeMaximum(timereports));
       request.getSession().setAttribute("reportForm", reportForm);
       return mapping.findForward("success");
     }
@@ -419,7 +419,7 @@ public class ShowDailyReportAction extends DailyReportAction<ShowDailyReportForm
       List<TimereportDTO> timereports = (List<TimereportDTO>) request.getSession().getAttribute("timereports");
       request.getSession().setAttribute("labortime", timereportHelper.calculateLaborTime(timereports));
       request.getSession().setAttribute("maxlabortime",
-          timereportHelper.checkLaborTimeMaximum(timereports, GlobalConstants.MAX_HOURS_PER_DAY));
+          workingdayService.checkLaborTimeMaximum(timereports));
       request.getSession().setAttribute("reportForm", reportForm);
       return mapping.findForward("success");
     }
@@ -651,7 +651,7 @@ public class ShowDailyReportAction extends DailyReportAction<ShowDailyReportForm
 
         request.getSession().setAttribute("labortime", timereportHelper.calculateLaborTime(timereports));
         request.getSession().setAttribute("maxlabortime",
-            timereportHelper.checkLaborTimeMaximum(timereports, GlobalConstants.MAX_HOURS_PER_DAY));
+            workingdayService.checkLaborTimeMaximum(timereports));
 
         if (reportForm.getEmployeeContractId() == -1) {
           request.getSession().setAttribute("currentEmployeeId", -1);
@@ -855,7 +855,7 @@ public class ShowDailyReportAction extends DailyReportAction<ShowDailyReportForm
       String laborTimeString = timereportHelper.calculateLaborTime(timereports);
       request.getSession().setAttribute("labortime", laborTimeString);
       request.getSession().setAttribute("maxlabortime",
-          timereportHelper.checkLaborTimeMaximum(timereports, GlobalConstants.MAX_HOURS_PER_DAY));
+          workingdayService.checkLaborTimeMaximum(timereports));
       // refresh workingday
       Workingday workingday;
       try {
@@ -941,7 +941,7 @@ public class ShowDailyReportAction extends DailyReportAction<ShowDailyReportForm
       String laborTimeString = timereportHelper.calculateLaborTime(timereports);
       request.getSession().setAttribute("labortime", laborTimeString);
       request.getSession().setAttribute("maxlabortime",
-          timereportHelper.checkLaborTimeMaximum(timereports, GlobalConstants.MAX_HOURS_PER_DAY));
+          workingdayService.checkLaborTimeMaximum(timereports));
       if (request.getSession().getAttribute("timereportComparator") != null) {
         @SuppressWarnings("unchecked")
         Comparator<TimereportDTO> comparator = (Comparator<TimereportDTO>) request.getSession()

--- a/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
+++ b/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
@@ -6,6 +6,7 @@ import static org.tb.common.exception.ErrorCode.WD_NOT_WORKED_TIMEREPORTS_FOUND;
 import static org.tb.common.exception.ErrorCode.WD_OUTSIDE_CONTRACT;
 import static org.tb.common.exception.ErrorCode.WD_READ_REQ_EMPLOYEE_OR_MANAGER;
 import static org.tb.common.exception.ErrorCode.WD_UPSERT_REQ_EMPLOYEE_OR_MANAGER;
+import static org.tb.common.GlobalConstants.MAX_HOURS_PER_DAY;
 import static org.tb.common.util.DateUtils.today;
 import static org.tb.dailyreport.domain.Workingday.WorkingDayType.NOT_WORKED;
 
@@ -170,6 +171,11 @@ public class WorkingdayService {
         LocalTime.MIDNIGHT.plus(beginDuration),
         LocalTime.MIDNIGHT.plus(endDuration)
     ));
+  }
+
+  public boolean checkLaborTimeMaximum(List<TimereportDTO> timereports) {
+    Duration actual = timereports.stream().map(TimereportDTO::getDuration).reduce(Duration.ZERO, Duration::plus);
+    return Duration.ofHours(MAX_HOURS_PER_DAY).minus(actual).isNegative();
   }
 
   @EventListener

--- a/src/main/java/org/tb/dailyreport/viewhelper/TimereportHelper.java
+++ b/src/main/java/org/tb/dailyreport/viewhelper/TimereportHelper.java
@@ -102,18 +102,6 @@ public class TimereportHelper {
     return "%02d:%02d".formatted(total.toHours(), total.toMinutesPart());
   }
 
-  /**
-   * Checks, if the overall labortime for a list of {@link Timereport}s extends the maximal daily labor time.
-   *
-   * @return Returns true, if the maximal labor time is extended, false otherwise
-   */
-  public boolean checkLaborTimeMaximum(List<TimereportDTO> timereports, int maxDailyLaborTimeHours) {
-
-    Duration actual = timereports.stream().map(TimereportDTO::getDuration).reduce(Duration.ZERO, Duration::plus);
-
-    // check actual is not greater than the max labor time
-    return Duration.ofHours(maxDailyLaborTimeHours).minus(actual).isNegative();
-  }
 
   public String calculateWorkingDayEnds(Workingday workingday, HttpServletRequest request) {
     if (workingday == null) {


### PR DESCRIPTION
## Summary
- Moves `TimereportHelper#checkLaborTimeMaximum` to `WorkingdayService`
- Drops the `maxDailyLaborTimeHours` parameter — all 5 callers always passed `MAX_HOURS_PER_DAY`, which is now encoded directly in the method
- Updates all 5 call sites in `ShowDailyReportAction`

Closes #604

## Test plan
- [x] `./mvnw compile` passes
- [x] `./mvnw test` passes
- [x] Manual smoke test: verify the "max labor time exceeded" warning still appears on the daily report screen when booking more than 10 hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)