### PR TITLE
Fix: update session filter after create to show new object in list

### DIFF
--- a/src/main/java/org/tb/customer/controller/CustomerController.java
+++ b/src/main/java/org/tb/customer/controller/CustomerController.java
@@ -80,6 +80,7 @@ public class CustomerController {
   public String store(@Valid @ModelAttribute("customer") CustomerDTO form,
                       BindingResult bindingResult,
                       Model model,
+                      HttpSession session,
                       RedirectAttributes redirectAttributes) {
     if (form.getShortName() == null || form.getShortName().isBlank()) {
       bindingResult.rejectValue("shortName", "error.shortName",
@@ -106,6 +107,7 @@ public class CustomerController {
           messageSourceAccessor.getMessage("form.customer.error.address.toolong", "Name is required"));
     }
 
+    boolean isCreate = form.getId() == null;
     var errors = !bindingResult.getFieldErrors().isEmpty();
 
     if(!errors) {
@@ -118,13 +120,16 @@ public class CustomerController {
     }
 
     if (errors) {
-      String titleKey = form.getId() == null ? "main.general.addcustomer.text" : "main.general.editcustomer.text";
-      String titleFallback = form.getId() == null ? "Create Customer" : "Edit Customer";
+      String titleKey = isCreate ? "main.general.addcustomer.text" : "main.general.editcustomer.text";
+      String titleFallback = isCreate ? "Create Customer" : "Edit Customer";
       model.addAttribute("pageTitle", messageSourceAccessor.getMessage(titleKey, titleFallback));
-      model.addAttribute("isEdit", form.getId() != null);
+      model.addAttribute("isEdit", !isCreate);
       return "customer/customer-form";
     }
 
+    if (isCreate) {
+      session.setAttribute("customers.filter", null);
+    }
     redirectAttributes.addFlashAttribute("toastSuccess",
         messageSourceAccessor.getMessage("form.customer.message.stored", "Customer saved successfully"));
     return "redirect:/customers";

--- a/src/main/java/org/tb/employee/controller/EmployeeController.java
+++ b/src/main/java/org/tb/employee/controller/EmployeeController.java
@@ -102,9 +102,11 @@ public class EmployeeController {
     public String store(@ModelAttribute("employeeForm") EmployeeForm form,
                         BindingResult bindingResult,
                         Model model,
+                        HttpSession session,
                         RedirectAttributes redirectAttributes) {
         validateForm(form, bindingResult);
 
+        boolean isCreate = form.getId() == null;
         boolean hasErrors = bindingResult.hasErrors();
         if (!hasErrors) {
             try {
@@ -134,6 +136,9 @@ public class EmployeeController {
             return "employee/employee-form";
         }
 
+        if (isCreate) {
+            session.setAttribute("employees.filter", null);
+        }
         redirectAttributes.addFlashAttribute("toastSuccess",
                 messages.getMessage("form.employee.message.stored", "Employee saved successfully"));
         return "redirect:/employees";

--- a/src/main/java/org/tb/employee/controller/EmployeecontractController.java
+++ b/src/main/java/org/tb/employee/controller/EmployeecontractController.java
@@ -152,9 +152,11 @@ public class EmployeecontractController {
     public String store(@ModelAttribute("employeecontractForm") EmployeecontractForm form,
                         BindingResult bindingResult,
                         Model model,
+                        HttpSession session,
                         RedirectAttributes redirectAttributes) {
         validateContractForm(form, bindingResult);
 
+        boolean isCreate = form.getId() == null;
         boolean hasErrors = bindingResult.hasErrors();
         List<String> logs = List.of();
         if (!hasErrors) {
@@ -212,6 +214,10 @@ public class EmployeecontractController {
             return "employee/employee-contract-form";
         }
 
+        if (isCreate) {
+            session.setAttribute("employees.contracts.employeeId", form.getEmployeeId());
+            session.setAttribute("employees.contracts.filter", null);
+        }
         if (!logs.isEmpty()) {
             redirectAttributes.addFlashAttribute("logs", logs);
         }

--- a/src/main/java/org/tb/order/controller/CustomerorderController.java
+++ b/src/main/java/org/tb/order/controller/CustomerorderController.java
@@ -130,6 +130,7 @@ public class CustomerorderController {
   public String store(@ModelAttribute("customerorderForm") CustomerorderForm form,
                       BindingResult bindingResult,
                       Model model,
+                      HttpSession session,
                       RedirectAttributes redirectAttributes) {
     validateForm(form, bindingResult);
 
@@ -162,6 +163,10 @@ public class CustomerorderController {
       return "order/customer-order-form";
     }
 
+    if (newId != null) {
+      session.setAttribute("orders.customerorders.customerId", form.getCustomerId());
+      session.setAttribute("orders.customerorders.filter", null);
+    }
     redirectAttributes.addFlashAttribute("toastSuccess",
         messages.getMessage("form.customerorder.message.stored", "Customer order saved successfully"));
     if (newId != null) {

--- a/src/main/java/org/tb/order/controller/EmployeeorderController.java
+++ b/src/main/java/org/tb/order/controller/EmployeeorderController.java
@@ -242,6 +242,7 @@ public class EmployeeorderController {
             @ModelAttribute("employeeorderForm") EmployeeorderForm form,
             BindingResult bindingResult,
             Model model,
+            HttpSession session,
             RedirectAttributes redirectAttributes,
             @RequestParam(required = false) String saveAndNew) {
 
@@ -252,6 +253,7 @@ public class EmployeeorderController {
             return "order/employee-order-form";
         }
 
+        boolean isCreate = form.getId() == null;
         Employeeorder eo;
         if (form.getId() != null) {
             eo = employeeorderService.getEmployeeorderById(form.getId());
@@ -288,6 +290,13 @@ public class EmployeeorderController {
             return "order/employee-order-form";
         }
 
+        if (isCreate) {
+            session.setAttribute("orders.employeeorders.employeeContractId", form.getEmployeeContractId());
+            session.setAttribute("orders.employeeorders.customerId", form.getCustomerId());
+            session.setAttribute("orders.employeeorders.orderId", form.getOrderId());
+            session.setAttribute("orders.employeeorders.suborderId", form.getSuborderId());
+            session.setAttribute("orders.employeeorders.filter", null);
+        }
         redirectAttributes.addFlashAttribute("toastSuccess",
                 messages.getMessage("form.employeeorder.message.stored", "Employee order saved successfully"));
         if (saveAndNew != null) {

--- a/src/main/java/org/tb/order/controller/SuborderController.java
+++ b/src/main/java/org/tb/order/controller/SuborderController.java
@@ -152,6 +152,7 @@ public class SuborderController {
   public String store(@ModelAttribute("suborderForm") SuborderForm form,
                       BindingResult bindingResult,
                       Model model,
+                      HttpSession session,
                       RedirectAttributes redirectAttributes) {
     validateForm(form, bindingResult);
 
@@ -196,6 +197,11 @@ public class SuborderController {
       return "order/sub-order-form";
     }
 
+    if (isCreate) {
+      session.setAttribute("orders.suborders.customerOrderId", form.getCustomerorderId());
+      session.setAttribute("orders.suborders.customerId", form.getCustomerId());
+      session.setAttribute("orders.suborders.filter", null);
+    }
     redirectAttributes.addFlashAttribute("toastSuccess",
         messages.getMessage("form.suborder.message.stored", "Suborder saved successfully"));
     if (isCreate && customerorderId != null) {

--- a/src/main/java/org/tb/reporting/controller/ReportController.java
+++ b/src/main/java/org/tb/reporting/controller/ReportController.java
@@ -130,6 +130,7 @@ public class ReportController {
   public String store(@ModelAttribute("report") ReportForm form,
                       BindingResult bindingResult,
                       Model model,
+                      HttpSession session,
                       RedirectAttributes redirectAttributes,
                       @RequestParam(value = "filter", required = false) String filter) {
 
@@ -152,7 +153,9 @@ public class ReportController {
 
     if (form.getId() == null) {
       reportService.create(form.getName(), form.getSql());
+      session.setAttribute("reporting.reports.filter", null);
       redirectAttributes.addFlashAttribute("toastSuccess", "Report created successfully");
+      return "redirect:/reporting/reports";
     } else {
       reportService.update(form.getId(), form.getName(), form.getSql());
       redirectAttributes.addFlashAttribute("toastSuccess", "Report updated successfully");


### PR DESCRIPTION
## Summary
- After creating a master data object and being redirected to the list, the active session filter was not updated to match the new object, causing it to be invisible.
- On a successful create, each controller now updates the relevant session FK filters (customer, order, contract, etc.) to match the newly created entity and clears the text search filter.
- Applies to: customer orders, sub orders, employee orders, employee contracts, customers, employees, and reports.

## Test plan
- [ ] Create a customer order while a *different* customer is selected in the filter — the new order should appear after save
- [ ] Create a sub order while a different customer order is selected in the filter — the new sub order should appear
- [ ] Create an employee contract while a different employee is selected in the filter — the new contract should appear
- [ ] Create an employee order with no filter or a mismatched filter — the new order should appear
- [ ] Create a customer while a text filter is active that doesn't match the new customer name — the customer list should reset and show the new customer
- [ ] Create an employee while a text filter is active — employee list should reset and show the new employee
- [ ] Create a report while a text filter is active — report list should reset and show the new report
- [ ] Edit any of the above — the filter must NOT be changed on update

Closes #685

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.