### PR TITLE
Apply in-memory text filtering across all six list pages

### DIFF
--- a/src/main/java/org/tb/customer/service/CustomerService.java
+++ b/src/main/java/org/tb/customer/service/CustomerService.java
@@ -45,17 +45,25 @@ public class CustomerService {
 
   @Transactional(readOnly = true)
   public List<CustomerDTO> getAllCustomerDTOsByFilter(String filter, boolean showHidden) {
-    if (filter == null || filter.isBlank()) {
-      var repo = showHidden
-          ? stream(customerRepository.findAll(Sort.by(Customer_.NAME)).spliterator(), false)
-          : customerRepository.findAllVisible().stream();
-      return repo.map(CustomerDTO::from).toList();
-    } else {
-      var results = showHidden
-          ? customerRepository.findAllByFilterIgnoringCase("%" + filter + "%")
-          : customerRepository.findVisibleByFilterIgnoringCase("%" + filter + "%");
-      return results.stream().map(CustomerDTO::from).toList();
-    }
+    boolean hasFilter = filter != null && !filter.isBlank();
+    var repo = showHidden
+        ? stream(customerRepository.findAll(Sort.by(Customer_.NAME)).spliterator(), false)
+        : customerRepository.findAllVisible().stream();
+    return repo
+        .filter(c -> !hasFilter || filterMatchesInMemory(c, filter))
+        .map(CustomerDTO::from)
+        .toList();
+  }
+
+  private boolean filterMatchesInMemory(Customer c, String filter) {
+    var upper = filter.toUpperCase();
+    return containsIgnoreCase(c.getShortname(), upper)
+        || containsIgnoreCase(c.getName(), upper)
+        || containsIgnoreCase(c.getAddress(), upper);
+  }
+
+  private static boolean containsIgnoreCase(String value, String upper) {
+    return value != null && value.toUpperCase().contains(upper);
   }
 
   @Authorized(requiresManager = true)

--- a/src/main/java/org/tb/employee/persistence/EmployeeDAO.java
+++ b/src/main/java/org/tb/employee/persistence/EmployeeDAO.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.tb.auth.domain.AccessLevel;
 import org.tb.auth.domain.AuthorizedUser;
-import org.tb.auth.domain.SalatUser_;
 import org.tb.common.GlobalConstants;
 import org.tb.employee.auth.EmployeeAuthorization;
 import org.tb.employee.domain.Employee;
@@ -118,24 +117,24 @@ public class EmployeeDAO {
         }
 
         Specification<Employee> spec = excludeHidden ? notHidden() : null;
-        if (hasFilter) {
-            var filterValue = "%" + filter.toUpperCase() + "%";
-            Specification<Employee> filterSpec = (root, query, builder) -> {
-                var salatUserJoin = root.join(Employee_.salatUser);
-                return builder.or(
-                    builder.like(builder.upper(salatUserJoin.get(SalatUser_.loginname)), filterValue),
-                    builder.like(builder.upper(root.get(Employee_.firstname)), filterValue),
-                    builder.like(builder.upper(root.get(Employee_.lastname)), filterValue),
-                    builder.like(builder.upper(root.get(Employee_.sign)), filterValue),
-                    builder.like(builder.upper(salatUserJoin.get(SalatUser_.status)), filterValue)
-                );
-            };
-            spec = spec == null ? filterSpec : spec.and(filterSpec);
-        }
         return employeeRepository.findAll(spec).stream()
             .filter(e -> employeeAuthorization.isAuthorized(e, AccessLevel.READ, supervisedIds))
+            .filter(e -> !hasFilter || filterMatchesInMemory(e, filter))
             .sorted(Comparator.comparing(Employee::getName))
             .collect(Collectors.toList());
+    }
+
+    private boolean filterMatchesInMemory(Employee e, String filter) {
+        var upper = filter.toUpperCase();
+        return containsIgnoreCase(e.getName(), upper)
+            || containsIgnoreCase(e.getLastname(), upper)
+            || containsIgnoreCase(e.getFirstname(), upper)
+            || containsIgnoreCase(e.getSign(), upper)
+            || containsIgnoreCase(e.getLoginname(), upper);
+    }
+
+    private static boolean containsIgnoreCase(String value, String upper) {
+        return value != null && value.toUpperCase().contains(upper);
     }
 
     public Set<Long> getSupervisedEmployeeIds() {

--- a/src/main/java/org/tb/employee/persistence/EmployeeDAO.java
+++ b/src/main/java/org/tb/employee/persistence/EmployeeDAO.java
@@ -116,7 +116,7 @@ public class EmployeeDAO {
                 .collect(Collectors.toList());
         }
 
-        Specification<Employee> spec = excludeHidden ? notHidden() : null;
+        Specification<Employee> spec = excludeHidden ? notHidden() : (root, query, builder) -> builder.conjunction();
         return employeeRepository.findAll(spec).stream()
             .filter(e -> employeeAuthorization.isAuthorized(e, AccessLevel.READ, supervisedIds))
             .filter(e -> !hasFilter || filterMatchesInMemory(e, filter))

--- a/src/main/java/org/tb/employee/persistence/EmployeecontractDAO.java
+++ b/src/main/java/org/tb/employee/persistence/EmployeecontractDAO.java
@@ -92,19 +92,17 @@ public class EmployeecontractDAO {
         return (root, query, builder) -> builder.equal(root.join(Employeecontract_.employee).get(Employee_.id), employeeId);
     }
 
-    private Specification<Employeecontract> filterMatches(String filter) {
-        final var filterValue = ('%' + filter + '%').toUpperCase();
-        return (root, query, builder) -> {
-            var employeeJoin = root.join(Employeecontract_.employee);
-            var salatUserJoin = employeeJoin.join("salatUser");
-            return builder.or(
-                builder.like(builder.upper(root.get(Employeecontract_.taskDescription)), filterValue),
-                builder.like(builder.upper(employeeJoin.get(Employee_.firstname)), filterValue),
-                builder.like(builder.upper(employeeJoin.get(Employee_.lastname)), filterValue),
-                builder.like(builder.upper(employeeJoin.get(Employee_.sign)), filterValue),
-                builder.like(builder.upper(salatUserJoin.get("loginname")), filterValue)
-            );
-        };
+    private boolean filterMatchesInMemory(Employeecontract ec, String filter) {
+        var upper = filter.toUpperCase();
+        var emp = ec.getEmployee();
+        var supervisor = ec.getSupervisor();
+        return containsIgnoreCase(emp.getName(), upper)
+            || containsIgnoreCase(ec.getTaskDescription(), upper)
+            || (supervisor != null && containsIgnoreCase(supervisor.getName(), upper));
+    }
+
+    private static boolean containsIgnoreCase(String value, String upper) {
+        return value != null && value.toUpperCase().contains(upper);
     }
 
     /**
@@ -113,6 +111,7 @@ public class EmployeecontractDAO {
      * @return List<Employeecontract>
      */
     public List<Employeecontract> getEmployeeContractsByFilters(Boolean showInvalid, String filter, Long employeeId, Boolean showHidden) {
+        boolean isFilter = filter != null && !filter.trim().isEmpty();
         return employeecontractRepository.findAll((Specification<Employeecontract>) (root, query, builder) -> {
             Set<Predicate> predicates = new HashSet<>();
             if (!TRUE.equals(showInvalid)) {
@@ -124,13 +123,10 @@ public class EmployeecontractDAO {
             if (employeeId != null && employeeId > 0) {
                 predicates.add(matchingEmployeeId(employeeId).toPredicate(root, query, builder));
             }
-            boolean isFilter = filter != null && !filter.trim().isEmpty();
-            if (isFilter) {
-                predicates.add(filterMatches(filter).toPredicate(root, query, builder));
-            }
             return builder.and(predicates.toArray(new Predicate[0]));
         }).stream()
             .filter(c -> employeecontractAuthorization.isAuthorized(c, AccessLevel.READ))
+            .filter(c -> !isFilter || filterMatchesInMemory(c, filter))
             .sorted(comparing((Employeecontract e) -> e.getEmployee().getLastname()).thenComparing(Employeecontract::getValidFrom))
             .collect(Collectors.toList());
     }

--- a/src/main/java/org/tb/order/persistence/CustomerorderDAO.java
+++ b/src/main/java/org/tb/order/persistence/CustomerorderDAO.java
@@ -21,7 +21,6 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 import org.tb.customer.domain.Customer_;
 import org.tb.employee.domain.Employee;
-import org.tb.employee.domain.Employee_;
 import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.domain.Employeecontract_;
 import org.tb.order.domain.Customerorder;
@@ -94,27 +93,26 @@ public class CustomerorderDAO {
         return (root, query, builder) -> builder.equal(root.join(Customerorder_.customer).get(Customer_.id), customerId);
     }
 
-    private Specification<Customerorder> filterMatches(String filter) {
-        final var filterValue = ('%' + filter + '%').toUpperCase();
-        return (root, query, builder) -> builder.or(
-            builder.like(builder.upper(root.get(Customerorder_.sign)), filterValue),
-            builder.like(builder.upper(root.get(Customerorder_.description)), filterValue),
-            builder.like(builder.upper(root.get(Customerorder_.responsible_customer_contractually)), filterValue),
-            builder.like(builder.upper(root.get(Customerorder_.responsible_customer_technical)), filterValue),
-            builder.like(builder.upper(root.get(Customerorder_.order_customer)), filterValue),
-            builder.like(builder.upper(root.join(Customerorder_.customer).get(Customer_.name)), filterValue),
-            builder.like(builder.upper(root.join(Customerorder_.customer).get(Customer_.shortname)), filterValue),
-            builder.like(builder.upper(root.join(Customerorder_.responsible_hbt).get(Employee_.firstname)), filterValue),
-            builder.like(builder.upper(root.join(Customerorder_.responsible_hbt).get(Employee_.lastname)), filterValue),
-            builder.like(builder.upper(root.join(Customerorder_.respEmpHbtContract).get(Employee_.firstname)), filterValue),
-            builder.like(builder.upper(root.join(Customerorder_.respEmpHbtContract).get(Employee_.lastname)), filterValue)
-        );
+    private boolean filterMatchesInMemory(Customerorder co, String filter) {
+        var upper = filter.toUpperCase();
+        var customer = co.getCustomer();
+        return containsIgnoreCase(customer.getShortname(), upper)
+            || containsIgnoreCase(customer.getName(), upper)
+            || containsIgnoreCase(co.getSign(), upper)
+            || containsIgnoreCase(co.getDescription(), upper)
+            || (co.getResponsible_hbt() != null && containsIgnoreCase(co.getResponsible_hbt().getName(), upper))
+            || (co.getRespEmpHbtContract() != null && containsIgnoreCase(co.getRespEmpHbtContract().getName(), upper));
+    }
+
+    private static boolean containsIgnoreCase(String value, String upper) {
+        return value != null && value.toUpperCase().contains(upper);
     }
 
     /**
      * Get a list of all Customerorders fitting to the given filters ordered by their sign.
      */
     public List<Customerorder> getCustomerordersByFilters(final Boolean showInvalid, final String filter, final Long customerId, final Boolean showHidden) {
+        boolean isFilter = filter != null && !filter.trim().isEmpty();
         var order = new Order(ASC, Customerorder_.SIGN).ignoreCase();
         return customerorderRepository.findAll((Specification<Customerorder>) (root, query, builder) -> {
             Set<Predicate> predicates = new HashSet<>();
@@ -127,12 +125,10 @@ public class CustomerorderDAO {
             if(customerId != null && customerId > 0) {
                 predicates.add(matchingCustomerId(customerId).toPredicate(root, query, builder));
             }
-            boolean isFilter = filter != null && !filter.trim().isEmpty();
-            if(isFilter) {
-                predicates.add(filterMatches(filter).toPredicate(root, query, builder));
-            }
             return builder.and(predicates.toArray(new Predicate[0]));
-        }, Sort.by(order));
+        }, Sort.by(order)).stream()
+            .filter(co -> !isFilter || filterMatchesInMemory(co, filter))
+            .collect(Collectors.toList());
     }
 
     public List<Customerorder> getCustomerordersByCustomerId(long customerId) {

--- a/src/main/java/org/tb/order/persistence/EmployeeorderDAO.java
+++ b/src/main/java/org/tb/order/persistence/EmployeeorderDAO.java
@@ -210,15 +210,18 @@ public class EmployeeorderDAO {
         var sub = eo.getSuborder();
         var emp = eo.getEmployeecontract().getEmployee();
         var co = sub.getCustomerorder();
+        var customer = co.getCustomer();
         return containsIgnoreCase(emp.getSign(), upper)
             || containsIgnoreCase(emp.getFirstname(), upper)
             || containsIgnoreCase(emp.getLastname(), upper)
+            || containsIgnoreCase(customer.getShortname(), upper)
+            || containsIgnoreCase(customer.getName(), upper)
             || containsIgnoreCase(co.getSign(), upper)
-            || containsIgnoreCase(co.getDescription(), upper)
             || containsIgnoreCase(co.getShortdescription(), upper)
             || containsIgnoreCase(sub.getSign(), upper)
-            || containsIgnoreCase(sub.getDescription(), upper)
-            || containsIgnoreCase(sub.getShortdescription(), upper);
+            || containsIgnoreCase(sub.getShortdescription(), upper)
+            || containsIgnoreCase(sub.getCompleteOrderSign(), upper)
+            || containsIgnoreCase(sub.getCompleteOrderDescription(true, false), upper);
     }
 
     private static boolean containsIgnoreCase(String value, String upper) {

--- a/src/main/java/org/tb/order/persistence/EmployeeorderDAO.java
+++ b/src/main/java/org/tb/order/persistence/EmployeeorderDAO.java
@@ -21,7 +21,6 @@ import org.tb.auth.domain.AccessLevel;
 import org.tb.common.LocalDateRange;
 import org.tb.common.util.DateUtils;
 import org.tb.customer.domain.Customer_;
-import org.tb.employee.domain.Employee_;
 import org.tb.employee.domain.Employeecontract_;
 import org.tb.order.auth.EmployeeorderAuthorization;
 import org.tb.order.domain.Customerorder_;
@@ -206,25 +205,31 @@ public class EmployeeorderDAO {
         return (root, query, builder) -> root.join(Employeeorder_.suborder).get(Suborder_.id).in(suborderIds);
     }
 
-    private Specification<Employeeorder> filterMatches(String filter) {
-        final var filterValue = ('%' + filter + '%').toUpperCase();
-        return (root, query, builder) -> builder.or(
-            builder.like(builder.upper(root.join(Employeeorder_.employeecontract).join(Employeecontract_.employee).get(Employee_.sign)), filterValue),
-            builder.like(builder.upper(root.join(Employeeorder_.employeecontract).join(Employeecontract_.employee).get(Employee_.firstname)), filterValue),
-            builder.like(builder.upper(root.join(Employeeorder_.employeecontract).join(Employeecontract_.employee).get(Employee_.lastname)), filterValue),
-            builder.like(builder.upper(root.join(Employeeorder_.suborder).join(Suborder_.customerorder).get(Customerorder_.sign)), filterValue),
-            builder.like(builder.upper(root.join(Employeeorder_.suborder).join(Suborder_.customerorder).get(Customerorder_.description)), filterValue),
-            builder.like(builder.upper(root.join(Employeeorder_.suborder).join(Suborder_.customerorder).get(Customerorder_.shortdescription)), filterValue),
-            builder.like(builder.upper(root.join(Employeeorder_.suborder).get(Suborder_.sign)), filterValue),
-            builder.like(builder.upper(root.join(Employeeorder_.suborder).get(Suborder_.description)), filterValue),
-            builder.like(builder.upper(root.join(Employeeorder_.suborder).get(Suborder_.shortdescription)), filterValue)
-        );
+    private boolean filterMatchesInMemory(Employeeorder eo, String filter) {
+        var upper = filter.toUpperCase();
+        var sub = eo.getSuborder();
+        var emp = eo.getEmployeecontract().getEmployee();
+        var co = sub.getCustomerorder();
+        return containsIgnoreCase(emp.getSign(), upper)
+            || containsIgnoreCase(emp.getFirstname(), upper)
+            || containsIgnoreCase(emp.getLastname(), upper)
+            || containsIgnoreCase(co.getSign(), upper)
+            || containsIgnoreCase(co.getDescription(), upper)
+            || containsIgnoreCase(co.getShortdescription(), upper)
+            || containsIgnoreCase(sub.getSign(), upper)
+            || containsIgnoreCase(sub.getDescription(), upper)
+            || containsIgnoreCase(sub.getShortdescription(), upper);
+    }
+
+    private static boolean containsIgnoreCase(String value, String upper) {
+        return value != null && value.toUpperCase().contains(upper);
     }
 
     /**
      * Get a list of all Employeeorders fitting to the given filters ordered by employee, customer order, and suborder.
      */
     public List<Employeeorder> getEmployeeordersByFilters(Boolean showInvalid, String filter, Long employeeContractId, Long customerId, Long customerOrderId, Long customerSuborderId, Boolean showHidden) {
+        boolean isFilter = filter != null && !filter.trim().isEmpty();
         return employeeorderRepository.findAll((Specification<Employeeorder>) (root, query, builder) -> {
                 Set<Predicate> predicates = new HashSet<>();
                 if(!TRUE.equals(showInvalid)) {
@@ -251,13 +256,10 @@ public class EmployeeorderDAO {
                         predicates.add(matchingSuborderIds(ids).toPredicate(root, query, builder));
                     }
                 }
-                boolean isFilter = filter != null && !filter.trim().isEmpty();
-                if(isFilter) {
-                    predicates.add(filterMatches(filter).toPredicate(root, query, builder));
-                }
                 return builder.and(predicates.toArray(new Predicate[0]));
             }).stream()
             .filter(eo -> employeeorderAuthorization.isAuthorized(eo, AccessLevel.READ))
+            .filter(eo -> !isFilter || filterMatchesInMemory(eo, filter))
             .sorted(comparing((Employeeorder e) -> e.getEmployeecontract().getEmployee().getSign())
                 .thenComparing((Employeeorder e) -> e.getSuborder().getCustomerorder().getSign())
                 .thenComparing((Employeeorder e) -> e.getSuborder().getCompleteOrderSign())

--- a/src/main/java/org/tb/order/persistence/SuborderDAO.java
+++ b/src/main/java/org/tb/order/persistence/SuborderDAO.java
@@ -179,19 +179,18 @@ public class SuborderDAO {
         if(filter == null || filter.trim().isEmpty()) {
             return true;
         }
-        var customerorder = suborder.getCustomerorder();
+        var co = suborder.getCustomerorder();
+        var customer = co.getCustomer();
         var matchCandidates = List.of(
-            customerorder.getSign(),
-            customerorder.getShortdescription(),
-            customerorder.getDescription(),
-            customerorder.getOrder_customer(),
+            customer.getShortname(),
+            customer.getName(),
+            co.getSign(),
+            co.getShortdescription(),
             suborder.getCompleteOrderSign(),
-            suborder.getShortdescription(),
-            suborder.getDescription(),
-            suborder.getSuborder_customer()
+            suborder.getCompleteOrderDescription(true, false),
+            suborder.getShortdescription()
         );
 
-        // do a case insensitive comparison
         final var filterValue = filter.toLowerCase();
         return matchCandidates.stream()
             .filter(Objects::nonNull)

--- a/src/main/resources/templates/order/sub-order-list.html
+++ b/src/main/resources/templates/order/sub-order-list.html
@@ -119,7 +119,7 @@
           </td>
           <td>
             <div th:text="${so.completeOrderSign}">Suborder Sign</div>
-            <small class="text-muted" th:text="${so.shortdescription}">short description</small>
+            <small class="text-muted" th:text="${so.getCompleteOrderDescription(true, false)}">short description</small>
           </td>
           <td class="d-none d-sm-table-cell">
             <div th:text="${so.fromDate}">From</div>


### PR DESCRIPTION
## Summary

- Hibernate's `upper()` rejects `@Lob` fields (mapped as CLOB), causing a `FunctionArgumentException` when using the text filter on the employee order list
- Root cause: `Suborder.description` is annotated `@Lob`, making it a CLOB type that is incompatible with JPQL string functions
- Fix: replace all JPQL `upper()`/`LIKE` filter specifications with in-memory Java predicates across all six list pages
- Each filter covers the text fields actually shown in the corresponding result table, including computed fields (`completeOrderSign`, `getName()`, `completeOrderDescription`)

## Affected lists

| List | Class | Filter fields |
|---|---|---|
| Employee orders | `EmployeeorderDAO` | employee name/sign, customer name/shortname, complete order sign & description |
| Suborders | `SuborderDAO` | customer name/shortname, customer order sign/shortdescription, complete order sign & description |
| Customer orders | `CustomerorderDAO` | customer name/shortname, order sign/description, responsible HBT names |
| Customers | `CustomerService` | shortname, name, address |
| Employees | `EmployeeDAO` | full name, lastname, firstname, sign, loginname |
| Employee contracts | `EmployeecontractDAO` | employee name, task description, supervisor name |

## Test plan

- [x] Open each of the six list pages and type a search term — list filters without errors
- [x] Verify matches work for fields shown in the table (name, sign, description, etc.)
- [x] Verify empty filter shows all records
- [x] Verify the original crash (`FunctionArgumentException` on employee order list) no longer occurs

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)