### PR TITLE
Refactor: remove determineTimesToDisplay from edit flow

### DIFF
--- a/src/main/java/org/tb/dailyreport/action/EditDailyReportAction.java
+++ b/src/main/java/org/tb/dailyreport/action/EditDailyReportAction.java
@@ -18,10 +18,7 @@ import org.apache.struts.action.ActionMapping;
 import org.springframework.stereotype.Component;
 import org.tb.common.util.DateUtils;
 import org.tb.dailyreport.domain.TimereportDTO;
-import org.tb.dailyreport.domain.Workingday;
 import org.tb.dailyreport.service.TimereportService;
-import org.tb.dailyreport.service.WorkingdayService;
-import org.tb.dailyreport.viewhelper.TimereportHelper;
 import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeecontractService;
 import org.tb.order.domain.Customerorder;
@@ -43,8 +40,6 @@ public class EditDailyReportAction extends DailyReportAction<AddDailyReportForm>
     private final CustomerorderService customerorderService;
     private final SuborderService suborderService;
     private final EmployeecontractService employeecontractService;
-    private final WorkingdayService workingdayService;
-    private final TimereportHelper timereportHelper;
 
     @Override
     public ActionForward executeAuthenticated(ActionMapping mapping, AddDailyReportForm reportForm, HttpServletRequest request, HttpServletResponse response) {
@@ -115,39 +110,11 @@ public class EditDailyReportAction extends DailyReportAction<AddDailyReportForm>
         reportForm.setEmployeeContractId(ec.getId());
 
         reportForm.setReferenceday(DateUtils.format(utilDate));
-        LocalDate reportDate = tr.getReferenceday();
-        Workingday workingday = workingdayService.getWorkingday(ec.getId(), reportDate);
-
-        boolean workingDayIsAvailable = false;
-        if (workingday != null) {
-            workingDayIsAvailable = true;
-        }
-
-        // workingday should only be available for today
-        LocalDate today = DateUtils.today();
-        if (!utilDate.equals(today)) {
-            workingDayIsAvailable = false;
-        }
-
-        request.getSession().setAttribute("workingDayIsAvailable", workingDayIsAvailable);
-        var displayTime = workingdayService.determineTimesToDisplay(ec.getId(), reportDate, workingday, tr);
-
-        if (workingDayIsAvailable) {
-            displayTime.ifPresent(dt -> {
-                reportForm.setSelectedHourBegin(dt.begin().getHour());
-                reportForm.setSelectedMinuteBegin(dt.begin().getMinute());
-                reportForm.setSelectedHourEnd(dt.end().getHour());
-                reportForm.setSelectedMinuteEnd(dt.end().getMinute());
-            });
-            reportForm.setSelectedHourBeginDay(workingday.getStarttimehour());
-            reportForm.setSelectedMinuteBeginDay(workingday.getStarttimeminute());
-            timereportHelper.refreshHours(reportForm);
-        } else {
-            reportForm.setSelectedHourDuration(tr.getDuration().toHours());
-            reportForm.setSelectedMinuteDuration(tr.getDuration().toMinutesPart());
-            reportForm.setSelectedHourBeginDay(DEFAULT_WORK_DAY_START);
-            reportForm.setSelectedMinuteBeginDay(0);
-        }
+        request.getSession().setAttribute("workingDayIsAvailable", false);
+        reportForm.setSelectedHourDuration(tr.getDuration().toHours());
+        reportForm.setSelectedMinuteDuration(tr.getDuration().toMinutesPart());
+        reportForm.setSelectedHourBeginDay(DEFAULT_WORK_DAY_START);
+        reportForm.setSelectedMinuteBeginDay(0);
 
         reportForm.setSuborder(tr.getCompleteOrderSign());
         reportForm.setSuborderSignId(tr.getSuborderId());

--- a/src/main/java/org/tb/dailyreport/service/TimesDisplay.java
+++ b/src/main/java/org/tb/dailyreport/service/TimesDisplay.java
@@ -1,5 +1,0 @@
-package org.tb.dailyreport.service;
-
-import java.time.LocalTime;
-
-public record TimesDisplay(LocalTime begin, LocalTime end) {}

--- a/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
+++ b/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
@@ -14,7 +14,6 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -154,24 +153,6 @@ public class WorkingdayService {
           .plusMinutes(workingday.getBreakminutes());
     }
     return LocalTime.MIDNIGHT.plus(elapsed);
-  }
-
-  public Optional<TimesDisplay> determineTimesToDisplay(long ecId, LocalDate date, Workingday workingday, TimereportDTO tr) {
-    if (workingday == null) return Optional.empty();
-    List<TimereportDTO> timereports = timereportDAO.getTimereportsByDateAndEmployeeContractId(ecId, date);
-    Duration beginDuration = Duration.ofHours(workingday.getStarttimehour())
-        .plusMinutes(workingday.getStarttimeminute())
-        .plusHours(workingday.getBreakhours())
-        .plusMinutes(workingday.getBreakminutes());
-    for (TimereportDTO timereport : timereports) {
-      if (Objects.equals(timereport.getId(), tr.getId())) break;
-      beginDuration = beginDuration.plus(timereport.getDuration());
-    }
-    Duration endDuration = beginDuration.plus(tr.getDuration());
-    return Optional.of(new TimesDisplay(
-        LocalTime.MIDNIGHT.plus(beginDuration),
-        LocalTime.MIDNIGHT.plus(endDuration)
-    ));
   }
 
   public String calculateQuittingTime(Workingday workingday) {


### PR DESCRIPTION
## Summary
- In `EditDailyReportAction.setFormEntries()`, always populate the form from `tr.getDuration()` and set `workingDayIsAvailable=false`, so the begin/end time picker never shows for edits
- Remove the `determineTimesToDisplay` call and the now-unused `WorkingdayService` and `TimereportHelper` fields from `EditDailyReportAction`
- Delete the `determineTimesToDisplay` method from `WorkingdayService` (was its only caller)
- Delete the `TimesDisplay` record (no remaining callers)

## Test plan
- [x] `jenv exec ./mvnw compile` — clean
- [x] `jenv exec ./mvnw test` — 204 tests, 0 failures
- [x] Open the edit form for a timereport on today's date — duration picker should appear (not begin/end pickers)

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #613