### PR TITLE
Add per-job option to suppress email when report result is empty

### DIFF
--- a/src/main/java/org/tb/reporting/controller/ScheduledReportJobController.java
+++ b/src/main/java/org/tb/reporting/controller/ScheduledReportJobController.java
@@ -95,6 +95,7 @@ public class ScheduledReportJobController {
     form.setReportParameters(job.getReportParameters());
     form.setRecipientEmails(job.getRecipientEmails());
     form.setEnabled(job.isEnabled());
+    form.setSuppressEmptyResults(job.isSuppressEmptyResults());
     form.setCronExpression(job.getCronExpression());
     form.setDescription(job.getDescription());
 
@@ -157,6 +158,7 @@ public class ScheduledReportJobController {
     job.setReportParameters(form.getReportParameters());
     job.setRecipientEmails(form.getRecipientEmails());
     job.setEnabled(form.isEnabled());
+    job.setSuppressEmptyResults(form.isSuppressEmptyResults());
     job.setCronExpression(form.getCronExpression());
     job.setDescription(form.getDescription());
 
@@ -187,6 +189,7 @@ public class ScheduledReportJobController {
     private String reportParameters;
     private String recipientEmails;
     private boolean enabled = true;
+    private boolean suppressEmptyResults = false;
     private String cronExpression;
     private String description;
   }

--- a/src/main/java/org/tb/reporting/domain/ScheduledReportJob.java
+++ b/src/main/java/org/tb/reporting/domain/ScheduledReportJob.java
@@ -36,6 +36,9 @@ public class ScheduledReportJob extends AuditedEntity implements Serializable {
   @Column(nullable = false)
   private boolean enabled = true;
 
+  @Column(name = "suppress_empty_results", nullable = false)
+  private boolean suppressEmptyResults = false;
+
   @Column(name = "cron_expression")
   private String cronExpression;
 

--- a/src/main/java/org/tb/reporting/service/ReportEmailService.java
+++ b/src/main/java/org/tb/reporting/service/ReportEmailService.java
@@ -33,7 +33,7 @@ public class ReportEmailService {
   @Value("${salat.reporting.email.enabled:true}")
   private boolean emailEnabled;
 
-  public void sendReportEmail(Long reportDefinitionId, List<ReportParameter> parameters, String[] recipients) {
+  public void sendReportEmail(Long reportDefinitionId, List<ReportParameter> parameters, String[] recipients, boolean suppressEmptyResults) {
     try {
       if (!emailEnabled) {
         log.info("Email sending is disabled. Skipping report email for report ID: {}", reportDefinitionId);
@@ -55,8 +55,8 @@ public class ReportEmailService {
         return;
       }
 
-      if(reportResult.getRows().isEmpty()) {
-        log.info("Report id={}, name={} returned no rows. Skipping email.", reportDefinitionId, rd.getName());
+      if(suppressEmptyResults && reportResult.getRows().isEmpty()) {
+        log.info("Report id={}, name={} returned no rows. Skipping email (suppressEmptyResults=true).", reportDefinitionId, rd.getName());
         return;
       }
 

--- a/src/main/java/org/tb/reporting/service/ScheduledReportJobService.java
+++ b/src/main/java/org/tb/reporting/service/ScheduledReportJobService.java
@@ -135,7 +135,8 @@ public class ScheduledReportJobService {
       reportEmailService.sendReportEmail(
           job.getReportDefinition().getId(),
           parameters,
-          recipients
+          recipients,
+          job.isSuppressEmptyResults()
       );
 
       log.info("Successfully executed scheduled report job: {} (ID: {})", job.getName(), job.getId());

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1751,5 +1751,26 @@ databaseChangeLog:
                   name: hide
                   valueBoolean: true
             where: "EMPLOYEE_ID IN (SELECT id FROM employee WHERE lastname LIKE 'z\\_%')"
+  - changeSet:
+      id: 49
+      author: kr
+      comment: Add suppress_empty_results flag to scheduled_report_job
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: scheduled_report_job
+                columnName: suppress_empty_results
+      changes:
+        - addColumn:
+            tableName: scheduled_report_job
+            columns:
+              - column:
+                  name: suppress_empty_results
+                  type: bit(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+
 #  - include:
 #      file: db/changelog/includes/addAllEmployees.sql

--- a/src/main/resources/org/tb/web/MessageResources.properties
+++ b/src/main/resources/org/tb/web/MessageResources.properties
@@ -958,3 +958,4 @@ orderrevenue.upload.row=Zeile
 orderrevenue.upload.start=Upload starten
 orderrevenue.upload.status=Status
 orderrevenue.upload.title=Umsatz-/Kosten-Upload
+reporting.scheduledjob.suppressEmptyResults.label=Keine Email bei leerem Ergebnis

--- a/src/main/resources/org/tb/web/MessageResources_en.properties
+++ b/src/main/resources/org/tb/web/MessageResources_en.properties
@@ -955,3 +955,4 @@ orderrevenue.upload.row=Row
 orderrevenue.upload.start=Start upload
 orderrevenue.upload.status=Status
 orderrevenue.upload.title=Revenue/Cost Upload
+reporting.scheduledjob.suppressEmptyResults.label=Suppress email if result is empty

--- a/src/main/resources/templates/reporting/scheduled-job-form.html
+++ b/src/main/resources/templates/reporting/scheduled-job-form.html
@@ -33,6 +33,10 @@
           field='enabled', label='Enabled'
         )}"></div>
 
+        <div th:replace="~{fragments/form-fields :: checkboxSwitch(
+          field='suppressEmptyResults', label=#{reporting.scheduledjob.suppressEmptyResults.label}
+        )}"></div>
+
         <div th:replace="~{fragments/form-fields :: textInputHelp(
           field='cronExpression', label='Cron Expression (optional)', required=false,
           maxlength=255, helpText='Leave empty for default schedule (Daily at 5:00 AM)'


### PR DESCRIPTION
## Summary
- Adds a `suppressEmptyResults` boolean flag to `ScheduledReportJob` (default `false`)
- When enabled, no email is sent if the report returns zero rows — useful for daily error reports that should stay silent when there's nothing to report
- The empty-rows check in `ReportEmailService` was previously unconditional; it is now gated on this per-job flag
- New checkbox in the scheduled-job form with German/English i18n keys
- Liquibase changeset 49 adds the `suppress_empty_results` column (`bit(1)`)

## Test plan
- [x] Create a scheduled job with `suppressEmptyResults = false` and run it manually against a report with no rows — email is sent
- [x] Create a scheduled job with `suppressEmptyResults = true` and run it manually against a report with no rows — email is suppressed (log confirms skipped)
- [x] Existing job edit/create form shows the new checkbox and persists it correctly
- [x] All 13 reporting unit tests pass

Closes #637

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.