### PR TITLE
Hide Overtime menu entry from navigation for restricted users

### DIFF
--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -85,7 +85,8 @@
                   <a class="dropdown-item" th:href="@{/do/ShowMatrix}" th:text="#{main.general.mainmenu.matrixmenu.text}">
                     Matrixübersicht
                   </a>
-                  <a class="dropdown-item" th:href="@{/do/ShowOvertime}" th:text="#{main.general.mainmenu.overtime.text}">
+                  <a class="dropdown-item" th:href="@{/do/ShowOvertime}" th:text="#{main.general.mainmenu.overtime.text}"
+                     th:if="${not #authorization.expression('hasRole(''RESTRICTED'')')}">
                     Überstunden
                   </a>
                   <a class="dropdown-item" th:href="@{/do/ShowTraining}" th:text="#{main.general.mainmenu.training.text}"

--- a/src/main/webapp/menu.jsp
+++ b/src/main/webapp/menu.jsp
@@ -45,9 +45,9 @@
 		<li><html:link styleClass="menu" action="/ShowMatrix">
 			<bean:message key="main.general.mainmenu.matrixmenu.text" />
 		</html:link></li>
-		<li class="first"><html:link styleClass="menu" action="/ShowOvertime">
+		<c:if test="${not loginEmployee.restricted}"><li class="first"><html:link styleClass="menu" action="/ShowOvertime">
 			<bean:message key="main.general.mainmenu.overtime.text" />
-		</html:link></li>
+		</html:link></li></c:if>
 		<c:if test="${not loginEmployee.restricted}"><li><html:link styleClass="menu" action="/ShowTraining">
 			<bean:message key="main.general.mainmenu.training.text" />
 		</html:link></li></c:if>


### PR DESCRIPTION
## Summary
- Restricted users no longer see the Overtime menu entry in the navigation
- Applied the same pattern already used for the Training menu entry
- Fixed in both the legacy JSP navigation (`menu.jsp`) and the Thymeleaf layout (`base.html`)

Closes #632

## Test plan
- [ ] Log in as a restricted user and verify the Overtime menu entry is not visible
- [ ] Log in as a non-restricted user and verify the Overtime menu entry is still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)