### PR TITLE
Fix fillNotWorked skipping existing workingday records and not resetting start/break

### DIFF
--- a/src/main/java/org/tb/dailyreport/service/MatrixService.java
+++ b/src/main/java/org/tb/dailyreport/service/MatrixService.java
@@ -178,11 +178,18 @@ public class MatrixService {
         effectiveFirst.datesUntil(effectiveLast.plusDays(1)).forEach(day -> {
             if (workingdayService.isRegularWorkingday(day)) {
                 boolean hasBookings = !timereportService.getTimereportsByDateAndEmployeeContractId(employeeContractId, day).isEmpty();
-                if (!hasBookings && workingdayService.getWorkingday(employeeContractId, day) == null) {
-                    var workingday = new Workingday();
-                    workingday.setEmployeecontract(employeecontract);
-                    workingday.setRefday(day);
+                if (!hasBookings) {
+                    var workingday = workingdayService.getWorkingday(employeeContractId, day);
+                    if (workingday == null) {
+                        workingday = new Workingday();
+                        workingday.setEmployeecontract(employeecontract);
+                        workingday.setRefday(day);
+                    }
                     workingday.setType(Workingday.WorkingDayType.NOT_WORKED);
+                    workingday.setStarttimehour(0);
+                    workingday.setStarttimeminute(0);
+                    workingday.setBreakhours(0);
+                    workingday.setBreakminutes(0);
                     workingdayService.upsertWorkingday(workingday);
                 }
             }


### PR DESCRIPTION
## Summary

- Remove the `== null` guard so days with an existing workingday record (e.g. start time entered but no timereports) are also marked NOT_WORKED
- Reuse the existing workingday record when one exists; create a new one only when none exists
- Zero out `starttimehour`, `starttimeminute`, `breakhours`, `breakminutes` when marking a day as NOT_WORKED, consistent with `DailyController.saveWorkingday`

## Test plan

- [x] Open Matrix view, enter a start time for a day without timereports, then click "Rest nicht gearbeitet" — day should now be marked NOT_WORKED
- [x] Verify start/break fields are reset to 0 in the DB after the button is clicked
- [x] Days with timereports are still left untouched

Closes #711