### PR TITLE
Fix suborder filter to include descendants in employee orders list

### DIFF
--- a/src/main/java/org/tb/order/persistence/EmployeeorderDAO.java
+++ b/src/main/java/org/tb/order/persistence/EmployeeorderDAO.java
@@ -27,6 +27,7 @@ import org.tb.order.auth.EmployeeorderAuthorization;
 import org.tb.order.domain.Customerorder_;
 import org.tb.order.domain.Employeeorder;
 import org.tb.order.domain.Employeeorder_;
+import org.tb.order.domain.Suborder;
 import org.tb.order.domain.Suborder_;
 
 @Component
@@ -37,6 +38,7 @@ public class EmployeeorderDAO {
 
     private final EmployeeorderRepository employeeorderRepository;
     private final EmployeeorderAuthorization employeeorderAuthorization;
+    private final SuborderDAO suborderDAO;
 
     /**
      * Gets the employeeorder for the given id.
@@ -200,11 +202,8 @@ public class EmployeeorderDAO {
         );
     }
 
-    private Specification<Employeeorder> matchingSuborderId(long suborderId) {
-        return (root, query, builder) -> builder.equal(
-            root.join(Employeeorder_.suborder).get(Suborder_.id),
-            suborderId
-        );
+    private Specification<Employeeorder> matchingSuborderIds(Set<Long> suborderIds) {
+        return (root, query, builder) -> root.join(Employeeorder_.suborder).get(Suborder_.id).in(suborderIds);
     }
 
     private Specification<Employeeorder> filterMatches(String filter) {
@@ -244,7 +243,13 @@ public class EmployeeorderDAO {
                     predicates.add(matchingCustomerorderId(customerOrderId).toPredicate(root, query, builder));
                 }
                 if(customerSuborderId != null && customerSuborderId > 0) {
-                    predicates.add(matchingSuborderId(customerSuborderId).toPredicate(root, query, builder));
+                    var suborder = suborderDAO.getSuborderById(customerSuborderId);
+                    if(suborder != null) {
+                        var ids = suborder.getAllChildren().stream()
+                            .map(Suborder::getId)
+                            .collect(Collectors.toSet());
+                        predicates.add(matchingSuborderIds(ids).toPredicate(root, query, builder));
+                    }
                 }
                 boolean isFilter = filter != null && !filter.trim().isEmpty();
                 if(isFilter) {


### PR DESCRIPTION
## Summary
- `EmployeeorderDAO.matchingSuborderId()` performed an exact equality check, so only employee orders directly assigned to the selected suborder were returned.
- Replaced the single-ID equality predicate with an `IN` predicate over the full descendant ID set, collected in-memory via `Suborder.getAllChildren()` (which visits the root and all nested sub-suborders recursively).
- Injected `SuborderDAO` into `EmployeeorderDAO` to load the selected suborder before building the predicate.

## Test plan
- [x] Select a top-level suborder in the employee orders list filter — verify orders for that suborder and all nested sub-suborders appear.
- [x] Select a leaf suborder (no children) — verify behaviour is unchanged from before.
- [x] Verify other filter combinations (employee contract, customer, customer order, text search) still work correctly alongside the suborder filter.

Closes #658

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.