### PR TITLE
Reset UiState when effective login sign changes

### DIFF
--- a/src/main/java/org/tb/auth/domain/AuthorizedUser.java
+++ b/src/main/java/org/tb/auth/domain/AuthorizedUser.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
+import org.tb.common.web.LoginSignProvider;
 
 // ADR-0013: Ausnahme — session-scoped Bean für Sicherheits- und Identitätszustand des eingeloggten
 // Nutzers (Rollen, Login-Kennung). Session-Scope ist hier korrekt; dies ist kein UI-Selektionszustand.
@@ -21,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Scope(value = SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
 @Getter
-public class AuthorizedUser implements Serializable {
+public class AuthorizedUser implements Serializable, LoginSignProvider {
 
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/tb/common/configuration/HttpFilterConfiguration.java
+++ b/src/main/java/org/tb/common/configuration/HttpFilterConfiguration.java
@@ -10,6 +10,7 @@ import org.tb.common.filter.LoggingFilter;
 import org.tb.common.filter.LoggingFilter.MdcDataSource;
 import org.tb.common.filter.PerformanceLoggingFilter;
 import org.tb.common.filter.UiStateFilter;
+import org.tb.common.web.LoginSignProvider;
 import org.tb.common.web.UiState;
 import org.tb.common.web.UiStateKeyRegistry;
 
@@ -20,6 +21,7 @@ public class HttpFilterConfiguration {
     private final Set<MdcDataSource> mdcDataSources;
     private final UiState uiState;
     private final UiStateKeyRegistry uiStateKeyRegistry;
+    private final LoginSignProvider loginSignProvider;
 
     @Bean
     public FilterRegistrationBean<PerformanceLoggingFilter> performanceLoggingFilter(){
@@ -52,7 +54,7 @@ public class HttpFilterConfiguration {
     public FilterRegistrationBean<UiStateFilter> uiStateFilter() {
         var registrationBean = new FilterRegistrationBean<UiStateFilter>();
         registrationBean.setOrder(103);
-        registrationBean.setFilter(new UiStateFilter(uiState, uiStateKeyRegistry));
+        registrationBean.setFilter(new UiStateFilter(uiState, uiStateKeyRegistry, loginSignProvider));
         registrationBean.addUrlPatterns("/*");
         return registrationBean;
     }

--- a/src/main/java/org/tb/common/filter/UiStateFilter.java
+++ b/src/main/java/org/tb/common/filter/UiStateFilter.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.tb.common.web.LoginSignProvider;
 import org.tb.common.web.UiState;
 import org.tb.common.web.UiStateKey;
 import org.tb.common.web.UiStateKeyRegistry;
@@ -21,9 +22,11 @@ import org.tb.common.web.UiStateKeyRegistry;
 public class UiStateFilter extends OncePerRequestFilter {
 
     static final String COOKIE_NAME = "salat_uistate";
+    static final String COOKIE_KEY_LOGIN_SIGN = "_ls";
 
     private final UiState uiState;
     private final UiStateKeyRegistry uiStateKeyRegistry;
+    private final LoginSignProvider loginSignProvider;
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
@@ -37,18 +40,25 @@ public class UiStateFilter extends OncePerRequestFilter {
             }
         });
 
-        // Phase 2: fill still-unset slots from the merged cookie
+        // Phase 2: fill still-unset slots from the merged cookie, but only when the stored
+        // login sign matches the current effective login sign (guards against stale state
+        // left behind by a previous user or an impersonation switch).
+        String effectiveLoginSign = loginSignProvider.getEffectiveLoginSign();
         Cookie[] cookies = req.getCookies();
         if (cookies != null) {
             for (Cookie c : cookies) {
                 if (COOKIE_NAME.equals(c.getName())) {
-                    parseCookieValue(c.getValue()).forEach((keyName, value) ->
-                        uiStateKeyRegistry.findByName(keyName).ifPresent(key -> {
-                            if (uiState.getValue(key) == null) {
-                                uiState.setValue(key, value);
-                            }
-                        })
-                    );
+                    Map<String, String> parsed = parseCookieValue(c.getValue());
+                    String storedLoginSign = parsed.get(COOKIE_KEY_LOGIN_SIGN);
+                    if (effectiveLoginSign != null && effectiveLoginSign.equals(storedLoginSign)) {
+                        parsed.forEach((keyName, value) ->
+                            uiStateKeyRegistry.findByName(keyName).ifPresent(key -> {
+                                if (uiState.getValue(key) == null) {
+                                    uiState.setValue(key, value);
+                                }
+                            })
+                        );
+                    }
                     break;
                 }
             }
@@ -57,16 +67,19 @@ public class UiStateFilter extends OncePerRequestFilter {
         // Write the merged cookie with the full current state
         Map<UiStateKey, String> all = uiState.getAll();
         if (!all.isEmpty()) {
-            writeCookie(res, buildCookieValue(uiState.getAll()));
+            writeCookie(res, buildCookieValue(all, effectiveLoginSign));
         }
 
         chain.doFilter(req, res);
     }
 
-    private String buildCookieValue(Map<UiStateKey, String> all) {
-        String plain = all.entrySet().stream()
+    private String buildCookieValue(Map<UiStateKey, String> all, String loginSign) {
+        String statePart = all.entrySet().stream()
             .map(e -> e.getKey().getName() + "=" + e.getValue())
             .collect(Collectors.joining("&"));
+        String plain = loginSign != null
+            ? COOKIE_KEY_LOGIN_SIGN + "=" + loginSign + "&" + statePart
+            : statePart;
         return Base64.getUrlEncoder().withoutPadding()
             .encodeToString(plain.getBytes(StandardCharsets.UTF_8));
     }

--- a/src/main/java/org/tb/common/web/LoginSignProvider.java
+++ b/src/main/java/org/tb/common/web/LoginSignProvider.java
@@ -1,0 +1,6 @@
+package org.tb.common.web;
+
+public interface LoginSignProvider {
+
+    String getEffectiveLoginSign();
+}

--- a/src/test/java/org/tb/common/filter/UiStateFilterTest.java
+++ b/src/test/java/org/tb/common/filter/UiStateFilterTest.java
@@ -1,0 +1,134 @@
+package org.tb.common.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.tb.common.filter.UiStateFilter.COOKIE_KEY_LOGIN_SIGN;
+import static org.tb.common.filter.UiStateFilter.COOKIE_NAME;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.tb.common.web.LoginSignProvider;
+import org.tb.common.web.UiState;
+import org.tb.common.web.UiStateKey;
+import org.tb.common.web.UiStateKeyContributor;
+import org.tb.common.web.UiStateKeyRegistry;
+
+class UiStateFilterTest {
+
+    private static final UiStateKey KEY = new UiStateKey("contract");
+    private static final String PARAM = "contractId";
+
+    private UiState uiState;
+    private UiStateKeyRegistry registry;
+    private LoginSignProvider loginSignProvider;
+    private UiStateFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        uiState = new UiState();
+        UiStateKeyContributor contributor = () -> Map.of(PARAM, KEY);
+        registry = new UiStateKeyRegistry(List.of(contributor));
+        loginSignProvider = mock(LoginSignProvider.class);
+        filter = new UiStateFilter(uiState, registry, loginSignProvider);
+    }
+
+    @Test
+    void cookieValuesLoadedWhenLoginSignMatches() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode("_ls=alice&contract=42")));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        assertThat(uiState.getValue(KEY)).isEqualTo("42");
+    }
+
+    @Test
+    void cookieValuesDiscardedWhenLoginSignMismatches() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("bob");
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode("_ls=alice&contract=42")));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        assertThat(uiState.getValue(KEY)).isNull();
+    }
+
+    @Test
+    void cookieValuesDiscardedWhenLoginSignMissingFromCookie() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode("contract=42")));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        assertThat(uiState.getValue(KEY)).isNull();
+    }
+
+    @Test
+    void cookieValuesDiscardedWhenUserNotAuthenticated() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn(null);
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode("_ls=alice&contract=42")));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        assertThat(uiState.getValue(KEY)).isNull();
+    }
+
+    @Test
+    void loginSignWrittenToCookieOnResponse() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode("_ls=alice&contract=42")));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        String setCookie = res.getHeader("Set-Cookie");
+        assertThat(setCookie).isNotNull();
+        String cookieValue = setCookie.split(";")[0].split("=", 2)[1];
+        String decoded = new String(Base64.getUrlDecoder().decode(cookieValue), StandardCharsets.UTF_8);
+        assertThat(decoded).contains(COOKIE_KEY_LOGIN_SIGN + "=alice");
+        assertThat(decoded).contains("contract=42");
+    }
+
+    @Test
+    void requestParamTakesPrecedenceOverCookie() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addParameter(PARAM, "99");
+        req.setCookies(new Cookie(COOKIE_NAME, encode("_ls=alice&contract=42")));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        assertThat(uiState.getValue(KEY)).isEqualTo("99");
+    }
+
+    private static String encode(String plain) {
+        return Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(plain.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary

- Introduced `LoginSignProvider` interface in `org.tb.common.web` with a single `getEffectiveLoginSign()` method; `AuthorizedUser` now implements it
- `UiStateFilter` embeds the effective login sign as `_ls` in the `salat_uistate` cookie when writing
- On read, the stored `_ls` is compared against the current `LoginSignProvider.getEffectiveLoginSign()`; if they differ (or `_ls` is absent, or the user is not authenticated), the cookie values are discarded — the new user starts with a clean `UiState`
- `HttpFilterConfiguration` injects `LoginSignProvider` to keep `common` free of `auth` imports (ArchUnit rule `commonShouldNotAccessOtherSalatPackages` remains satisfied)

## Test plan

- [x] `UiStateFilterTest` — 6 unit tests covering: matching sign loads values, mismatched sign discards, missing sign discards, unauthenticated user discards, `_ls` written to response cookie, request param takes precedence over cookie
- [x] `ArchitectureTest` passes — no new inter-module cycles, `common` still does not depend on `auth`
- [x] Full build: `jenv exec ./mvnw verify` — 239 tests, 0 failures

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #726