### PR TITLE
Restrict supervisor selector in release view to managers

### DIFF
--- a/src/main/java/org/tb/dailyreport/action/ShowReleaseAction.java
+++ b/src/main/java/org/tb/dailyreport/action/ShowReleaseAction.java
@@ -132,7 +132,7 @@ public class ShowReleaseAction extends LoginRequiredAction<ShowReleaseForm> {
             updateEmployee = true;
         }
 
-        if (request.getParameter("task") != null && request.getParameter("task").equals("updateSupervisor")) {
+        if (authorizedUser.isManager() && request.getParameter("task") != null && request.getParameter("task").equals("updateSupervisor")) {
             superId = releaseForm.getSupervisorId();
             request.getSession().setAttribute("supervisorId", superId);
             if (superId == -1) {

--- a/src/main/webapp/dailyreport/showRelease.jsp
+++ b/src/main/webapp/dailyreport/showRelease.jsp
@@ -90,7 +90,7 @@
 					</td>
 				</tr>
 				
-				<c:if test="${isSupervisor or authorizedUser.manager}">
+				<c:if test="${authorizedUser.manager}">
 					<tr>
 						<td align="left" class="noBborderStyle">
 							<b><bean:message key="main.release.supervisor.text" />:&nbsp;&nbsp;</b>


### PR DESCRIPTION
## Summary
- A People Lead's own contract has their supervisor (X) in it, so X appeared in the supervisor dropdown visible to all People Leads
- When a People Lead selected X and submitted, `getTeamContracts(X.getId())` returned X's entire team — including employees the People Lead has no authority over (siblings under the same supervisor)
- Fix: guard `updateSupervisor` server-side with `authorizedUser.isManager()`, and hide the supervisor selector in the JSP for non-managers — People Leads always see exactly their own direct reports, so the selector is irrelevant for them

## Test plan
- [x] Log in as a People Lead — supervisor selector must not be visible at `/do/ShowRelease`
- [x] Log in as a manager — supervisor selector must still be visible and functional
- [x] Verify a People Lead can only see their own direct reports, not colleagues sharing the same supervisor

Closes #631

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.