### PR TITLE
Fix gender display in employee read-only view

### DIFF
--- a/src/main/java/org/tb/employee/domain/Employee.java
+++ b/src/main/java/org/tb/employee/domain/Employee.java
@@ -6,6 +6,8 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.util.Objects;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.AccessLevel;
@@ -14,6 +16,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.tb.auth.domain.SalatUser;
 import org.tb.common.GlobalConstants;
 import org.tb.common.domain.AuditedEntity;
+
+import static org.tb.common.GlobalConstants.GENDER_MALE;
 
 @Getter
 @Setter
@@ -76,6 +80,10 @@ public class Employee extends AuditedEntity implements Serializable {
         if (salatUser != null) {
             salatUser.setLoginname(loginname);
         }
+    }
+
+    public boolean isMale() {
+        return Objects.equals(gender, GENDER_MALE);
     }
 
     @Transient

--- a/src/main/resources/templates/employee/employee-view.html
+++ b/src/main/resources/templates/employee/employee-view.html
@@ -21,7 +21,7 @@
       <div class="mb-3">
         <label class="form-label" th:text="#{main.employee.gender.text}">Gender</label>
         <p class="form-control-plaintext"
-           th:text="${employee.gender == 'm'} ? #{main.general.employee.gender.male} : #{main.general.employee.gender.female}"></p>
+           th:text="${employee.male} ? #{main.general.employee.gender.male} : #{main.general.employee.gender.female}"></p>
       </div>
 
       <div class="mb-3">


### PR DESCRIPTION
## Summary
- Thymeleaf/SpEL comparing a Java `char` field against a string literal `'m'` always evaluates to `false`, so the gender was always shown as female
- Added `isMale()` helper on `Employee` using the existing `GENDER_MALE` constant
- Updated `employee-view.html` to use `${employee.male}` instead of the broken char-to-string comparison

Closes #636

## Test plan
- [x] Open the employee detail view for a male employee and verify the gender shows "Männlich" (or equivalent)
- [x] Open the employee detail view for a female employee and verify the gender still shows "Weiblich"

🤖 Generated with [Claude Code](https://claude.com/claude-code)