### PR TITLE
Auto-preselect employee filter when only one employee is selectable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,13 +339,15 @@ Two stacked layers provide defence in depth:
 - **HTTP boundary** (`@PreAuthorize` on controller): enforced by Spring Security before the method runs
 - **Service boundary** (`@Authorized` + runtime guard): enforced inside the service regardless of caller
 - `AuthorizedUser` (session-scoped bean, `auth/domain/AuthorizedUser.java`): exposes `isManager()`, `isAdmin()`, `isBackoffice()`, `isRestricted()`, and the current login sign
-- Spring Security roles: `RESTRICTED`, `BACKOFFICE`, `MANAGER`, `ADMIN`; `manager` role includes admins; `backoffice` includes managers and admins
-- Role semantics:
-  - `RESTRICTED` — external employees (contractors) and Praktikanten; heavily limited access, cannot access most list/management views
-  - `BACKOFFICE` — regular internal employees; can log time for themselves, view their own contracts and orders
-  - `MANAGER` — team leads and supervisors; can manage contracts, orders, and time reports for their team
-  - `ADMIN` — system administrators; full access
-  - Note: `restricted=true` on `Employee` entity (or the `SalatUser`) maps to the `RESTRICTED` role. A "regular employee" is someone with `restricted=false` in the BACKOFFICE role who can only view their own data.
+- Spring Security roles: `USER`, `RESTRICTED`, `BACKOFFICE`, `PEOPLE_LEAD`, `MANAGER`, `ADMIN`; `manager` role includes admins; `backoffice` includes managers and admins; `people_lead` includes managers and admins
+- Role semantics (derived from `SalatUser.status` at login):
+  - `USER` — base role granted to every authenticated user = every employee
+  - `RESTRICTED` — external employees (contractors) and interns (`status=restricted`); heavily limited access, cannot access most list/management views
+  - `BACKOFFICE` — Backoffice (`status=bo`) plus everyone with `MANAGER`; can create invoices and upload financial data from books and records
+  - `PEOPLE_LEAD` — people leads/supervisors (`status=pv`) plus everyone with `MANAGER`; can read time reports and contracts of their team members, run reports
+  - `MANAGER` — general manager (`status=bl`) plus `ADMIN`; can manage contracts, orders, and time reports for everyone
+  - `ADMIN` — system administrators (`status=adm`); full access; only role that is NOT an employee
+  - A "regular employee" is someone with `BACKOFFICE` but not `PEOPLE_LEAD` or `MANAGER` — they can only view their own data.
 
 ### Flags Column Pattern
 List views that expose boolean state flags on rows use a dedicated **Flags** column rather than inline badges or text next to the primary field.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,12 @@ Two stacked layers provide defence in depth:
 - **Service boundary** (`@Authorized` + runtime guard): enforced inside the service regardless of caller
 - `AuthorizedUser` (session-scoped bean, `auth/domain/AuthorizedUser.java`): exposes `isManager()`, `isAdmin()`, `isBackoffice()`, `isRestricted()`, and the current login sign
 - Spring Security roles: `RESTRICTED`, `BACKOFFICE`, `MANAGER`, `ADMIN`; `manager` role includes admins; `backoffice` includes managers and admins
+- Role semantics:
+  - `RESTRICTED` — external employees (contractors) and Praktikanten; heavily limited access, cannot access most list/management views
+  - `BACKOFFICE` — regular internal employees; can log time for themselves, view their own contracts and orders
+  - `MANAGER` — team leads and supervisors; can manage contracts, orders, and time reports for their team
+  - `ADMIN` — system administrators; full access
+  - Note: `restricted=true` on `Employee` entity (or the `SalatUser`) maps to the `RESTRICTED` role. A "regular employee" is someone with `restricted=false` in the BACKOFFICE role who can only view their own data.
 
 ### Flags Column Pattern
 List views that expose boolean state flags on rows use a dedicated **Flags** column rather than inline badges or text next to the primary field.

--- a/src/main/java/org/tb/employee/controller/EmployeecontractController.java
+++ b/src/main/java/org/tb/employee/controller/EmployeecontractController.java
@@ -30,6 +30,7 @@ import org.tb.common.util.DataValidationUtils;
 import org.tb.common.util.DateUtils;
 import org.tb.common.util.DurationUtils;
 import org.tb.common.viewhelper.ErrorCodeViewHelper;
+import java.util.Comparator;
 import org.tb.employee.domain.Employee;
 import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.domain.Overtime;
@@ -69,8 +70,15 @@ public class EmployeecontractController {
             show = (Boolean) session.getAttribute("employees.contracts.show");
             showHidden = (Boolean) session.getAttribute("employees.contracts.showHidden");
         }
+        var employees = employeecontractService.getVisibleEmployeeContracts().stream()
+                .map(Employeecontract::getEmployee)
+                .distinct()
+                .sorted(Comparator.comparing(Employee::getName))
+                .toList();
+        if (employeeId == null && employees.size() == 1) {
+            employeeId = employees.getFirst().getId();
+        }
         var contracts = employeecontractService.getEmployeeContractViewsByFilters(show, filter, employeeId, showHidden);
-        var employees = employeeService.getAllEmployees();
         model.addAttribute("employeecontracts", contracts);
         model.addAttribute("employees", employees);
         model.addAttribute("filter", filter);

--- a/src/main/java/org/tb/order/controller/EmployeeorderController.java
+++ b/src/main/java/org/tb/order/controller/EmployeeorderController.java
@@ -89,6 +89,9 @@ public class EmployeeorderController {
         }
 
         var employeeContracts = employeecontractService.getVisibleEmployeeContracts();
+        if (employeeContractId == null && employeeContracts.size() == 1) {
+            employeeContractId = employeeContracts.getFirst().getId();
+        }
         var orders = customerorderService.getCustomerordersByFilters(show, filter, customerId, showHidden);
 
         var filterSet = (filter != null && !filter.isEmpty()) ||


### PR DESCRIPTION
## Summary
- `EmployeecontractController`: derive employee dropdown from `getVisibleEmployeeContracts()` instead of `getAllEmployees()`, so the dropdown respects authorization; auto-preselect the employee when only 1 is viewable
- `EmployeeorderController`: auto-preselect `employeeContractId` when `getVisibleEmployeeContracts()` returns exactly 1 contract
- `AGENTS.md`: added role semantics section documenting `RESTRICTED` (contractors/Praktikanten), `BACKOFFICE` (regular internal employees), `MANAGER`, `ADMIN`

## Test plan
- [x] Log in as a regular (BACKOFFICE, non-manager) employee → `/employees/contracts` shows their employee pre-selected and their contracts loaded
- [x] Log in as a regular employee → `/orders/employeeorders` shows their contract pre-selected and results loaded
- [x] Log in as a manager → both pages show the full employee/contract dropdown (no auto-preselect) as before
- [x] Existing session filter values are respected; auto-preselect only applies when no value was previously saved

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #630