### PR TITLE
Fix isAuthorized() owner short-circuit bypassing COMMITTED+owner restriction on WRITE/DELETE

### DIFF
--- a/src/main/java/org/tb/common/GlobalConstants.java
+++ b/src/main/java/org/tb/common/GlobalConstants.java
@@ -109,7 +109,7 @@ public class GlobalConstants {
     public static final String ALL_EMPLOYEES = "ALL EMPLOYEES";
 
     public static final String TIMEREPORT_STATUS_OPEN = "open";
-    public static final String TIMEREPORT_STATUS_COMMITED = "commited"; // TODO fix type commited -> committed (changes data in database
+    public static final String TIMEREPORT_STATUS_COMMITED = "commited"; // TODO fix type commited -> committed (changes data in database)
     public static final String TIMEREPORT_STATUS_CLOSED = "closed";
 
     // view constants

--- a/src/main/java/org/tb/dailyreport/auth/TimereportAuthorization.java
+++ b/src/main/java/org/tb/dailyreport/auth/TimereportAuthorization.java
@@ -35,7 +35,8 @@ public class TimereportAuthorization {
   public boolean isAuthorized(Timereport timereport, AccessLevel accessLevel) {
     if(authorizedUser.isManager()) return true;
     if(accessLevel == READ && authorizedUser.isPeopleLead() && isSupervisedByCurrentUser(timereport.getEmployeecontract())) return true;
-    if(timereport.getEmployeecontract().getEmployee().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign())) return true;
+    var isOwner = timereport.getEmployeecontract().getEmployee().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
+    if(isOwner && accessLevel == READ) return true;
 
     if(accessLevel == READ) {
       // every project manager may see the time reports of her project
@@ -62,13 +63,10 @@ public class TimereportAuthorization {
          !authorizedUser.isAdmin()) {
         return false;
       }
-      if(TIMEREPORT_STATUS_COMMITED.equals(timereport.getStatus()) &&
-         Objects.equals(authorizedUser.getEffectiveLoginSign(), timereport.getEmployeecontract().getEmployee().getSalatUser().getLoginname())) {
+      if(TIMEREPORT_STATUS_COMMITED.equals(timereport.getStatus()) && isOwner) {
         return false;
       }
-      if(TIMEREPORT_STATUS_OPEN.equals(timereport.getStatus()) &&
-         !authorizedUser.isAdmin() &&
-         !Objects.equals(authorizedUser.getEffectiveLoginSign(), timereport.getEmployeecontract().getEmployee().getSalatUser().getLoginname())) {
+      if(TIMEREPORT_STATUS_OPEN.equals(timereport.getStatus()) && !authorizedUser.isAdmin() && !isOwner) {
         return false;
       }
     }

--- a/src/main/java/org/tb/dailyreport/auth/TimereportAuthorization.java
+++ b/src/main/java/org/tb/dailyreport/auth/TimereportAuthorization.java
@@ -33,7 +33,7 @@ public class TimereportAuthorization {
   private final AuthService authService;
 
   public boolean isAuthorized(Timereport timereport, AccessLevel accessLevel) {
-    if(authorizedUser.isManager()) return true;
+    if(accessLevel == READ && authorizedUser.isManager()) return true;
     if(accessLevel == READ && authorizedUser.isPeopleLead() && isSupervisedByCurrentUser(timereport.getEmployeecontract())) return true;
     var isOwner = timereport.getEmployeecontract().getEmployee().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
     if(isOwner && accessLevel == READ) return true;
@@ -55,18 +55,18 @@ public class TimereportAuthorization {
 
     if(accessLevel == DELETE || accessLevel == AccessLevel.WRITE) {
       if(TIMEREPORT_STATUS_CLOSED.equals(timereport.getStatus()) &&
-         !authorizedUser.isAdmin()) {
+         (!authorizedUser.isManager() || isOwner)) {
         return false;
       }
       if(TIMEREPORT_STATUS_COMMITED.equals(timereport.getStatus()) &&
          !authorizedUser.isManager() &&
-         !authorizedUser.isAdmin()) {
+         !(authorizedUser.isPeopleLead() && isSupervisedByCurrentUser(timereport.getEmployeecontract()))) {
         return false;
       }
       if(TIMEREPORT_STATUS_COMMITED.equals(timereport.getStatus()) && isOwner) {
         return false;
       }
-      if(TIMEREPORT_STATUS_OPEN.equals(timereport.getStatus()) && !authorizedUser.isAdmin() && !isOwner) {
+      if(TIMEREPORT_STATUS_OPEN.equals(timereport.getStatus()) && !authorizedUser.isManager() && !isOwner) {
         return false;
       }
     }
@@ -82,22 +82,22 @@ public class TimereportAuthorization {
     // authorization is based on the status
     timereports.forEach(timereport -> {
       if(accessLevel == DELETE || accessLevel == AccessLevel.WRITE) {
+        var isOwner = Objects.equals(authorizedUser.getEffectiveLoginSign(), timereport.getEmployeecontract().getEmployee().getSalatUser().getLoginname());
         if(TIMEREPORT_STATUS_CLOSED.equals(timereport.getStatus()) &&
-           !authorizedUser.isAdmin()) {
+           (!authorizedUser.isManager() || isOwner)) {
           throw new AuthorizationException(TR_CLOSED_TIME_REPORT_REQ_ADMIN);
         }
         if(TIMEREPORT_STATUS_COMMITED.equals(timereport.getStatus()) &&
            !authorizedUser.isManager() &&
-           !authorizedUser.isAdmin()) {
+           !(authorizedUser.isPeopleLead() && isSupervisedByCurrentUser(timereport.getEmployeecontract()))) {
           throw new AuthorizationException(TR_COMMITTED_TIME_REPORT_REQ_MANAGER);
         }
-        if(TIMEREPORT_STATUS_COMMITED.equals(timereport.getStatus()) &&
-           Objects.equals(authorizedUser.getEffectiveLoginSign(), timereport.getEmployeecontract().getEmployee().getSalatUser().getLoginname())) {
+        if(TIMEREPORT_STATUS_COMMITED.equals(timereport.getStatus()) && isOwner) {
           throw new AuthorizationException(TR_COMMITTED_TIME_REPORT_NOT_SELF);
         }
         if(TIMEREPORT_STATUS_OPEN.equals(timereport.getStatus()) &&
-           !authorizedUser.isAdmin() &&
-           !Objects.equals(authorizedUser.getEffectiveLoginSign(), timereport.getEmployeecontract().getEmployee().getSalatUser().getLoginname())) {
+           !authorizedUser.isManager() &&
+           !isOwner) {
           throw new AuthorizationException(TR_OPEN_TIME_REPORT_REQ_EMPLOYEE);
         }
       }

--- a/src/main/java/org/tb/dailyreport/service/DailyService.java
+++ b/src/main/java/org/tb/dailyreport/service/DailyService.java
@@ -5,8 +5,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
-import static org.tb.common.GlobalConstants.TIMEREPORT_STATUS_CLOSED;
-import static org.tb.common.GlobalConstants.TIMEREPORT_STATUS_COMMITED;
+import static org.tb.common.GlobalConstants.*;
 import static org.tb.common.util.DateUtils.isInRange;
 import static org.tb.common.util.DateUtils.today;
 
@@ -31,6 +30,7 @@ import org.tb.dailyreport.domain.ListViewData.ListDay;
 import org.tb.dailyreport.domain.Publicholiday;
 import org.tb.dailyreport.domain.TimereportDTO;
 import org.tb.dailyreport.domain.Workingday;
+import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeecontractService;
 
 @Service
@@ -75,10 +75,10 @@ public class DailyService {
             ? DurationUtils.format(workingday.getEmployeecontract().getDailyWorkingTime())
             : null;
 
-        boolean isOwner = contract.getEmployee().getSalatUser().getLoginname()
-            .equals(authorizedUser.getEffectiveLoginSign());
+        boolean isOwner = contract.getEmployee().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
+        var isSupervised = isSupervisedByCurrentUser(contract);
         Set<Long> editableIds = timereports.stream()
-            .filter(tr -> canEditTimereport(tr.getStatus(), isOwner))
+            .filter(tr -> canEditTimereport(tr.getStatus(), isOwner, isSupervised))
             .map(TimereportDTO::getId)
             .collect(toSet());
         boolean workingdayEditable = isOwner || authorizedUser.isManager();
@@ -152,10 +152,10 @@ public class DailyService {
         boolean monthReleased = contract.getReportReleaseDate() != null
             && !contract.getReportReleaseDate().isBefore(last);
 
-        boolean isOwner = contract.getEmployee().getSalatUser().getLoginname()
-            .equals(authorizedUser.getEffectiveLoginSign());
+        boolean isOwner = contract.getEmployee().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
+        var isSupervised = isSupervisedByCurrentUser(contract);
         Set<Long> editableIds = timereports.stream()
-            .filter(tr -> canEditTimereport(tr.getStatus(), isOwner))
+            .filter(tr -> canEditTimereport(tr.getStatus(), isOwner, isSupervised))
             .map(TimereportDTO::getId)
             .collect(toSet());
         boolean canCreate = (!monthReleased && isOwner) || authorizedUser.isManager();
@@ -196,12 +196,29 @@ public class DailyService {
         var contract = employeecontractService.getEmployeecontractById(employeeContractId);
         boolean isOwner = contract.getEmployee().getSalatUser().getLoginname()
             .equals(authorizedUser.getEffectiveLoginSign());
-        return canEditTimereport(tr.getStatus(), isOwner);
+        var isSupervised = isSupervisedByCurrentUser(contract);
+        return canEditTimereport(tr.getStatus(), isOwner, isSupervised);
     }
 
-    private boolean canEditTimereport(String status, boolean isOwner) {
-        if (TIMEREPORT_STATUS_COMMITED.equals(status)) return authorizedUser.isManager() && !isOwner;
-        if (TIMEREPORT_STATUS_CLOSED.equals(status)) return authorizedUser.isManager() && !isOwner;
-        return isOwner || authorizedUser.isManager(); // TIMEREPORT_STATUS_OPEN
+    private boolean canEditTimereport(String status, boolean isOwner, boolean isSupervised) {
+        return switch(status) {
+            // people leads may edit committed time reports if they are the supervisor too
+            // manager for all employees
+            // but not their own (to prevent mistakes)
+            case TIMEREPORT_STATUS_COMMITED -> (isSupervised && authorizedUser.isPeopleLead() || authorizedUser.isManager()) && !isOwner;
+            // managers may edit closed time reports too
+            // but not their own (to prevent mistakes)
+            case TIMEREPORT_STATUS_CLOSED -> authorizedUser.isManager() && !isOwner;
+            // all employees may edit their own open time reports.
+            // manager may do this too, even if open
+            case TIMEREPORT_STATUS_OPEN -> isOwner || authorizedUser.isManager();
+            default -> false; // other status values must default to false
+        };
     }
+
+    private boolean isSupervisedByCurrentUser(Employeecontract ec) {
+        return ec.getSupervisors().stream()
+                .anyMatch(s -> s.getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign()));
+    }
+
 }

--- a/src/main/java/org/tb/dailyreport/service/DailyService.java
+++ b/src/main/java/org/tb/dailyreport/service/DailyService.java
@@ -200,8 +200,8 @@ public class DailyService {
     }
 
     private boolean canEditTimereport(String status, boolean isOwner) {
-        if (TIMEREPORT_STATUS_CLOSED.equals(status)) return authorizedUser.isAdmin();
         if (TIMEREPORT_STATUS_COMMITED.equals(status)) return authorizedUser.isManager() && !isOwner;
-        return isOwner || authorizedUser.isAdmin(); // OPEN
+        if (TIMEREPORT_STATUS_CLOSED.equals(status)) return authorizedUser.isManager() && !isOwner;
+        return isOwner || authorizedUser.isManager(); // TIMEREPORT_STATUS_OPEN
     }
 }


### PR DESCRIPTION
## Summary

- The owner check in `isAuthorized()` was an unconditional early-return (`return true`) that applied to all access levels, making the COMMITTED+owner guard dead code when callers use `isAuthorized()` directly instead of `checkAuthorized()`
- Restricted the owner short-circuit to `READ` only — for WRITE/DELETE the call now falls through to the status checks
- Extracted `isOwner` as a local variable, reused in the WRITE/DELETE block to simplify the COMMITTED+owner and OPEN+!owner checks

## Test plan

- [ ] Owner of a COMMITTED timereport: `isAuthorized(tr, WRITE)` now returns `false`
- [ ] Owner of an OPEN timereport: `isAuthorized(tr, WRITE)` still returns `true` (falls through to `authService`)
- [ ] Manager: `isAuthorized(tr, WRITE)` on a committed timereport still returns `true`
- [ ] `checkAuthorized()` behaviour is unchanged

Closes #712