### PR TITLE
Fix suborder dropdown sort order in employee order and suborder forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,14 @@ See also README.md
   ```
 - **PR compliance note**: every PR description must include: _"Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines."_
 - **Refactoring issues**: promote one refactoring at a time — open a new issue for the next step rather than bundling multiple cleanups in one PR.
+- **Issue type**: every issue must have its type set via the GitHub GraphQL API after creation. Use `Bug` for defects and `Feature` for new capabilities. Available type IDs:
+  - `Task`:    `IT_kwDOAYn5ks4AV-6C`
+  - `Bug`:     `IT_kwDOAYn5ks4AV-6D`
+  - `Feature`: `IT_kwDOAYn5ks4AV-6H`
+  ```bash
+  gh api graphql -f query='mutation { updateIssue(input: { id: "<node_id>", issueTypeId: "<type_id>" }) { issue { number issueType { name } } } }'
+  # get node_id via: gh api repos/HBTGmbH/salat/issues/NNN --jq .node_id
+  ```
 
 ## Documentation
 - Keep this document updated when architectural rules evolve.


### PR DESCRIPTION
## Summary

- `SuborderDAO.getSubordersByCustomerorderId()` was sorting by the local `sign` column, causing hierarchical suborders to appear in the wrong order in both the employee order form and the suborder parent-select
- Changed both overloads to sort in-memory by `completeOrderSign` (the full hierarchical path), consistent with how all other DAO methods sort suborders
- Also documents the GitHub issue type IDs and GraphQL snippet in AGENTS.md so new issues always get the correct type set

## Test plan

- [x] Open the employee order form — suborder dropdown options are sorted by `completeOrderSign` ascending (e.g. `CUST/SUB-A/SUB-A1` before `CUST/SUB-B`)
- [x] Open the suborder form — parent suborder dropdown options are sorted by `completeOrderSign` ascending
- [x] HTMX-driven refresh (change customer order) also shows correctly sorted options in both forms

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #659