### PR TITLE
Remove duplicate login employee from release view dropdown

### DIFF
--- a/src/main/webapp/dailyreport/showRelease.jsp
+++ b/src/main/webapp/dailyreport/showRelease.jsp
@@ -124,14 +124,6 @@
 							<c:when test="${authorizedUser.manager or isSupervisor}">
 								<html:select property="employeeContractId" styleClass="make-select2"
 									onchange="setUpdateEmployeeContract(this.form)">
-									<html:option value="${loginEmployeeContract.id}">
-										<c:out value="${loginEmployeeContract.employee.name}" /> |
-										<c:out value="${loginEmployeeContract.employee.sign}" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(<c:out
-											value="${loginEmployeeContract.timeString}" />
-										<c:if test="${loginEmployeeContract.openEnd}">
-											<bean:message key="main.general.open.text" />
-										</c:if>)
-									</html:option>
 									<c:forEach var="employeecontract" items="${employeecontracts}">
 										<html:option value="${employeecontract.id}">
 											<c:out value="${employeecontract.employee.name}" /> |


### PR DESCRIPTION
## Summary
- `showRelease.jsp` rendered the login employee's own contract as a hardcoded first `<option>` and then again via the `${employeecontracts}` loop, causing a duplicate entry
- Removed the hardcoded option — the login employee's contract is already included in the list

## Test plan
- [x] Log in as a People Lead or manager and open `/do/ShowRelease` — the own name must appear exactly once in the employee dropdown

Closes #647

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.