### PR TITLE
Exclude hidden employees from People Lead dropdown in Employee Contract form

### DIFF
--- a/src/main/java/org/tb/employee/persistence/EmployeeDAO.java
+++ b/src/main/java/org/tb/employee/persistence/EmployeeDAO.java
@@ -78,6 +78,7 @@ public class EmployeeDAO {
         return employeecontractDAO.getEmployeeContracts().stream()
             .filter(Employeecontract::getCurrentlyValid)
             .map(Employeecontract::getEmployee)
+            .filter(e -> !TRUE.equals(e.getHide()))
             .filter(e -> !e.getSign().equals(GlobalConstants.EMPLOYEE_SIGN_ADM))
             .filter(e -> employeeAuthorization.isAuthorized(e, AccessLevel.READ, supervisedIds))
             .distinct()


### PR DESCRIPTION
## Summary
- `getEmployeesWithValidContracts()` in `EmployeeDAO` was not filtering out hidden employees, so employees with `hide=true` appeared in the People Lead dropdown when editing an Employee Contract
- Added `.filter(e -> !TRUE.equals(e.getHide()))` to the stream, consistent with the `notHidden()` spec used by `getEmployees()`

## Test plan
- [x] Open the Employee Contract edit dialog for any employee
- [x] Verify that hidden employees no longer appear in the People Lead dropdown
- [x] Verify that non-hidden employees with valid contracts and PV/BL status still appear
- [x] Existing `EmployeeServiceTest` suite passes (5/5 tests)

Closes #623

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.