### PR TITLE
Externalize hbteam.atlassian.net URLs into application.yaml (#703)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Beschreibung
+
+<!-- Was wurde geändert und warum? -->
+
+## Akzeptanzkriterien / Testplan
+
+- [ ] 
+
+## Operations / Deployment Notes
+
+<!-- Muss in der Produktionsumgebung nach dem Deployment etwas manuell konfiguriert werden?
+     Neue Umgebungsvariablen, Kubernetes ConfigMap-Einträge, Datenbankmigrationen o. ä.
+     Falls ja: Label "needs-ops-action" setzen. Falls nein: diesen Abschnitt leer lassen oder löschen. -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  categories:
+    - title: "⚙️ Operations / Deployment Required"
+      labels:
+        - needs-ops-action
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+    - title: "✨ New Features"
+      labels:
+        - enhancement
+        - Feature
+    - title: "🔧 Tasks & Improvements"
+      labels:
+        - technical improvement
+        - dependencies
+    - title: "📖 Documentation"
+      labels:
+        - documentation
+    - title: "🔀 Other Changes"
+      labels:
+        - "*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,29 @@ A feature or fix is considered done when **all** of the following are true:
 
 ---
 
+## Globally Accessible Objects in `layout/base.html`
+
+`layout/base.html` is the shared layout template rendered for every page. It has no dedicated controller, so Spring MVC model attributes are not available.
+
+**Convention:** Access Spring beans via `${@beanName.property}` — Thymeleaf resolves `@beanName` as a Spring application context lookup.
+
+```html
+[[${@buildProperties.version}]]
+[[${@salatProperties.docsUrl}]]
+```
+
+**Constraint:** `@beanName` is only valid inside `${...}` expressions. It is **not** allowed inside `@{...}` URL expressions. For URLs sourced from a bean, extract the value first with `th:with`, then reference it via `${...}`:
+
+```html
+<!-- correct -->
+<a th:with="url=${@salatProperties.docsUrl}" th:href="${url}">...</a>
+
+<!-- fails: @beanName prohibited inside @{} -->
+<a th:href="@{${@salatProperties.docsUrl}}">...</a>
+```
+
+> Note: `BuildInformationProvider.contextInitialized()` registers `buildProperties`, `gitProperties`, and `serverTimeHelper` as servlet context attributes. This is legacy wiring for Struts/JSP pages. Thymeleaf templates use `${@beanName}` (Spring bean lookup) directly and do not rely on servlet context attributes.
+
 ## TomSelect Dropdowns
 
 All `<select>` elements use [TomSelect](https://tom-select.github.io/) for search-as-you-type behaviour. Initialisation is handled centrally in `layout/base.html` via a `querySelectorAll` on page load and again on `htmx:afterSettle` (so OOB-swapped selects are picked up automatically).

--- a/src/main/java/org/tb/common/SalatProperties.java
+++ b/src/main/java/org/tb/common/SalatProperties.java
@@ -12,6 +12,8 @@ public class SalatProperties {
 
   private String url;
   private String mailHost;
+  private String docsUrl;
+  private String apiDocsUrl;
   private Auth auth;
   private AuthService authService;
 

--- a/src/main/java/org/tb/common/configuration/AzureEasyAuthOpenApiConfiguration.java
+++ b/src/main/java/org/tb/common/configuration/AzureEasyAuthOpenApiConfiguration.java
@@ -63,8 +63,8 @@ public class AzureEasyAuthOpenApiConfiguration {
             .contact(new io.swagger.v3.oas.models.info.Contact()
                 .name("HBT SALAT Dev Team")
                 .url("https://hbt.de"))
-            .termsOfService("https://hbteam.atlassian.net/wiki/spaces/SALAT/pages/1440481391/Rest+API"))
-        .externalDocs(new ExternalDocumentation().description("Confluence").url("https://hbteam.atlassian.net/wiki/spaces/SALAT/pages/1440481391/Rest+API"))
+            .termsOfService(salatProperties.getApiDocsUrl()))
+        .externalDocs(new ExternalDocumentation().description("Confluence").url(salatProperties.getApiDocsUrl()))
         .schemaRequirement("EasyAuth", easyAuth)
         .schemaRequirement("oauth2", oauth2)
         .security(of(

--- a/src/main/java/org/tb/common/configuration/LocalDevOpenApiConfiguration.java
+++ b/src/main/java/org/tb/common/configuration/LocalDevOpenApiConfiguration.java
@@ -51,7 +51,7 @@ public class LocalDevOpenApiConfiguration {
             .title("DEVELOPMENT SALAT Rest API")
             .version(buildProperties.isPresent() ? buildProperties.get().getVersion() : "DEVELOPMENT")
             .description(openApiDescription.toString()))
-        .externalDocs(new ExternalDocumentation().description("Confluence").url("https://hbteam.atlassian.net/wiki/spaces/SALAT/pages/1440481391/Rest+API"))
+        .externalDocs(new ExternalDocumentation().description("Confluence").url(salatProperties.getApiDocsUrl()))
         .schemaRequirement("loginName", loginName)
         .security(of(new SecurityRequirement().addList("loginName")));
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,8 @@ salat:
       logout-url: /?logout=true
   url: localhost
   mail-host: localhost
+  docs-url: ""
+  api-docs-url: ""
   auth-service:
     cache-expiry: 1s
   cache:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,11 @@ salat:
       logout-url: /?logout=true
   url: localhost
   mail-host: localhost
+  # User-facing documentation URL (e.g. Confluence overview). Hidden in footer when empty.
+  # Override locally via JVM arg: -Dsalat.docs-url=https://your-confluence/wiki/spaces/SALAT/overview
   docs-url: ""
+  # REST API documentation URL (OpenAPI externalDocs / termsOfService). Left empty when not configured.
+  # Override locally via JVM arg: -Dsalat.api-docs-url=https://your-confluence/wiki/spaces/SALAT/pages/.../Rest+API
   api-docs-url: ""
   auth-service:
     cache-expiry: 1s

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -399,7 +399,7 @@
           <div class="col-lg-auto ms-lg-auto">
             <ul class="list-inline list-inline-dots mb-0">
               <li class="list-inline-item"><a th:href="@{/api/doc/swagger-ui/index.html}" target="_blank" class="link-secondary" rel="noopener">API</a></li>
-              <li class="list-inline-item"><a href="https://hbteam.atlassian.net/wiki/spaces/SALAT/overview" target="_blank" class="link-secondary" rel="noopener">Documentation</a></li>
+              <li class="list-inline-item" th:if="${not #strings.isEmpty(@salatProperties.docsUrl)}"><a th:href="${@salatProperties.docsUrl}" target="_blank" class="link-secondary" rel="noopener">Documentation</a></li>
               <li class="list-inline-item"><a href="https://raw.githubusercontent.com/HBTGmbH/salat/refs/heads/main/LICENSE" class="link-secondary">License</a></li>
               <li class="list-inline-item"><a href="https://github.com/HBTGmbH/salat" target="_blank" class="link-secondary" rel="noopener">Source code</a></li>
               <li class="list-inline-item">


### PR DESCRIPTION
## Summary

- Adds `salat.docs-url` (user documentation) and `salat.api-docs-url` (REST API documentation) to `SalatProperties`, both defaulting to empty string
- `LocalDevOpenApiConfiguration` and `AzureEasyAuthOpenApiConfiguration` use `api-docs-url` for `externalDocs` / `termsOfService`
- Footer Documentation link in `base.html` uses `docs-url` and is hidden when the property is empty
- No hardcoded `hbteam.atlassian.net` URLs remain in source or templates

Closes #703

## Test plan

- [x] App starts without external config (empty defaults → Documentation link hidden, OpenAPI externalDocs URL empty)
- [x] Setting `salat.docs-url` shows the Documentation link in the footer
- [x] Setting `salat.api-docs-url` populates OpenAPI externalDocs correctly

## ⚙️ Operations / Deployment Notes

Die folgenden Properties müssen nach dem Deployment in der externen Konfiguration (z. B. Kubernetes ConfigMap) gesetzt werden, damit die bisherige Funktionalität erhalten bleibt:

| Property | Beschreibung | Wert |
|----------|--------------|------|
| `salat.docs-url` | Footer-Link „Documentation" (Nutzer-Doku) | `https://hbteam.atlassian.net/wiki/spaces/SALAT/overview` |
| `salat.api-docs-url` | OpenAPI `externalDocs` / `termsOfService` (REST-API-Doku) | `https://hbteam.atlassian.net/wiki/spaces/SALAT/pages/1440481391/Rest+API` |

Ohne diese Properties ist der Footer-Link ausgeblendet und die OpenAPI-Dokumentation enthält keine externe Referenz. Die Anwendung startet fehlerfrei (leere Defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)