### PR TITLE
Allow People Leads to accept timereports of their direct reports

### DIFF
--- a/src/main/java/org/tb/dailyreport/service/ReleaseService.java
+++ b/src/main/java/org/tb/dailyreport/service/ReleaseService.java
@@ -88,7 +88,7 @@ public class ReleaseService {
   private final ReleaseAuthorization releaseAuthorization;
 
   public void releaseTimereports(long employeecontractId, LocalDate releaseDate) {
-    // check authentication
+    // check authorization
     var employeecontract = employeecontractDAO.getEmployeecontractById(employeecontractId);
     if(!releaseAuthorization.isReleaseAuthorized(employeecontract, AccessLevel.WRITE)) {
       throw new AuthorizationException(RL_RELEASE_NOT_ALLOWED);
@@ -111,9 +111,8 @@ public class ReleaseService {
     sendTimeReportsReleasedMail(employeecontract);
   }
 
-  @Authorized(requiresManager = true)
   public void acceptTimereports(long employeecontractId, LocalDate acceptanceDate) {
-    // check authentication
+    // check authorization
     var employeecontract = employeecontractDAO.getEmployeecontractById(employeecontractId);
     if(!releaseAuthorization.isAcceptAuthorized(employeecontract, AccessLevel.WRITE)) {
       throw new AuthorizationException(RL_ACCEPT_NOT_ALLOWED);


### PR DESCRIPTION
## Summary
- `acceptTimereports()` in `ReleaseService` had `@Authorized(requiresManager = true)` which caused `AuthorizationAspect` to throw `AA_NEEDS_MANAGER` before the method body ran
- `ReleaseAuthorization.isAcceptAuthorized()` already correctly grants access to People Leads who supervise the employee — but it was never reached
- Fix: remove the redundant annotation; the method's own `isAcceptAuthorized()` guard handles authorization for both managers and People Leads

## Test plan
- [x] Existing `ReleaseServiceTest` passes (14 tests)
- [x] Log in as a People Lead and accept timereports of a directly assigned employee — should succeed without "Erfordert Manager-Berechtigung"
- [x] Verify a People Lead still cannot accept timereports of employees they do not supervise

Closes #634

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.