### PR TITLE
Fix for Result of multiplication cast to wider type

### DIFF
--- a/src/main/java/org/tb/common/util/DateUtils.java
+++ b/src/main/java/org/tb/common/util/DateUtils.java
@@ -435,7 +435,7 @@ public class DateUtils {
     }
 
     public static LocalTime getTimeFromMinutes(int minutes) {
-        return LocalTime.ofSecondOfDay(minutes * 60);
+        return LocalTime.ofSecondOfDay(minutes * 60L);
     }
 
     public static boolean isInRange(LocalDate value, LocalDate min, LocalDate max) {


### PR DESCRIPTION
To fix this safely without changing intended behavior, force the multiplication to occur in `long` by making one operand `long` (e.g., `60L`). This prevents intermediate `int` overflow and passes a correctly computed `long` to `LocalTime.ofSecondOfDay`.

Best single change:
- File: `src/main/java/org/tb/common/util/DateUtils.java`
- Method: `getTimeFromMinutes(int minutes)` around line 438
- Replace `minutes * 60` with `minutes * 60L`

No additional imports, helper methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._