### PR TITLE
Fix HTTP 400 when report parameter value contains "%"

### DIFF
--- a/src/main/java/org/tb/reporting/controller/ReportController.java
+++ b/src/main/java/org/tb/reporting/controller/ReportController.java
@@ -12,6 +12,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.YearMonth;
@@ -235,7 +237,8 @@ public class ReportController {
     response.getOutputStream().write(bytes);
   }
 
-  private static String renderQueryParams(List<ReportParameter> parameters) {
+  @VisibleForTesting
+  static String renderQueryParams(List<ReportParameter> parameters) {
     if (parameters == null || parameters.isEmpty()) {
       return "";
     }
@@ -246,7 +249,7 @@ public class ReportController {
         if (!"string".equals(parameter.getType())) {
           result.append(parameter.getType()).append(",");
         }
-        result.append(parameter.getValue());
+        result.append(URLEncoder.encode(parameter.getValue(), StandardCharsets.UTF_8));
       }
     }
     return result.toString();

--- a/src/test/java/org/tb/reporting/controller/ReportControllerTest.java
+++ b/src/test/java/org/tb/reporting/controller/ReportControllerTest.java
@@ -1,5 +1,6 @@
 package org.tb.reporting.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDateTime;
@@ -21,6 +22,25 @@ class ReportControllerTest {
 
   @Mock
   private ReportDefinition reportDefinition;
+
+  @Test
+  void renderQueryParams_encodes_percent_in_value() {
+    var params = List.of(new ReportParameter("sign", "string", "G%"));
+    assertThat(ReportController.renderQueryParams(params)).isEqualTo("&sign=G%25");
+  }
+
+  @Test
+  void renderQueryParams_encodes_percent_with_type_prefix() {
+    var params = List.of(new ReportParameter("name", "number", "G%"));
+    assertThat(ReportController.renderQueryParams(params)).isEqualTo("&name=number,G%25");
+  }
+
+  @Test
+  void renderQueryParams_star_is_preserved_for_later_sql_translation() {
+    // URLEncoder does not encode '*', so it passes through for getParameterMap to convert to '%'
+    var params = List.of(new ReportParameter("sign", "string", "G*"));
+    assertThat(ReportController.renderQueryParams(params)).isEqualTo("&sign=G*");
+  }
 
   @Test
   void testCreateFileNameWithValidData() {


### PR DESCRIPTION
## Summary
- `renderQueryParams` now wraps each parameter value in `URLEncoder.encode(..., UTF_8)` before appending it to the redirect URL
- `%` → `%25`, so Tomcat's URL parser no longer sees an incomplete percent-encoding sequence
- `*` is unaffected (URLEncoder leaves it as-is, and the existing `replace('*','%')` in `getParameterMap` continues to work)
- `renderQueryParams` promoted from `private` to package-private (`@VisibleForTesting`) to allow direct unit testing

## Test plan
- [x] Enter `G%` as a report parameter value — report executes without HTTP 400
- [x] Enter `G*` as a report parameter value — still works as a LIKE wildcard
- [x] 3 new unit tests in `ReportControllerTest` covering `%`, typed params with `%`, and `*`

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #669