### PR TITLE
Support multiple supervisors per employee contract (#683)

### DIFF
--- a/src/main/java/org/tb/dailyreport/auth/ReleaseAuthorization.java
+++ b/src/main/java/org/tb/dailyreport/auth/ReleaseAuthorization.java
@@ -38,8 +38,8 @@ public class ReleaseAuthorization {
   }
 
   private boolean isSupervisedByCurrentUser(Employeecontract ec) {
-    return ec.getSupervisor() != null &&
-           ec.getSupervisor().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
+    return ec.getSupervisors().stream()
+        .anyMatch(s -> s.getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign()));
   }
 
 }

--- a/src/main/java/org/tb/dailyreport/auth/TimereportAuthorization.java
+++ b/src/main/java/org/tb/dailyreport/auth/TimereportAuthorization.java
@@ -110,8 +110,8 @@ public class TimereportAuthorization {
   }
 
   private boolean isSupervisedByCurrentUser(Employeecontract ec) {
-    return ec.getSupervisor() != null &&
-           ec.getSupervisor().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
+    return ec.getSupervisors().stream()
+        .anyMatch(s -> s.getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign()));
   }
 
 }

--- a/src/main/java/org/tb/dailyreport/controller/AcceptanceController.java
+++ b/src/main/java/org/tb/dailyreport/controller/AcceptanceController.java
@@ -50,8 +50,7 @@ public class AcceptanceController {
         if (authorizedUser.isManager()) {
             var allViewable = employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(today());
             List<Employee> supervisors = allViewable.stream()
-                .map(Employeecontract::getSupervisor)
-                .filter(s -> s != null)
+                .flatMap(ec -> ec.getSupervisors().stream())
                 .distinct()
                 .sorted(Comparator.comparing(Employee::getName))
                 .toList();

--- a/src/main/java/org/tb/dailyreport/service/ReleaseService.java
+++ b/src/main/java/org/tb/dailyreport/service/ReleaseService.java
@@ -342,65 +342,67 @@ public class ReleaseService {
 
     var employeeContract = employeecontractService.getEmployeecontractById(employeecontracttoAcceptId);
     var coworker = employeeContract.getEmployee();
-    var recipient = employeeContract.getSupervisor();
     var sender = employeeService.getLoginEmployee();
 
     String subject = "SALAT: Erinnerung SALAT-Freigabe abnehmen";
-    StringBuilder message = new StringBuilder();
-    if (GlobalConstants.GENDER_FEMALE == recipient.getGender()) {
-      message.append("Liebe ");
-    } else {
-      message.append("Lieber ");
-    }
-    message.append(recipient.getFirstname());
-    message.append(",\n\n");
-    message.append("bitte nimm die SALAT-Buchungen des abgelaufenen Monats von ");
-    if (GlobalConstants.GENDER_FEMALE == coworker.getGender()) {
-      message.append("Kollegin ");
-    } else {
-      message.append("Kollege ");
-    }
-    message.append(coworker.getName());
-    message.append(" ab.\n\n");
-    message.append(sender.getName());
+    for (var recipient : employeeContract.getSupervisors()) {
+      StringBuilder message = new StringBuilder();
+      if (GlobalConstants.GENDER_FEMALE == recipient.getGender()) {
+        message.append("Liebe ");
+      } else {
+        message.append("Lieber ");
+      }
+      message.append(recipient.getFirstname());
+      message.append(",\n\n");
+      message.append("bitte nimm die SALAT-Buchungen des abgelaufenen Monats von ");
+      if (GlobalConstants.GENDER_FEMALE == coworker.getGender()) {
+        message.append("Kollegin ");
+      } else {
+        message.append("Kollege ");
+      }
+      message.append(coworker.getName());
+      message.append(" ab.\n\n");
+      message.append(sender.getName());
 
-    mailService.sendEmail(
-        subject,
-        message.toString(),
-        new MailContact(sender.getName(), sender.getEmailAddress()),
-        new MailContact(recipient.getName(), recipient.getEmailAddress())
-    );
+      mailService.sendEmail(
+          subject,
+          message.toString(),
+          new MailContact(sender.getName(), sender.getEmailAddress()),
+          new MailContact(recipient.getName(), recipient.getEmailAddress())
+      );
+    }
   }
 
   private void sendTimeReportsReleasedMail(Employeecontract releasedEmployeeContract) {
     var sender = releasedEmployeeContract.getEmployee();
-    var recipient = releasedEmployeeContract.getSupervisor();
-
     String subject = "SALAT: Buchungen durch " + sender.getSign() + " freigegeben";
-    StringBuilder message = new StringBuilder();
-    if (GlobalConstants.GENDER_FEMALE == recipient.getGender()) {
-      message.append("Liebe Personalverantwortliche ");
-    } else {
-      message.append("Lieber Personalverantwortlicher ");
-    }
-    message.append(recipient.getFirstname());
-    message.append(",\n\n");
-    message.append(sender.getName());
-    message.append(" hat eben ");
-    if (GlobalConstants.GENDER_FEMALE == sender.getGender()) {
-      message.append("ihre ");
-    } else {
-      message.append("seine ");
-    }
-    message.append("SALAT-Buchungen freigegeben.\n");
-    message.append("Bitte nimm diese ab.");
 
-    mailService.sendEmail(
-        subject,
-        message.toString(),
-        new MailContact(sender.getName(), sender.getEmailAddress()),
-        new MailContact(recipient.getName(), recipient.getEmailAddress())
-    );
+    for (var recipient : releasedEmployeeContract.getSupervisors()) {
+      StringBuilder message = new StringBuilder();
+      if (GlobalConstants.GENDER_FEMALE == recipient.getGender()) {
+        message.append("Liebe Personalverantwortliche ");
+      } else {
+        message.append("Lieber Personalverantwortlicher ");
+      }
+      message.append(recipient.getFirstname());
+      message.append(",\n\n");
+      message.append(sender.getName());
+      message.append(" hat eben ");
+      if (GlobalConstants.GENDER_FEMALE == sender.getGender()) {
+        message.append("ihre ");
+      } else {
+        message.append("seine ");
+      }
+      message.append("SALAT-Buchungen freigegeben.\n");
+      message.append("Bitte nimm diese ab.");
+
+      mailService.sendEmail(
+          subject,
+          message.toString(),
+          new MailContact(sender.getName(), sender.getEmailAddress()),
+          new MailContact(recipient.getName(), recipient.getEmailAddress())
+      );
+    }
   }
 
   private void validateForAcceptance(long employeeContractId, LocalDate acceptanceDate) {

--- a/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
+++ b/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
@@ -54,8 +54,8 @@ public class WorkingdayService {
   private final EmployeecontractService employeecontractService;
 
   private boolean isSupervisedByCurrentUser(Employeecontract ec) {
-    return ec.getSupervisor() != null &&
-           ec.getSupervisor().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
+    return ec.getSupervisors().stream()
+        .anyMatch(s -> s.getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign()));
   }
 
   public Workingday getWorkingday(long employeecontractId, LocalDate date) {

--- a/src/main/java/org/tb/dailyreport/viewhelper/matrix/MatrixHelper.java
+++ b/src/main/java/org/tb/dailyreport/viewhelper/matrix/MatrixHelper.java
@@ -423,8 +423,8 @@ public class MatrixHelper {
             results.put("currentEmployeeContract", employeeContract);
             results.put("currentEmployeeId", employeeContract.getEmployee().getId());
             if (authorizedUser.isManager() ||
-                (authorizedUser.isPeopleLead() && employeeContract.getSupervisor() != null &&
-                    employeeContract.getSupervisor().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign())) ||
+                (authorizedUser.isPeopleLead() && employeeContract.getSupervisors().stream()
+                    .anyMatch(s -> s.getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign()))) ||
                 authorizedUser.getEffectiveLoginSign().equals(employeeContract.getEmployee().getSalatUser().getLoginname())) {
                 results.put("csvDownloadUrl", getCsvDownloadUrl(reportForm, employeeContract.getEmployee().getSign()));
             } else {

--- a/src/main/java/org/tb/employee/auth/EmployeecontractAuthorization.java
+++ b/src/main/java/org/tb/employee/auth/EmployeecontractAuthorization.java
@@ -22,8 +22,8 @@ public class EmployeecontractAuthorization {
   }
 
   private boolean isSupervisedByCurrentUser(Employeecontract ec) {
-    return ec.getSupervisor() != null &&
-        ec.getSupervisor().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
+    return ec.getSupervisors().stream()
+        .anyMatch(s -> s.getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign()));
   }
 
 }

--- a/src/main/java/org/tb/employee/controller/EmployeecontractController.java
+++ b/src/main/java/org/tb/employee/controller/EmployeecontractController.java
@@ -165,7 +165,7 @@ public class EmployeecontractController {
                             form.getId(),
                             form.getValidFromTyped(),
                             form.getValidUntilTyped(),
-                            form.getSupervisorId(),
+                            form.getSupervisorIds(),
                             form.getTaskdescription(),
                             Boolean.TRUE.equals(form.getFreelancer()),
                             Boolean.TRUE.equals(form.getHide()),
@@ -178,7 +178,7 @@ public class EmployeecontractController {
                             form.getEmployeeId(),
                             form.getValidFromTyped(),
                             form.getValidUntilTyped(),
-                            form.getSupervisorId(),
+                            form.getSupervisorIds(),
                             form.getTaskdescription(),
                             Boolean.TRUE.equals(form.getFreelancer()),
                             Boolean.TRUE.equals(form.getHide()),
@@ -333,12 +333,15 @@ public class EmployeecontractController {
         var employees = employeeService.getAllEmployees();
         var supervisors = new ArrayList<>(employeeService.getEligibleSupervisors());
         if (isEdit && form != null) {
-            Long supervisorIdToEnsure = form.getSupervisorId() != null ? form.getSupervisorId() : form.getStoredSupervisorId();
-            if (supervisorIdToEnsure != null
-                    && supervisors.stream().noneMatch(e -> Objects.equals(e.getId(), supervisorIdToEnsure))) {
-                Employee storedSupervisor = employeeService.getEmployeeById(supervisorIdToEnsure);
-                if (storedSupervisor != null) {
-                    supervisors.add(storedSupervisor);
+            var idsToEnsure = new ArrayList<Long>();
+            idsToEnsure.addAll(form.getSupervisorIds());
+            idsToEnsure.addAll(form.getStoredSupervisorIds());
+            for (Long id : idsToEnsure) {
+                if (id != null && supervisors.stream().noneMatch(e -> Objects.equals(e.getId(), id))) {
+                    Employee storedSupervisor = employeeService.getEmployeeById(id);
+                    if (storedSupervisor != null) {
+                        supervisors.add(storedSupervisor);
+                    }
                 }
             }
         }
@@ -368,10 +371,9 @@ public class EmployeecontractController {
         var form = new EmployeecontractForm();
         form.setId(ec.getId());
         form.setEmployeeId(ec.getEmployee().getId());
-        if (ec.getSupervisor() != null) {
-            form.setSupervisorId(ec.getSupervisor().getId());
-            form.setStoredSupervisorId(ec.getSupervisor().getId());
-        }
+        var supervisorIds = ec.getSupervisors().stream().map(Employee::getId).toList();
+        form.setSupervisorIds(new ArrayList<>(supervisorIds));
+        form.setStoredSupervisorIds(new ArrayList<>(supervisorIds));
         form.setTaskdescription(ec.getTaskDescription());
         form.setFreelancer(ec.getFreelancer());
         form.setHide(ec.getHide());

--- a/src/main/java/org/tb/employee/controller/EmployeecontractForm.java
+++ b/src/main/java/org/tb/employee/controller/EmployeecontractForm.java
@@ -6,6 +6,8 @@ import static org.tb.common.util.DateUtils.today;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import org.tb.common.util.DateUtils;
 import org.tb.common.util.DurationUtils;
@@ -15,9 +17,9 @@ public class EmployeecontractForm {
 
     private Long id;
     private Long employeeId;
-    private Long supervisorId;
+    private List<Long> supervisorIds = new ArrayList<>();
     /** Set once from DB when edit form is opened; never mutated by form lifecycle. */
-    private Long storedSupervisorId;
+    private List<Long> storedSupervisorIds = new ArrayList<>();
     private String taskdescription;
     private String validFrom;
     private String validUntil;

--- a/src/main/java/org/tb/employee/domain/Employeecontract.java
+++ b/src/main/java/org/tb/employee/domain/Employeecontract.java
@@ -41,7 +41,7 @@ public class Employeecontract extends AuditedEntity implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "employeecontract_supervisor",
         joinColumns = @JoinColumn(name = "EMPLOYEECONTRACT_ID"),
         inverseJoinColumns = @JoinColumn(name = "SUPERVISOR_ID"))

--- a/src/main/java/org/tb/employee/domain/Employeecontract.java
+++ b/src/main/java/org/tb/employee/domain/Employeecontract.java
@@ -5,7 +5,10 @@ import static org.tb.common.util.DateUtils.format;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.io.Serializable;
@@ -38,10 +41,13 @@ public class Employeecontract extends AuditedEntity implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    @ManyToOne
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "employeecontract_supervisor",
+        joinColumns = @JoinColumn(name = "EMPLOYEECONTRACT_ID"),
+        inverseJoinColumns = @JoinColumn(name = "SUPERVISOR_ID"))
     @Fetch(FetchMode.SELECT)
-    @JoinColumn(name = "SUPERVISOR_ID")
-    private Employee supervisor;
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    private List<Employee> supervisors = new ArrayList<>();
 
     private LocalDate validFrom;
     private LocalDate validUntil;

--- a/src/main/java/org/tb/employee/domain/EmployeecontractListItemDTO.java
+++ b/src/main/java/org/tb/employee/domain/EmployeecontractListItemDTO.java
@@ -7,7 +7,7 @@ public record EmployeecontractListItemDTO(
     Long id,
     String employeeName,
     String taskDescription,
-    String supervisorName,
+    String supervisorNames,
     LocalDate validFrom,
     LocalDate validUntil,
     boolean freelancer,

--- a/src/main/java/org/tb/employee/persistence/EmployeecontractDAO.java
+++ b/src/main/java/org/tb/employee/persistence/EmployeecontractDAO.java
@@ -51,6 +51,7 @@ public class EmployeecontractDAO {
     public Employeecontract getEmployeeContractByIdInitializeEager(long id) {
         return employeecontractRepository.findById(id).map(e -> {
             Hibernate.initialize(e.getVacations());
+            Hibernate.initialize(e.getSupervisors());
             return e;
         }).orElse(null);
     }

--- a/src/main/java/org/tb/employee/persistence/EmployeecontractDAO.java
+++ b/src/main/java/org/tb/employee/persistence/EmployeecontractDAO.java
@@ -95,10 +95,9 @@ public class EmployeecontractDAO {
     private boolean filterMatchesInMemory(Employeecontract ec, String filter) {
         var upper = filter.toUpperCase();
         var emp = ec.getEmployee();
-        var supervisor = ec.getSupervisor();
         return containsIgnoreCase(emp.getName(), upper)
             || containsIgnoreCase(ec.getTaskDescription(), upper)
-            || (supervisor != null && containsIgnoreCase(supervisor.getName(), upper));
+            || ec.getSupervisors().stream().anyMatch(s -> containsIgnoreCase(s.getName(), upper));
     }
 
     private static boolean containsIgnoreCase(String value, String upper) {

--- a/src/main/java/org/tb/employee/persistence/EmployeecontractDAO.java
+++ b/src/main/java/org/tb/employee/persistence/EmployeecontractDAO.java
@@ -51,7 +51,6 @@ public class EmployeecontractDAO {
     public Employeecontract getEmployeeContractByIdInitializeEager(long id) {
         return employeecontractRepository.findById(id).map(e -> {
             Hibernate.initialize(e.getVacations());
-            Hibernate.initialize(e.getSupervisors());
             return e;
         }).orElse(null);
     }

--- a/src/main/java/org/tb/employee/persistence/EmployeecontractRepository.java
+++ b/src/main/java/org/tb/employee/persistence/EmployeecontractRepository.java
@@ -33,7 +33,8 @@ public interface EmployeecontractRepository extends PagingAndSortingRepository<E
 
   @Query("""
     select ec from Employeecontract ec
-    where ec.supervisor.id = :supervisorId
+    join ec.supervisors s
+    where s.id = :supervisorId
     and (ec.hide = false or ec.hide is null)
     and ec.validFrom <= :date and (ec.validUntil is null or ec.validUntil >= :date)
     order by ec.employee.lastname asc, ec.validFrom asc

--- a/src/main/java/org/tb/employee/service/EmployeecontractService.java
+++ b/src/main/java/org/tb/employee/service/EmployeecontractService.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.Hibernate;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.jpa.domain.Specification;
@@ -450,9 +449,7 @@ public class EmployeecontractService {
   }
 
   public List<Employeecontract> getViewableEmployeeContractsForAuthorizedUserValidAt(LocalDate validAt) {
-    var contracts = employeecontractDAO.getViewableEmployeeContractsForAuthorizedUser(validAt);
-    contracts.forEach(ec -> Hibernate.initialize(ec.getSupervisors()));
-    return contracts;
+    return employeecontractDAO.getViewableEmployeeContractsForAuthorizedUser(validAt);
   }
 
   public List<Employeecontract> getViewableEmployeeContractsValidAt(LocalDate validAt) {

--- a/src/main/java/org/tb/employee/service/EmployeecontractService.java
+++ b/src/main/java/org/tb/employee/service/EmployeecontractService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.jpa.domain.Specification;
@@ -449,7 +450,9 @@ public class EmployeecontractService {
   }
 
   public List<Employeecontract> getViewableEmployeeContractsForAuthorizedUserValidAt(LocalDate validAt) {
-    return employeecontractDAO.getViewableEmployeeContractsForAuthorizedUser(validAt);
+    var contracts = employeecontractDAO.getViewableEmployeeContractsForAuthorizedUser(validAt);
+    contracts.forEach(ec -> Hibernate.initialize(ec.getSupervisors()));
+    return contracts;
   }
 
   public List<Employeecontract> getViewableEmployeeContractsValidAt(LocalDate validAt) {

--- a/src/main/java/org/tb/employee/service/EmployeecontractService.java
+++ b/src/main/java/org/tb/employee/service/EmployeecontractService.java
@@ -78,7 +78,7 @@ public class EmployeecontractService {
       long employeeId,
       LocalDate validFrom,
       LocalDate validUntil,
-      long supervisorId,
+      List<Long> supervisorIds,
       String taskDescription,
       boolean freelancer,
       boolean hide,
@@ -94,7 +94,7 @@ public class EmployeecontractService {
     employeecontract.setEmployee(theEmployee);
     var info = createOrUpdate(employeecontract, validFrom,
         validUntil,
-        supervisorId,
+        supervisorIds,
         taskDescription,
         freelancer,
         hide,
@@ -119,7 +119,7 @@ public class EmployeecontractService {
       long employeecontractId,
       LocalDate validFrom,
       LocalDate validUntil,
-      long supervisorId,
+      List<Long> supervisorIds,
       String taskDescription,
       boolean freelancer,
       boolean hide,
@@ -131,7 +131,7 @@ public class EmployeecontractService {
     var employeecontract = employeecontractDAO.getEmployeecontractById(employeecontractId);
     return createOrUpdate(employeecontract, validFrom,
         validUntil,
-        supervisorId,
+        supervisorIds,
         taskDescription,
         freelancer,
         hide,
@@ -144,7 +144,7 @@ public class EmployeecontractService {
       Employeecontract employeecontract,
       LocalDate validFrom,
       LocalDate validUntil,
-      long supervisorId,
+      List<Long> supervisorIds,
       String taskDescription,
       boolean freelancer,
       boolean hide,
@@ -155,13 +155,16 @@ public class EmployeecontractService {
     List<String> logs = new ArrayList<>();
 
     var throwResolvableConflicts = !resolveConflicts; // throw always if not resolving any conflicts
-    var valid = validateEmployeecontractBusinessRules(employeecontract, validFrom, validUntil, supervisorId, throwResolvableConflicts);
+    var valid = validateEmployeecontractBusinessRules(employeecontract, validFrom, validUntil, supervisorIds, throwResolvableConflicts);
 
     employeecontract.setValidUntil(validFrom);
     employeecontract.setValidFrom(validFrom);
     employeecontract.setValidUntil(validUntil);
 
-    employeecontract.setSupervisor(employeeDAO.getEmployeeById(supervisorId));
+    var resolvedSupervisors = supervisorIds.stream()
+        .map(id -> employeeDAO.getEmployeeById(id))
+        .toList();
+    employeecontract.setSupervisors(resolvedSupervisors);
     employeecontract.setTaskDescription(taskDescription);
     employeecontract.setFreelancer(freelancer);
     employeecontract.setHide(hide);
@@ -299,19 +302,24 @@ public class EmployeecontractService {
   }
 
   private boolean validateEmployeecontractBusinessRules(Employeecontract employeecontract, LocalDate validFrom,
-      LocalDate validUntil, long supervisorId, boolean throwResolvableConflicts) {
+      LocalDate validUntil, List<Long> supervisorIds, boolean throwResolvableConflicts) {
     DataValidationUtils.validDateRange(validFrom, validUntil, ErrorCode.EC_INVALID_DATE_RANGE);
 
-    var supervisor = employeeDAO.getEmployeeById(supervisorId);
-    if (supervisor == null) {
+    if (supervisorIds == null || supervisorIds.isEmpty()) {
       throw new BusinessRuleException(EC_SUPERVISOR_INVALID);
     }
-    if (employeecontract.getEmployee().getId().equals(supervisorId)) {
-      throw new BusinessRuleException(EC_SUPERVISOR_INVALID);
-    }
-    var supervisorStatus = supervisor.getSalatUser().getStatus();
-    if (!EMPLOYEE_STATUS_PV.equals(supervisorStatus) && !EMPLOYEE_STATUS_BL.equals(supervisorStatus)) {
-      throw new BusinessRuleException(EC_SUPERVISOR_INVALID);
+    for (Long supervisorId : supervisorIds) {
+      var supervisor = employeeDAO.getEmployeeById(supervisorId);
+      if (supervisor == null) {
+        throw new BusinessRuleException(EC_SUPERVISOR_INVALID);
+      }
+      if (employeecontract.getEmployee().getId().equals(supervisorId)) {
+        throw new BusinessRuleException(EC_SUPERVISOR_INVALID);
+      }
+      var supervisorStatus = supervisor.getSalatUser().getStatus();
+      if (!EMPLOYEE_STATUS_PV.equals(supervisorStatus) && !EMPLOYEE_STATUS_BL.equals(supervisorStatus)) {
+        throw new BusinessRuleException(EC_SUPERVISOR_INVALID);
+      }
     }
 
     // ensure no overlapping employee contracts
@@ -501,7 +509,7 @@ public class EmployeecontractService {
             ec.getId(),
             ec.getEmployee().getName(),
             ec.getTaskDescription(),
-            ec.getSupervisor() != null ? ec.getSupervisor().getName() : null,
+            ec.getSupervisors().stream().map(Employee::getName).collect(java.util.stream.Collectors.joining(", ")),
             ec.getValidFrom(),
             ec.getValidUntil(),
             Boolean.TRUE.equals(ec.getFreelancer()),

--- a/src/main/java/org/tb/order/auth/EmployeeorderAuthorization.java
+++ b/src/main/java/org/tb/order/auth/EmployeeorderAuthorization.java
@@ -23,8 +23,8 @@ public class EmployeeorderAuthorization {
   }
 
   private boolean isSupervisedByCurrentUser(Employeecontract ec) {
-    return ec.getSupervisor() != null &&
-        ec.getSupervisor().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
+    return ec.getSupervisors().stream()
+        .anyMatch(s -> s.getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign()));
   }
 
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1810,10 +1810,12 @@ databaseChangeLog:
             tableName: employeecontract
             columnName: SUPERVISOR_ID
       changes:
+        - dropForeignKeyConstraint:
+            baseTableName: employeecontract
+            constraintName: FKF359ADE030CF4EF8
         - dropColumn:
             tableName: employeecontract
             columnName: SUPERVISOR_ID
-            cascadeConstraints: true
 
 #  - include:
 #      file: db/changelog/includes/addAllEmployees.sql

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1771,6 +1771,33 @@ databaseChangeLog:
                   defaultValueBoolean: false
                   constraints:
                     nullable: false
+  - changeSet:
+      id: 50
+      author: kr
+      comment: Replace single supervisor with multiple supervisors on employee contract
+      changes:
+        - createTable:
+            tableName: employeecontract_supervisor
+            columns:
+              - column:
+                  name: EMPLOYEECONTRACT_ID
+                  type: bigint
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_ecsu_contract
+                    references: employeecontract(id)
+              - column:
+                  name: SUPERVISOR_ID
+                  type: bigint
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_ecsu_supervisor
+                    references: employee(id)
+        - sql:
+            sql: "INSERT INTO employeecontract_supervisor (EMPLOYEECONTRACT_ID, SUPERVISOR_ID) SELECT id, SUPERVISOR_ID FROM employeecontract WHERE SUPERVISOR_ID IS NOT NULL"
+        - dropColumn:
+            tableName: employeecontract
+            columnName: SUPERVISOR_ID
 
 #  - include:
 #      file: db/changelog/includes/addAllEmployees.sql

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1813,6 +1813,7 @@ databaseChangeLog:
         - dropColumn:
             tableName: employeecontract
             columnName: SUPERVISOR_ID
+            cascadeConstraints: true
 
 #  - include:
 #      file: db/changelog/includes/addAllEmployees.sql

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1774,7 +1774,12 @@ databaseChangeLog:
   - changeSet:
       id: 50
       author: kr
-      comment: Replace single supervisor with multiple supervisors on employee contract
+      comment: Create employeecontract_supervisor join table and migrate existing supervisor data
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: employeecontract_supervisor
       changes:
         - createTable:
             tableName: employeecontract_supervisor
@@ -1795,6 +1800,16 @@ databaseChangeLog:
                     references: employee(id)
         - sql:
             sql: "INSERT INTO employeecontract_supervisor (EMPLOYEECONTRACT_ID, SUPERVISOR_ID) SELECT id, SUPERVISOR_ID FROM employeecontract WHERE SUPERVISOR_ID IS NOT NULL"
+  - changeSet:
+      id: 51
+      author: kr
+      comment: Drop legacy SUPERVISOR_ID column from employeecontract after join table migration
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: employeecontract
+            columnName: SUPERVISOR_ID
+      changes:
         - dropColumn:
             tableName: employeecontract
             columnName: SUPERVISOR_ID

--- a/src/main/resources/templates/dailyreport/acceptance.html
+++ b/src/main/resources/templates/dailyreport/acceptance.html
@@ -165,7 +165,7 @@
                 </button>
               </form>
             </td>
-            <td class="d-none d-md-table-cell text-muted" th:text="${ec.supervisors.isEmpty() ? '' : #strings.listJoin(ec.supervisors.![sign], ', ')}"></td>
+            <td class="d-none d-md-table-cell text-muted" th:text="${ec.supervisors.isEmpty() ? '' : #strings.listJoin(ec.supervisors.![name], ', ')}"></td>
             <td>
               <span th:if="${ec.acceptanceWarning}" class="text-danger fw-semibold" th:text="${ec.reportAcceptanceDateString}"></span>
               <span th:unless="${ec.acceptanceWarning}" th:text="${ec.reportAcceptanceDateString}"></span>

--- a/src/main/resources/templates/dailyreport/acceptance.html
+++ b/src/main/resources/templates/dailyreport/acceptance.html
@@ -165,7 +165,7 @@
                 </button>
               </form>
             </td>
-            <td class="d-none d-md-table-cell text-muted" th:text="${ec.supervisor != null ? ec.supervisor.sign : ''}"></td>
+            <td class="d-none d-md-table-cell text-muted" th:text="${ec.supervisors.isEmpty() ? '' : #strings.listJoin(ec.supervisors.![sign], ', ')}"></td>
             <td>
               <span th:if="${ec.acceptanceWarning}" class="text-danger fw-semibold" th:text="${ec.reportAcceptanceDateString}"></span>
               <span th:unless="${ec.acceptanceWarning}" th:text="${ec.reportAcceptanceDateString}"></span>

--- a/src/main/resources/templates/employee/employee-contract-form.html
+++ b/src/main/resources/templates/employee/employee-contract-form.html
@@ -9,7 +9,9 @@
 
     <div class="card-body">
       <input type="hidden" th:field="*{id}" />
-      <input type="hidden" th:field="*{storedSupervisorId}" />
+      <th:block th:each="storedId : *{storedSupervisorIds}">
+        <input type="hidden" name="storedSupervisorIds" th:value="${storedId}"/>
+      </th:block>
 
       <div th:replace="~{fragments/form-fields :: checkboxSwitch(
             field='resolveConflicts', label=#{main.employeecontract.resolveconflicts.text}
@@ -34,10 +36,14 @@
         </div>
       </div>
 
-      <div th:replace="~{fragments/form-fields :: selectInput(
-        field='supervisorId', label=#{main.employeecontract.supervisor.text}, required=true,
-        placeholder=#{main.general.selectone.text}, options=${supervisors}, optionValue='id', optionLabel='name'
-      )}"></div>
+      <div class="mb-3">
+        <label class="form-label required" th:text="#{main.employeecontract.supervisor.text}">People Lead</label>
+        <select class="form-select tomselect tomselect-multi" id="supervisorIds"
+                th:field="*{supervisorIds}" multiple th:errorclass="is-invalid">
+          <option th:each="s : ${supervisors}" th:value="${s.id}" th:text="${s.name}"></option>
+        </select>
+        <div class="invalid-feedback" th:if="${#fields.hasErrors('supervisorIds')}" th:errors="*{supervisorIds}"></div>
+      </div>
 
       <div th:replace="~{fragments/form-fields :: textareaInput(
         field='taskdescription', label=#{main.employeecontract.taskdescription.text}, required=false, rows=4, monospace=false

--- a/src/main/resources/templates/employee/employee-contract-list.html
+++ b/src/main/resources/templates/employee/employee-contract-list.html
@@ -109,7 +109,7 @@
             <tr th:each="ec : ${group}" th:classappend="${!ec.currentlyValid} ? 'table-danger' : ''">
               <td th:text="${ec.employeeName}"></td>
               <td class="d-none d-md-table-cell" th:text="${ec.taskDescription}"></td>
-              <td class="d-none d-md-table-cell" th:text="${ec.supervisorName}"></td>
+              <td class="d-none d-md-table-cell" th:text="${ec.supervisorNames}"></td>
               <td>
                 <div th:text="${ec.validFrom}" class="text-nowrap">From</div>
                 <small class="text-muted">
@@ -171,7 +171,7 @@
             <tr th:each="ec : ${group}" th:classappend="${!ec.currentlyValid} ? 'table-danger' : ''">
               <td th:text="${ec.employeeName}"></td>
               <td class="d-none d-md-table-cell" th:text="${ec.taskDescription}"></td>
-              <td class="d-none d-md-table-cell" th:text="${ec.supervisorName}"></td>
+              <td class="d-none d-md-table-cell" th:text="${ec.supervisorNames}"></td>
               <td>
                 <div th:text="${ec.validFrom}" class="text-nowrap">From</div>
                 <small class="text-muted">

--- a/src/main/resources/templates/employee/employee-contract-view.html
+++ b/src/main/resources/templates/employee/employee-contract-view.html
@@ -16,7 +16,7 @@
       <div class="mb-3">
         <label class="form-label" th:text="#{main.employeecontract.supervisor.text}">Supervisor</label>
         <p class="form-control-plaintext"
-           th:text="${employeecontract.supervisor != null} ? ${employeecontract.supervisor.name} : '—'"></p>
+           th:text="${employeecontract.supervisors.isEmpty()} ? '—' : ${#strings.listJoin(employeecontract.supervisors.![name], ', ')}"></p>
       </div>
 
       <div class="mb-3">

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -423,7 +423,7 @@
 <script>
   const tomSelectConfig = (el) => ({
     create: false,
-    maxItems: 1,
+    maxItems: el.classList.contains('tomselect-multi') ? null : 1,
     maxOptions: 1000,
     sortField: [{ field: '$order' }],
     placeholder: el.getAttribute('placeholder') || 'Select an option...',

--- a/src/test/java/org/tb/employee/EmployeecontractServiceTest.java
+++ b/src/test/java/org/tb/employee/EmployeecontractServiceTest.java
@@ -64,7 +64,7 @@ public class EmployeecontractServiceTest {
 				ec.getEmployee().getId(),
 				ec.getValidFrom(),
 				ec.getValidUntil(),
-				ec.getSupervisor().getId(),
+				ec.getSupervisors().stream().map(org.tb.employee.domain.Employee::getId).toList(),
 				ec.getTaskDescription(),
 				ec.getFreelancer(),
 				TRUE == ec.getHide(),

--- a/src/test/java/org/tb/employee/EmployeecontractServiceTest.java
+++ b/src/test/java/org/tb/employee/EmployeecontractServiceTest.java
@@ -1,12 +1,15 @@
 package org.tb.employee;
 
+import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 import static org.tb.testutils.EmployeeTestUtils.BOSS_SIGN;
 import static org.tb.testutils.EmployeeTestUtils.TESTY_SIGN;
 
 import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -19,6 +22,7 @@ import org.tb.auth.domain.AuthorizedUser;
 import org.tb.auth.service.AuthService;
 import org.tb.common.GlobalConstants;
 import org.tb.common.SalatProperties;
+import org.tb.common.exception.BusinessRuleException;
 import org.tb.employee.auth.EmployeeAuthorization;
 import org.tb.employee.auth.EmployeecontractAuthorization;
 import org.tb.employee.domain.Employee;
@@ -80,6 +84,85 @@ public class EmployeecontractServiceTest {
 		assertThat(employeecontract.getId()).isEqualTo(info.getId());
 		assertThat(employeecontract.getVacations()).hasSize(1);
 		assertThat(employeecontract.getVacations().getFirst().getEntitlement()).isEqualTo(ec.getVacationEntitlement());
+	}
+
+	@Test
+	public void employee_contract_can_have_two_supervisors() {
+		Employee employee = EmployeeTestUtils.createEmployee(TESTY_SIGN);
+		this.employeeService.createOrUpdate(employee);
+
+		Employee supervisor1 = EmployeeTestUtils.createEmployee(BOSS_SIGN);
+		supervisor1.getSalatUser().setStatus(GlobalConstants.EMPLOYEE_STATUS_PV);
+		this.employeeService.createOrUpdate(supervisor1);
+
+		Employee supervisor2 = EmployeeTestUtils.createEmployee("lead");
+		supervisor2.getSalatUser().setStatus(GlobalConstants.EMPLOYEE_STATUS_PV);
+		this.employeeService.createOrUpdate(supervisor2);
+
+		Employeecontract ec = EmployeecontractTestUtils.createEmployeecontract(employee, supervisor1);
+		var info = employeecontractService.createEmployeecontract(
+				ec.getEmployee().getId(),
+				ec.getValidFrom(),
+				ec.getValidUntil(),
+				List.of(supervisor1.getId(), supervisor2.getId()),
+				ec.getTaskDescription(),
+				ec.getFreelancer(),
+				TRUE == ec.getHide(),
+				ec.getDailyWorkingTime(),
+				ec.getVacationEntitlement(),
+				Duration.ZERO,
+				false
+		);
+
+		var saved = employeecontractService.getEmployeecontractById(info.getId());
+		assertThat(saved.getSupervisors()).hasSize(2);
+		assertThat(saved.getSupervisors()).extracting(Employee::getSign)
+				.containsExactlyInAnyOrder(BOSS_SIGN, "lead");
+	}
+
+	@Test
+	public void employee_contract_requires_at_least_one_supervisor() {
+		Employee employee = EmployeeTestUtils.createEmployee(TESTY_SIGN);
+		this.employeeService.createOrUpdate(employee);
+
+		Employeecontract ec = EmployeecontractTestUtils.createEmployeecontract(employee, null);
+
+		assertThatThrownBy(() -> employeecontractService.createEmployeecontract(
+				ec.getEmployee().getId(),
+				ec.getValidFrom(),
+				ec.getValidUntil(),
+				List.of(),
+				ec.getTaskDescription(),
+				ec.getFreelancer(),
+				FALSE == ec.getHide(),
+				ec.getDailyWorkingTime(),
+				ec.getVacationEntitlement(),
+				Duration.ZERO,
+				false
+		)).isInstanceOf(BusinessRuleException.class);
+	}
+
+	@Test
+	public void employee_contract_rejects_self_as_supervisor() {
+		Employee employee = EmployeeTestUtils.createEmployee(TESTY_SIGN);
+		employee.getSalatUser().setStatus(GlobalConstants.EMPLOYEE_STATUS_PV);
+		this.employeeService.createOrUpdate(employee);
+
+		Employeecontract ec = EmployeecontractTestUtils.createEmployeecontract(employee, employee);
+
+		assertThatThrownBy(() -> employeecontractService.createEmployeecontract(
+				ec.getEmployee().getId(),
+				ec.getValidFrom(),
+				ec.getValidUntil(),
+				List.of(employee.getId()),
+				ec.getTaskDescription(),
+				ec.getFreelancer(),
+				FALSE == ec.getHide(),
+				ec.getDailyWorkingTime(),
+				ec.getVacationEntitlement(),
+				Duration.ZERO,
+				false
+		)).isInstanceOf(BusinessRuleException.class);
 	}
 
 }

--- a/src/test/java/org/tb/testutils/EmployeecontractTestUtils.java
+++ b/src/test/java/org/tb/testutils/EmployeecontractTestUtils.java
@@ -14,7 +14,7 @@ public class EmployeecontractTestUtils {
 		ec.setDailyWorkingTime(Duration.ofHours(8));
 		ec.setEmployee(employee);
 		ec.setValidFrom(DateUtils.parse("2017-01-01"));
-		ec.setSupervisor(supervisor);
+		ec.setSupervisors(java.util.List.of(supervisor));
 		return ec;
 	}
 }

--- a/src/test/java/org/tb/testutils/EmployeecontractTestUtils.java
+++ b/src/test/java/org/tb/testutils/EmployeecontractTestUtils.java
@@ -14,7 +14,9 @@ public class EmployeecontractTestUtils {
 		ec.setDailyWorkingTime(Duration.ofHours(8));
 		ec.setEmployee(employee);
 		ec.setValidFrom(DateUtils.parse("2017-01-01"));
-		ec.setSupervisors(java.util.List.of(supervisor));
+		if (supervisor != null) {
+			ec.setSupervisors(java.util.List.of(supervisor));
+		}
 		return ec;
 	}
 }


### PR DESCRIPTION
## Summary
- Replaces single `SUPERVISOR_ID` FK on `employeecontract` with a `employeecontract_supervisor` join table (Liquibase changesets 50 & 51, each guarded by `preConditions: onFail: MARK_RAN` per ADR-0009)
- `Employeecontract` entity gains `@ManyToMany List<Employee> supervisors`; at least one supervisor is required and validated in `EmployeecontractService`
- All downstream authorization checks (`isSupervisedByCurrentUser`), mail dispatch, acceptance view, and templates updated to handle the collection

## Test plan
- [x] Build passes: `jenv exec ./mvnw verify`
- [x] Create a new employee contract, select two supervisors → both shown in list and detail view
- [x] Edit contract, remove all supervisors → validation error prevents save
- [x] Acceptance page: supervisor filter shows both people leads; filtering by one shows only their contracts
- [x] Log in as supervisor → can view and accept team members' time reports

Closes #683

---
I have read the Definition of Done and certify that this PR fulfills all applicable criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)