### PR TITLE
Move TrainingHelper#fromDBtimeToString to DurationUtils#formatWithWorkingdays

### DIFF
--- a/src/main/java/org/tb/common/util/DurationUtils.java
+++ b/src/main/java/org/tb/common/util/DurationUtils.java
@@ -102,6 +102,21 @@ public class DurationUtils {
     }
   }
 
+  public static String formatWithWorkingdays(Duration duration, Duration dailyWorkingTime) {
+    long trainingDays = 0;
+    long trainingHours = 0;
+    long trainingMinutes = 0;
+    long totalMinutes = duration.toMinutes();
+    long dailyMinutes = dailyWorkingTime.toMinutes();
+    if (dailyMinutes != 0) {
+      trainingDays = totalMinutes / dailyMinutes;
+      long restMinutes = totalMinutes % dailyMinutes;
+      trainingHours = restMinutes / MINUTES_PER_HOUR;
+      trainingMinutes = restMinutes % MINUTES_PER_HOUR;
+    }
+    return "%02d:%02d:%02d".formatted(trainingDays, trainingHours, trainingMinutes);
+  }
+
   public static String decimalFormat(Duration duration) {
     if(duration == null) {
       return "";

--- a/src/main/java/org/tb/dailyreport/action/ShowTrainingAction.java
+++ b/src/main/java/org/tb/dailyreport/action/ShowTrainingAction.java
@@ -9,6 +9,7 @@ import static org.tb.common.util.DateUtils.today;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.text.ParseException;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ import org.tb.auth.struts.LoginRequiredAction;
 import org.tb.common.GlobalConstants;
 import org.tb.common.OptionItem;
 import org.tb.common.util.DateUtils;
+import org.tb.common.util.DurationUtils;
 import org.tb.dailyreport.domain.TrainingInformation;
 import org.tb.dailyreport.domain.TrainingOverview;
 import org.tb.dailyreport.service.TrainingService;
@@ -194,20 +196,20 @@ public class ShowTrainingAction extends LoginRequiredAction<ShowTrainingForm> {
                 to = new TrainingOverview(year, empCon, GlobalConstants.ZERO_DHM, GlobalConstants.ZERO_DHM, GlobalConstants.ZERO_HM, GlobalConstants.ZERO_HM);
             } else if (commonTraining == null) {
                 int[] ti = TrainingHelper.getHoursMin(projectTraining);
-                String time = TrainingHelper.fromDBtimeToString(empCon, ti[0], ti[1]);
+                String time = DurationUtils.formatWithWorkingdays(Duration.ofHours(ti[0]).plusMinutes(ti[1]), empCon.getDailyWorkingTime());
                 String hoursMin = TrainingHelper.hoursMinToString(ti);
                 to = new TrainingOverview(year, empCon, time, GlobalConstants.ZERO_DHM, hoursMin, GlobalConstants.ZERO_HM);
             } else if (projectTraining == null) {
                 int[] ti = TrainingHelper.getHoursMin(commonTraining);
-                String time = TrainingHelper.fromDBtimeToString(empCon, ti[0], ti[1]);
+                String time = DurationUtils.formatWithWorkingdays(Duration.ofHours(ti[0]).plusMinutes(ti[1]), empCon.getDailyWorkingTime());
                 String hoursMin = TrainingHelper.hoursMinToString(ti);
                 to = new TrainingOverview(year, empCon, GlobalConstants.ZERO_DHM, time, GlobalConstants.ZERO_HM, hoursMin);
             } else {
                 int[] tcT = TrainingHelper.getHoursMin(commonTraining);
-                String commonTime = TrainingHelper.fromDBtimeToString(empCon, tcT[0], tcT[1]);
+                String commonTime = DurationUtils.formatWithWorkingdays(Duration.ofHours(tcT[0]).plusMinutes(tcT[1]), empCon.getDailyWorkingTime());
                 String cHoursMin = TrainingHelper.hoursMinToString(tcT);
                 int[] tpT = TrainingHelper.getHoursMin(projectTraining);
-                String projectTime = TrainingHelper.fromDBtimeToString(empCon, tpT[0], tpT[1]);
+                String projectTime = DurationUtils.formatWithWorkingdays(Duration.ofHours(tpT[0]).plusMinutes(tpT[1]), empCon.getDailyWorkingTime());
                 String pHoursMin = TrainingHelper.hoursMinToString(tpT);
                 to = new TrainingOverview(year, empCon, projectTime, commonTime, pHoursMin, cHoursMin);
             }
@@ -234,10 +236,10 @@ public class ShowTrainingAction extends LoginRequiredAction<ShowTrainingForm> {
             .orElse(new TrainingInformation(ec.getId(), 0, 0));
 
         int[] cTime = TrainingHelper.getHoursMin(cTT);
-        String commonTrainingTime = TrainingHelper.fromDBtimeToString(ec, cTime[0], cTime[1]);
+        String commonTrainingTime = DurationUtils.formatWithWorkingdays(Duration.ofHours(cTime[0]).plusMinutes(cTime[1]), ec.getDailyWorkingTime());
         String cHoursMin = TrainingHelper.hoursMinToString(cTime);
         int[] pTime = TrainingHelper.getHoursMin(pTT);
-        String projectTrainingTime = TrainingHelper.fromDBtimeToString(ec, pTime[0], pTime[1]);
+        String projectTrainingTime = DurationUtils.formatWithWorkingdays(Duration.ofHours(pTime[0]).plusMinutes(pTime[1]), ec.getDailyWorkingTime());
         String pHoursMin = TrainingHelper.hoursMinToString(pTime);
 
         TrainingOverview to = new TrainingOverview(year, ec, projectTrainingTime, commonTrainingTime, pHoursMin, cHoursMin);

--- a/src/main/java/org/tb/dailyreport/viewhelper/TrainingHelper.java
+++ b/src/main/java/org/tb/dailyreport/viewhelper/TrainingHelper.java
@@ -3,49 +3,12 @@ package org.tb.dailyreport.viewhelper;
 import static org.tb.common.GlobalConstants.MINUTES_PER_HOUR;
 
 import org.tb.dailyreport.domain.TrainingInformation;
-import org.tb.employee.domain.Employeecontract;
 
 public class TrainingHelper {
 
     public static int[] getHoursMin(TrainingInformation trainingInformation) {
         if(trainingInformation == null) return new int[] {0, 0};
         return new int[] {(int) trainingInformation.getDurationHours(), (int) trainingInformation.getDurationMinutes()};
-    }
-
-    public static String fromDBtimeToString(Employeecontract ec, int hours, int minutes) {
-
-        long trainingDays = 0;
-        long trainingHours = 0;
-        long trainingMinutes = 0;
-
-        long totalTrainingMinutes = hours * MINUTES_PER_HOUR + minutes;
-
-        long dailyWorkingTimeMinutes = ec.getDailyWorkingTime().toMinutes();
-
-        if (dailyWorkingTimeMinutes != 0) {
-            trainingDays = totalTrainingMinutes / dailyWorkingTimeMinutes;
-            var restMinutes = totalTrainingMinutes % dailyWorkingTimeMinutes;
-            trainingHours = restMinutes / MINUTES_PER_HOUR;
-            trainingMinutes = restMinutes % MINUTES_PER_HOUR;
-        }
-
-        StringBuilder trainingString = new StringBuilder();
-        if (trainingDays < 10) {
-            trainingString.append('0');
-        }
-        trainingString.append(trainingDays);
-        trainingString.append(':');
-        if (trainingHours < 10) {
-            trainingString.append('0');
-        }
-        trainingString.append(trainingHours);
-        trainingString.append(':');
-        if (trainingMinutes < 10) {
-            trainingString.append('0');
-        }
-        trainingString.append(trainingMinutes);
-
-        return trainingString.toString();
     }
 
     public static String hoursMinToString(int[] time) {


### PR DESCRIPTION
## Summary

- Adds `DurationUtils.formatWithWorkingdays(Duration, Duration)` — formats a duration as `DD:HH:MM` relative to a daily working time
- Removes `TrainingHelper.fromDBtimeToString` (business logic that did not belong in the viewhelper layer)
- Updates all 6 call sites in `ShowTrainingAction` to use `DurationUtils.formatWithWorkingdays`

## Test plan

- [x] Build compiles cleanly
- [x] Training overview page shows correct `DD:HH:MM` values for common and project training times

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)