### PR TITLE
Add run button to scheduled report jobs list with execution feedback

### DIFF
--- a/src/main/java/org/tb/reporting/controller/ScheduledReportJobController.java
+++ b/src/main/java/org/tb/reporting/controller/ScheduledReportJobController.java
@@ -174,7 +174,7 @@ public class ScheduledReportJobController {
     return "redirect:/reporting/jobs";
   }
 
-  @PostMapping("/run")
+  @GetMapping("/run")
   public String run(@RequestParam("id") Long id, RedirectAttributes redirectAttributes) {
     try {
       jobService.getJob(id); // ownership check

--- a/src/main/java/org/tb/reporting/controller/ScheduledReportJobController.java
+++ b/src/main/java/org/tb/reporting/controller/ScheduledReportJobController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.tb.reporting.domain.JobExecutionResult;
 import org.tb.reporting.domain.ScheduledReportJob;
 import org.tb.reporting.service.ReportService;
 import org.tb.reporting.service.ScheduledReportJobScheduler;
@@ -171,6 +172,29 @@ public class ScheduledReportJobController {
     }
 
     return "redirect:/reporting/jobs";
+  }
+
+  @PostMapping("/run")
+  public String run(@RequestParam("id") Long id, RedirectAttributes redirectAttributes) {
+    try {
+      jobService.getJob(id); // ownership check
+      var result = jobService.executeScheduledReportJobById(id);
+      String message = result.map(this::buildRunMessage).orElse("Job was not executed (disabled or not found)");
+      redirectAttributes.addFlashAttribute("toastSuccess", message);
+    } catch (Exception e) {
+      redirectAttributes.addFlashAttribute("toastError", "Error executing job: " + e.getMessage());
+    }
+    return "redirect:/reporting/jobs";
+  }
+
+  private String buildRunMessage(JobExecutionResult result) {
+    if (result.suppressed()) {
+      return "Report '" + result.jobName() + "' executed: 0 rows — email suppressed";
+    } else if (result.rowCount() == 0) {
+      return "Report '" + result.jobName() + "' executed: 0 rows — empty result email sent to " + result.recipientEmails();
+    } else {
+      return "Report '" + result.jobName() + "' executed: " + result.rowCount() + " rows sent to " + result.recipientEmails();
+    }
   }
 
   @PostMapping("/delete")

--- a/src/main/java/org/tb/reporting/controller/ScheduledReportJobController.java
+++ b/src/main/java/org/tb/reporting/controller/ScheduledReportJobController.java
@@ -179,8 +179,9 @@ public class ScheduledReportJobController {
     try {
       jobService.getJob(id); // ownership check
       var result = jobService.executeScheduledReportJobById(id);
+      var errorToast = result.map(JobExecutionResult::error).orElse(true);
       String message = result.map(this::buildRunMessage).orElse("Job was not executed (disabled or not found)");
-      redirectAttributes.addFlashAttribute("toastSuccess", message);
+      redirectAttributes.addFlashAttribute(errorToast ? "toastError" : "toastSuccess", message);
     } catch (Exception e) {
       redirectAttributes.addFlashAttribute("toastError", "Error executing job: " + e.getMessage());
     }
@@ -188,7 +189,15 @@ public class ScheduledReportJobController {
   }
 
   private String buildRunMessage(JobExecutionResult result) {
-    if (result.suppressed()) {
+    if (result.error()) {
+      return "Report '%s' failed: %s:%s (%s, State: %s)".formatted(
+          result.jobName(),
+          result.errorInfo().getErrorClass(),
+          result.errorInfo().getErrorMessage(),
+          result.errorInfo().getErrorCode() != null ? result.errorInfo().getErrorCode() : "n/a",
+          result.errorInfo().getSqlState() != null ? result.errorInfo().getSqlState() : "n/a"
+      );
+    } else if (result.suppressed()) {
       return "Report '" + result.jobName() + "' executed: 0 rows — email suppressed";
     } else if (result.rowCount() == 0) {
       return "Report '" + result.jobName() + "' executed: 0 rows — empty result email sent to " + result.recipientEmails();

--- a/src/main/java/org/tb/reporting/domain/JobExecutionResult.java
+++ b/src/main/java/org/tb/reporting/domain/JobExecutionResult.java
@@ -1,0 +1,4 @@
+package org.tb.reporting.domain;
+
+public record JobExecutionResult(String jobName, int rowCount, String recipientEmails, boolean suppressed) {
+}

--- a/src/main/java/org/tb/reporting/domain/JobExecutionResult.java
+++ b/src/main/java/org/tb/reporting/domain/JobExecutionResult.java
@@ -1,4 +1,4 @@
 package org.tb.reporting.domain;
 
-public record JobExecutionResult(String jobName, int rowCount, String recipientEmails, boolean suppressed) {
+public record JobExecutionResult(String jobName, int rowCount, String recipientEmails, boolean suppressed, boolean error, ReportResult.ErrorInfo errorInfo) {
 }

--- a/src/main/java/org/tb/reporting/domain/ReportResult.java
+++ b/src/main/java/org/tb/reporting/domain/ReportResult.java
@@ -2,7 +2,6 @@ package org.tb.reporting.domain;
 
 import java.io.Serializable;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
@@ -21,13 +20,11 @@ public class ReportResult implements Serializable {
   @Singular
   private final List<ReportResultRow> rows;
 
+  private final String sql; // SQL statement if available
+
   // Error handling (e.g., SQL grammar issues)
   private final boolean error; // true if an error occurred while executing the report
-  private final String errorClass; // exception class simple name
-  private final String errorMessage; // human readable message
-  private final String sql; // offending SQL if available
-  private final String sqlState; // JDBC SQL state if available
-  private final Integer errorCode; // vendor specific error code
+  private final ErrorInfo errorInfo;
 
   /**
    * Liefert ein JavaScript-kompatibles Array als String,
@@ -122,6 +119,15 @@ public class ReportResult implements Serializable {
       }
     }
     return sb.toString();
+  }
+
+  @Getter
+  @Builder
+  public static class ErrorInfo {
+    private final String errorClass; // exception class simple name
+    private final String errorMessage; // human readable message
+    private final String sqlState; // JDBC SQL state if available
+    private final Integer errorCode; // vendor specific error code
   }
 
 }

--- a/src/main/java/org/tb/reporting/service/ReportEmailService.java
+++ b/src/main/java/org/tb/reporting/service/ReportEmailService.java
@@ -48,13 +48,7 @@ public class ReportEmailService {
       ReportResult reportResult = reportService.execute(reportDefinitionId, parameters);
 
       if(reportResult.isError()) {
-        log.error(
-            "Report id={}, name={} produced an error. Skipping email. ErrorMessage: {}",
-            reportDefinitionId,
-            rd.getName(),
-            reportResult.getErrorMessage()
-        );
-        return new SendResult(0, true);
+        throw new RuntimeException("Report execution failed: " + reportResult.getErrorMessage());
       }
 
       int rowCount = reportResult.getRows().size();

--- a/src/main/java/org/tb/reporting/service/ReportEmailService.java
+++ b/src/main/java/org/tb/reporting/service/ReportEmailService.java
@@ -33,13 +33,13 @@ public class ReportEmailService {
   @Value("${salat.reporting.email.enabled:true}")
   private boolean emailEnabled;
 
-  public record SendResult(int rowCount, boolean suppressed) {}
+  public record SendResult(int rowCount, boolean suppressed, boolean error, ReportResult.ErrorInfo errorInfo) {}
 
   public SendResult sendReportEmail(Long reportDefinitionId, List<ReportParameter> parameters, String[] recipients, boolean suppressEmptyResults) {
     try {
       if (!emailEnabled) {
         log.info("Email sending is disabled. Skipping report email for report ID: {}", reportDefinitionId);
-        return new SendResult(0, true);
+        return new SendResult(0, true, false, null);
       }
 
       log.info("Generating report {} with parameters: {}", reportDefinitionId, parameters);
@@ -48,14 +48,14 @@ public class ReportEmailService {
       ReportResult reportResult = reportService.execute(reportDefinitionId, parameters);
 
       if(reportResult.isError()) {
-        throw new RuntimeException("Report execution failed: " + reportResult.getErrorMessage());
+        return new SendResult(0, false, true, reportResult.getErrorInfo());
       }
 
       int rowCount = reportResult.getRows().size();
 
       if(suppressEmptyResults && reportResult.getRows().isEmpty()) {
         log.info("Report id={}, name={} returned no rows. Skipping email (suppressEmptyResults=true).", reportDefinitionId, rd.getName());
-        return new SendResult(0, true);
+        return new SendResult(0, true, false, null);
       }
 
       byte[] excelBytes = excelExportService.exportToExcel(reportResult);
@@ -87,7 +87,7 @@ public class ReportEmailService {
 
       mailService.sendEmail(emailRequest);
       log.info("Report email sent successfully to {} recipients for report: {}", recipients.length, rd.getName());
-      return new SendResult(rowCount, false);
+      return new SendResult(rowCount, false, false, null);
 
     } catch (Exception e) {
       log.error("Failed to send report email for report ID: {}", reportDefinitionId, e);
@@ -118,7 +118,7 @@ public class ReportEmailService {
     var fileName = "report-" + reportDefinition.getName() +
                    "-erzeugt-" + DateUtils.formatDateTime(DateTimeUtils.now(), "dd-MM-yy-HHmm") +
                    ".xlsx";
-    return fileName.replaceAll("[^a-zA-Z0-9-_\\.]", "_");
+    return fileName.replaceAll("[^a-zA-Z0-9-_.]", "_");
   }
 
 }

--- a/src/main/java/org/tb/reporting/service/ReportEmailService.java
+++ b/src/main/java/org/tb/reporting/service/ReportEmailService.java
@@ -33,18 +33,20 @@ public class ReportEmailService {
   @Value("${salat.reporting.email.enabled:true}")
   private boolean emailEnabled;
 
-  public void sendReportEmail(Long reportDefinitionId, List<ReportParameter> parameters, String[] recipients, boolean suppressEmptyResults) {
+  public record SendResult(int rowCount, boolean suppressed) {}
+
+  public SendResult sendReportEmail(Long reportDefinitionId, List<ReportParameter> parameters, String[] recipients, boolean suppressEmptyResults) {
     try {
       if (!emailEnabled) {
         log.info("Email sending is disabled. Skipping report email for report ID: {}", reportDefinitionId);
-        return;
+        return new SendResult(0, true);
       }
 
       log.info("Generating report {} with parameters: {}", reportDefinitionId, parameters);
       ReportDefinition rd = reportService.getReportDefinition(reportDefinitionId);
       if(rd == null) throw new InvalidDataException(ErrorCode.XX_DATA_MISSING, "No report definition found for ID: " + reportDefinitionId);
       ReportResult reportResult = reportService.execute(reportDefinitionId, parameters);
-      
+
       if(reportResult.isError()) {
         log.error(
             "Report id={}, name={} produced an error. Skipping email. ErrorMessage: {}",
@@ -52,12 +54,14 @@ public class ReportEmailService {
             rd.getName(),
             reportResult.getErrorMessage()
         );
-        return;
+        return new SendResult(0, true);
       }
+
+      int rowCount = reportResult.getRows().size();
 
       if(suppressEmptyResults && reportResult.getRows().isEmpty()) {
         log.info("Report id={}, name={} returned no rows. Skipping email (suppressEmptyResults=true).", reportDefinitionId, rd.getName());
-        return;
+        return new SendResult(0, true);
       }
 
       byte[] excelBytes = excelExportService.exportToExcel(reportResult);
@@ -89,6 +93,7 @@ public class ReportEmailService {
 
       mailService.sendEmail(emailRequest);
       log.info("Report email sent successfully to {} recipients for report: {}", recipients.length, rd.getName());
+      return new SendResult(rowCount, false);
 
     } catch (Exception e) {
       log.error("Failed to send report email for report ID: {}", reportDefinitionId, e);

--- a/src/main/java/org/tb/reporting/service/ReportEmailService.java
+++ b/src/main/java/org/tb/reporting/service/ReportEmailService.java
@@ -33,7 +33,7 @@ public class ReportEmailService {
   @Value("${salat.reporting.email.enabled:true}")
   private boolean emailEnabled;
 
-  public record SendResult(int rowCount, boolean suppressed, boolean error, ReportResult.ErrorInfo errorInfo) {}
+  public record  SendResult(int rowCount, boolean suppressed, boolean error, ReportResult.ErrorInfo errorInfo) {}
 
   public SendResult sendReportEmail(Long reportDefinitionId, List<ReportParameter> parameters, String[] recipients, boolean suppressEmptyResults) {
     try {
@@ -87,7 +87,7 @@ public class ReportEmailService {
 
       mailService.sendEmail(emailRequest);
       log.info("Report email sent successfully to {} recipients for report: {}", recipients.length, rd.getName());
-      return new SendResult(rowCount, false, false, null);
+      return new SendResult(reportResult.getRows().size(), false, false, null);
 
     } catch (Exception e) {
       log.error("Failed to send report email for report ID: {}", reportDefinitionId, e);

--- a/src/main/java/org/tb/reporting/service/ReportService.java
+++ b/src/main/java/org/tb/reporting/service/ReportService.java
@@ -151,17 +151,19 @@ public class ReportService {
     } catch (BadSqlGrammarException e) {
       // capture detailed SQL error information in the result to display in UI
       var sqlEx = e.getSQLException();
-      var msg = e.getMostSpecificCause() != null ? e.getMostSpecificCause().getMessage() : e.getMessage();
+      var msg = e.getMostSpecificCause().getMessage();
       log.warn("Bad SQL grammar while executing report {}: {}", reportDefinitionId, msg);
+      var errorInfo = ReportResult.ErrorInfo.builder()
+          .errorClass(e.getClass().getSimpleName())
+          .errorMessage(msg)
+          .sqlState(sqlEx != null ? sqlEx.getSQLState() : null)
+          .errorCode(sqlEx != null ? sqlEx.getErrorCode() : null)
+          .build();
       return ReportResult.builder()
           .parameters(parameters)
           .columnHeaders(List.of())
           .error(true)
-          .errorClass(e.getClass().getSimpleName())
-          .errorMessage(msg)
-          .sql(resolvedSql)
-          .sqlState(sqlEx != null ? sqlEx.getSQLState() : null)
-          .errorCode(sqlEx != null ? sqlEx.getErrorCode() : null)
+          .errorInfo(errorInfo)
           .build();
     }
   }

--- a/src/main/java/org/tb/reporting/service/ScheduledReportJobService.java
+++ b/src/main/java/org/tb/reporting/service/ScheduledReportJobService.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -20,6 +21,7 @@ import org.tb.auth.domain.Authorized;
 import org.tb.auth.domain.AuthorizedUser;
 import org.tb.common.exception.AuthorizationException;
 import org.tb.common.exception.ErrorCode;
+import org.tb.reporting.domain.JobExecutionResult;
 import org.tb.reporting.domain.ReportParameter;
 import org.tb.reporting.domain.ScheduledReportExecutionHistory;
 import org.tb.reporting.domain.ScheduledReportJob;
@@ -84,15 +86,17 @@ public class ScheduledReportJobService {
 
   /**
    * Execute a single scheduled report job by its id.
+   * Returns the execution result, or empty if the job was not found or is disabled.
    */
-  public void executeScheduledReportJobById(Long jobId) {
-    scheduledReportJobRepository.findById(jobId).ifPresent(job -> {
-      if (job.isEnabled()) {
-        executeJob(job);
-      } else {
-        log.info("Skipping disabled scheduled report job ID: {}", jobId);
-      }
-    });
+  public Optional<JobExecutionResult> executeScheduledReportJobById(Long jobId) {
+    var jobOpt = scheduledReportJobRepository.findById(jobId);
+    if (jobOpt.isEmpty()) return Optional.empty();
+    var job = jobOpt.get();
+    if (!job.isEnabled()) {
+      log.info("Skipping disabled scheduled report job ID: {}", jobId);
+      return Optional.empty();
+    }
+    return Optional.of(executeJob(job));
   }
 
   @Authorized(permitAll = true)
@@ -109,30 +113,22 @@ public class ScheduledReportJobService {
     }
   }
 
-  private void executeJob(ScheduledReportJob job) {
+  private JobExecutionResult executeJob(ScheduledReportJob job) {
     log.info("Executing scheduled report job: {} (ID: {})", job.getName(), job.getId());
 
     LocalDateTime executedAt = LocalDateTime.now();
+    List<ReportParameter> parameters = parseParameters(job.getReportParameters());
+    String[] recipients = parseRecipients(job.getRecipientEmails());
+
+    if (recipients.length == 0) {
+      String msg = "No recipients configured";
+      log.warn(msg + " for job: {} (ID: {})", job.getName(), job.getId());
+      historyRepository.save(historyEntry(job, executedAt, false, msg));
+      throw new RuntimeException(msg);
+    }
+
     try {
-      List<ReportParameter> parameters = parseParameters(job.getReportParameters());
-      String[] recipients = parseRecipients(job.getRecipientEmails());
-
-      if (recipients.length == 0) {
-        String msg = "No recipients configured";
-        log.warn(msg + " for job: {} (ID: {})", job.getName(), job.getId());
-        historyRepository.save(ScheduledReportExecutionHistory.builder()
-            .jobId(job.getId())
-            .jobName(job.getName())
-            .reportDefinitionId(job.getReportDefinition() != null ? job.getReportDefinition().getId() : null)
-            .reportDefinitionName(job.getReportDefinition() != null ? job.getReportDefinition().getName() : null)
-            .executedAt(executedAt)
-            .success(false)
-            .message(msg)
-            .build());
-        return;
-      }
-
-      reportEmailService.sendReportEmail(
+      var sendResult = reportEmailService.sendReportEmail(
           job.getReportDefinition().getId(),
           parameters,
           recipients,
@@ -140,29 +136,28 @@ public class ScheduledReportJobService {
       );
 
       log.info("Successfully executed scheduled report job: {} (ID: {})", job.getName(), job.getId());
-      historyRepository.save(ScheduledReportExecutionHistory.builder()
-          .jobId(job.getId())
-          .jobName(job.getName())
-          .reportDefinitionId(job.getReportDefinition() != null ? job.getReportDefinition().getId() : null)
-          .reportDefinitionName(job.getReportDefinition() != null ? job.getReportDefinition().getName() : null)
-          .executedAt(executedAt)
-          .success(true)
-          .message("Email sent to " + recipients.length + " recipient(s)")
-          .build());
+      String historyMsg = sendResult.suppressed() ? "Email suppressed (empty result)" : "Email sent to " + recipients.length + " recipient(s)";
+      historyRepository.save(historyEntry(job, executedAt, true, historyMsg));
+
+      return new JobExecutionResult(job.getName(), sendResult.rowCount(), job.getRecipientEmails(), sendResult.suppressed());
 
     } catch (Exception e) {
       log.error("Error executing job: {} (ID: {})", job.getName(), job.getId(), e);
-      historyRepository.save(ScheduledReportExecutionHistory.builder()
-          .jobId(job.getId())
-          .jobName(job.getName())
-          .reportDefinitionId(job.getReportDefinition() != null ? job.getReportDefinition().getId() : null)
-          .reportDefinitionName(job.getReportDefinition() != null ? job.getReportDefinition().getName() : null)
-          .executedAt(executedAt)
-          .success(false)
-          .message(safeMessage(e))
-          .build());
+      historyRepository.save(historyEntry(job, executedAt, false, safeMessage(e)));
       throw new RuntimeException("Failed to execute scheduled report job", e);
     }
+  }
+
+  private ScheduledReportExecutionHistory historyEntry(ScheduledReportJob job, LocalDateTime executedAt, boolean success, String message) {
+    return ScheduledReportExecutionHistory.builder()
+        .jobId(job.getId())
+        .jobName(job.getName())
+        .reportDefinitionId(job.getReportDefinition() != null ? job.getReportDefinition().getId() : null)
+        .reportDefinitionName(job.getReportDefinition() != null ? job.getReportDefinition().getName() : null)
+        .executedAt(executedAt)
+        .success(success)
+        .message(message)
+        .build();
   }
 
   private String safeMessage(Exception e) {

--- a/src/main/java/org/tb/reporting/service/ScheduledReportJobService.java
+++ b/src/main/java/org/tb/reporting/service/ScheduledReportJobService.java
@@ -135,11 +135,18 @@ public class ScheduledReportJobService {
           job.isSuppressEmptyResults()
       );
 
-      log.info("Successfully executed scheduled report job: {} (ID: {})", job.getName(), job.getId());
-      String historyMsg = sendResult.suppressed() ? "Email suppressed (empty result)" : "Email sent to " + recipients.length + " recipient(s)";
-      historyRepository.save(historyEntry(job, executedAt, true, historyMsg));
-
-      return new JobExecutionResult(job.getName(), sendResult.rowCount(), job.getRecipientEmails(), sendResult.suppressed());
+      if(!sendResult.error()) {
+        log.info("Successfully executed scheduled report job: {} (ID: {})", job.getName(), job.getId());
+        String historyMsg = sendResult.suppressed() ? "Email suppressed (empty result)" : "Email sent to " + recipients.length + " recipient(s)";
+        historyRepository.save(historyEntry(job, executedAt, true, historyMsg));
+        return new JobExecutionResult(job.getName(), sendResult.rowCount(), job.getRecipientEmails(), sendResult.suppressed(), false,null);
+      } else {
+        var errorInfo = sendResult.errorInfo();
+        String message = "%s:%s".formatted(errorInfo.getErrorClass(), errorInfo.getErrorMessage());
+        log.error("Error executing job: {} (ID: {}) {}", job.getName(), job.getId(), message);
+        historyRepository.save(historyEntry(job, executedAt, false, message));
+        return new JobExecutionResult(job.getName(), sendResult.rowCount(), job.getRecipientEmails(), sendResult.suppressed(), true, errorInfo);
+      }
 
     } catch (Exception e) {
       log.error("Error executing job: {} (ID: {})", job.getName(), job.getId(), e);

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -316,6 +316,21 @@
           </div>
         </div>
       </div>
+      <div class="container-xl my-4" th:if="${not #strings.isEmpty(toastError)}">
+        <div class="alert alert-danger align-items-start gap-3" role="alert">
+          <div class="icon">
+            <i class="ti ti-circle-x"></i>
+          </div>
+          <div class="flex-fill">
+            <div class="d-flex justify-content-between">
+              <div>
+                <h4 class="alert-title mb-1">Error</h4>
+                <div class="text-secondary">[[${toastError}]]</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="container-xl my-4" th:if="${errors != null && !errors.isEmpty()}">
         <div class="alert alert-danger align-items-start gap-3" role="alert">
           <div class="icon">

--- a/src/main/resources/templates/reporting/scheduled-jobs-list.html
+++ b/src/main/resources/templates/reporting/scheduled-jobs-list.html
@@ -22,6 +22,7 @@
         <th th:replace="~{fragments/master-table :: colHeader(label=${'Last Updated'})}"></th>
         <th th:replace="~{fragments/master-table :: colHeaderActionIcon()}"></th>
         <th th:replace="~{fragments/master-table :: colHeaderActionIcon()}"></th>
+        <th th:replace="~{fragments/master-table :: colHeaderActionIcon()}"></th>
       </tr>
     </thead>
 
@@ -35,6 +36,12 @@
         <td th:replace="~{fragments/master-table :: colDate(date=${job.lastupdate})}"></td>
         <td th:replace="~{fragments/master-table :: colEditLink(href=@{'/reporting/jobs/edit'(id=${job.id})})}"></td>
         <td th:replace="~{fragments/master-table :: colDeleteForm(id=${job.id}, action=@{'/reporting/jobs/delete'})}"></td>
+        <td>
+          <form th:action="@{/reporting/jobs/run}" method="post">
+            <input type="hidden" name="id" th:value="${job.id}"/>
+            <button type="submit" class="btn btn-outline-success" title="Run now"><i class="icon ti ti-player-play m-0"></i></button>
+          </form>
+        </td>
       </tr>
     </tbody>
 

--- a/src/main/resources/templates/reporting/scheduled-jobs-list.html
+++ b/src/main/resources/templates/reporting/scheduled-jobs-list.html
@@ -34,14 +34,11 @@
         <td th:replace="~{fragments/master-table :: colYesNo(enabled=${job.enabled})}"></td>
         <td th:replace="~{fragments/master-table :: colTextAdd(text=${#strings.isEmpty(job.cronExpression) ? defaultCron : job.cronExpression}, additional=${cronDescriptions[job.id]})}"></td>
         <td th:replace="~{fragments/master-table :: colDate(date=${job.lastupdate})}"></td>
+        <td>
+          <a class="btn btn-success" th:href="@{'/reporting/jobs/run'(id=${job.id})}"><i class="icon ti ti-player-play" style="margin-right: 0; margin-left: 0"></i></a>
+        </td>
         <td th:replace="~{fragments/master-table :: colEditLink(href=@{'/reporting/jobs/edit'(id=${job.id})})}"></td>
         <td th:replace="~{fragments/master-table :: colDeleteForm(id=${job.id}, action=@{'/reporting/jobs/delete'})}"></td>
-        <td>
-          <form th:action="@{/reporting/jobs/run}" method="post">
-            <input type="hidden" name="id" th:value="${job.id}"/>
-            <button type="submit" class="btn btn-outline-success" title="Run now"><i class="icon ti ti-player-play m-0"></i></button>
-          </form>
-        </td>
       </tr>
     </tbody>
 


### PR DESCRIPTION
## Summary
- Add a **Run** button to each row in `/reporting/jobs` so jobs can be triggered immediately without waiting for their cron schedule
- `POST /reporting/jobs/run` executes the job synchronously via `executeScheduledReportJobById` (ownership-checked) and redirects with a descriptive flash message
- Flash message covers all three cases: rows sent, email suppressed (empty result + suppressEmptyResults=true), and empty result email still sent
- Errors during execution surface as `toastError` flash — also fixes `toastError` being used by many controllers but never rendered in `layout/base.html`
- `sendReportEmail` now returns `SendResult(rowCount, suppressed)` instead of void; `executeScheduledReportJobById` returns `Optional<JobExecutionResult>`; history-entry builder extracted to `historyEntry()` helper to remove repetition

## Test plan
- [x] Open `/reporting/jobs`, click Run on an enabled job — verify success toast shows job name, row count, and recipient emails
- [x] Run a job whose report returns 0 rows with `suppressEmptyResults=true` — verify "email suppressed" message
- [x] Run a job whose report returns 0 rows with `suppressEmptyResults=false` — verify "empty result email sent to …" message
- [x] Run a disabled job — verify "Job was not executed (disabled or not found)" toast
- [x] Simulate an execution error (e.g. bad SQL) — verify error toast is shown
- [x] Confirm scheduled (cron-triggered) execution still works correctly
- [x] Verify `toastError` flash renders correctly on pages that already use it (e.g. order/employee controllers)

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #655