### PR TITLE
Fix suborder dropdown sort order in employee order and suborder forms

### DIFF
--- a/src/main/java/org/tb/order/persistence/SuborderDAO.java
+++ b/src/main/java/org/tb/order/persistence/SuborderDAO.java
@@ -2,7 +2,6 @@ package org.tb.order.persistence;
 
 import static java.lang.Boolean.TRUE;
 import static java.util.Comparator.comparing;
-import static org.springframework.data.domain.Sort.Direction.ASC;
 import static org.tb.common.util.DateUtils.today;
 
 import jakarta.persistence.criteria.Predicate;
@@ -17,7 +16,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 import org.tb.customer.domain.Customer_;
@@ -90,8 +88,9 @@ public class SuborderDAO {
         if (onlyValid) {
             return getSubordersByCustomerorderId(customerorderId, today());
         } else {
-            var order = new Order(ASC, Suborder_.SIGN);
-            return suborderRepository.findAllByCustomerorderId(customerorderId, Sort.by(order));
+            return suborderRepository.findAllByCustomerorderId(customerorderId, Sort.unsorted()).stream()
+                .sorted(comparing(Suborder::getCompleteOrderSign))
+                .collect(Collectors.toList());
         }
     }
 
@@ -99,9 +98,9 @@ public class SuborderDAO {
      * Gets a list of Suborders by customer order id.
      */
     public List<Suborder> getSubordersByCustomerorderId(long customerorderId, LocalDate date) {
-        var order = new Order(ASC, Suborder_.SIGN);
-        return suborderRepository.findAllByCustomerorderId(customerorderId, Sort.by(order)).stream()
+        return suborderRepository.findAllByCustomerorderId(customerorderId, Sort.unsorted()).stream()
             .filter(s -> s.isValidAt(date))
+            .sorted(comparing(Suborder::getCompleteOrderSign))
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## Summary

- `SuborderDAO.getSubordersByCustomerorderId()` was sorting by the local `sign` column, causing incorrect ordering for hierarchical suborders in two dropdowns:
  - **Employee order form** — suborder select (`suborderId`)
  - **Suborder form** — parent suborder select (`parentId`)
- Both forms call the same DAO method, so a single fix in the DAO covers both. Both overloads (all records and date-filtered) now sort in-memory by `completeOrderSign`, consistent with every other place in the codebase that presents a suborder list.
- Removed the now-unused `Sort.Order` and `Sort.Direction.ASC` imports.

## Test plan

- [x] Open the employee order create/edit form; select a customer order that has suborders at multiple levels — verify options appear in `completeOrderSign` ascending order (e.g. `CUST/SUB-A` before `CUST/SUB-B`, `CUST/SUB-A/SUB-A1` before `CUST/SUB-A/SUB-A2`).
- [x] Open the suborder create/edit form; verify the parent suborder options are also sorted by `completeOrderSign` ascending.
- [x] Change the customer order via the HTMX dropdown in both forms — verify the refreshed lists are also correctly sorted.
- [x] Verify no regression in the suborder management list view.

Closes #659

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.