### PR TITLE
Expose UiState values as fallback request parameters

### DIFF
--- a/docs/adr/0014-uistate-fuer-benutzerbezogenen-selektionszustand.md
+++ b/docs/adr/0014-uistate-fuer-benutzerbezogenen-selektionszustand.md
@@ -41,11 +41,15 @@ Chosen: **Option B**, weil sie ADR-0013 umsetzt ohne Boilerplate in jedem Contro
 ```java
 @RequiredArgsConstructor
 public class SomeController {
-    private final UiState uiState;
 
-    private long effectiveContractId() {
-        Long fromCookie = uiState.getSelectedContractId();
-        if (fromCookie != null && fromCookie > 0) return fromCookie;
+    @GetMapping
+    public String show(@RequestParam(required = false) Long employeeContractId, Model model) {
+        long ecId = effectiveContractId(employeeContractId);
+        // ...
+    }
+
+    private long effectiveContractId(Long employeeContractId) {
+        if (employeeContractId != null && employeeContractId > 0) return employeeContractId;
         // Fallback auf den aktuellen Vertrag des eingeloggten Mitarbeiters
         return employeecontractService.getCurrentContract(loginEmployee.getId())
             .map(EmployeeContract::getId).orElse(-1L);
@@ -53,11 +57,13 @@ public class SomeController {
 }
 ```
 
-Die Selektion wird im HTML per verstecktem Feld oder als Query-Parameter übergeben; der Filter erkennt sie automatisch und aktualisiert Cookie + UiState.
+Der Filter stellt UiState-Werte als Fallback-Request-Parameter bereit (Phase 3: `UiStateParameterRequestWrapper`). Dadurch empfängt Spring MVC den Cookie-Wert automatisch als `@RequestParam`, ohne dass Controller `UiState` direkt einbinden müssen. Ein explizit übermittelter Request-Parameter hat weiterhin Vorrang.
 
 ### Weiterentwicklung
 
 Die Key-Konstanten und HTTP-Param-Mappings wurden in ADR-0016 in das jeweilige Fachmodul verschoben (`EmployeeUiStateKeyContributor`, `OrderUiStateKeyContributor`). `UiStateKey` ist seitdem ein `@Component` mit Contributor-Muster. `UiState` hat keine domänenspezifischen Methoden mehr.
+
+`UiState` und `UiStateFilter` wurden anschließend um eine Phase 3 erweitert: Nach dem Befüllen des UiState-Beans (Phasen 1+2) wrapat der Filter den `HttpServletRequest` mit einem `UiStateParameterRequestWrapper`, der UiState-Werte als Fallback-Request-Parameter anbietet. Controller müssen `UiState` daher nicht mehr direkt per Dependency Injection einbinden.
 
 ### Consequences
 

--- a/src/main/java/org/tb/common/filter/UiStateFilter.java
+++ b/src/main/java/org/tb/common/filter/UiStateFilter.java
@@ -36,6 +36,8 @@ public class UiStateFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
             FilterChain chain) throws ServletException, IOException {
 
+        var dirty = false;
+
         // Phase 1: fill slots from the cookie, but only when the stored
         // login sign matches the current effective login sign (guards against stale state
         // left behind by a previous user or an impersonation switch).
@@ -46,12 +48,16 @@ public class UiStateFilter extends OncePerRequestFilter {
                 if (COOKIE_NAME.equals(c.getName())) {
                     Map<String, String> parsed = parseCookieValue(c.getValue());
                     String storedLoginSign = parsed.get(COOKIE_KEY_LOGIN_SIGN);
-                    if (effectiveLoginSign != null && effectiveLoginSign.equals(storedLoginSign)) {
-                        parsed.forEach((keyName, value) ->
-                            uiStateKeyRegistry.findByName(keyName).ifPresent(key -> {
-                                uiState.setValue(key, value);
-                            })
-                        );
+                    if (effectiveLoginSign != null) {
+                        if(effectiveLoginSign.equals(storedLoginSign)) {
+                            parsed.forEach((keyName, value) ->
+                                    uiStateKeyRegistry.findByName(keyName).ifPresent(key -> {
+                                        uiState.setValue(key, value);
+                                    })
+                            );
+                        } else {
+                            dirty = true;
+                        }
                     }
                     break;
                 }
@@ -59,7 +65,6 @@ public class UiStateFilter extends OncePerRequestFilter {
         }
 
         // Phase 2: explicit request params take precedence (override cookie value)
-        var dirty = false;
         for(var entry : uiStateKeyRegistry.getParamToKey().entrySet()) {
             var param = entry.getKey();
             var key = entry.getValue();
@@ -75,7 +80,16 @@ public class UiStateFilter extends OncePerRequestFilter {
             writeCookie(res, buildCookieValue(all, effectiveLoginSign));
         }
 
-        chain.doFilter(req, res);
+        // Phase 3: expose UiState values as fallback request parameters
+        Map<String, String> fallbacks = new java.util.HashMap<>();
+        uiStateKeyRegistry.getParamToKey().forEach((paramName, key) -> {
+            String value = uiState.getValue(key);
+            if (value != null) fallbacks.put(paramName, value);
+        });
+        HttpServletRequest wrappedReq = fallbacks.isEmpty() ? req
+            : new UiStateParameterRequestWrapper(req, fallbacks);
+
+        chain.doFilter(wrappedReq, res);
     }
 
     private String buildCookieValue(Map<UiStateKey, String> all, String loginSign) {

--- a/src/main/java/org/tb/common/filter/UiStateParameterRequestWrapper.java
+++ b/src/main/java/org/tb/common/filter/UiStateParameterRequestWrapper.java
@@ -1,0 +1,49 @@
+package org.tb.common.filter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+class UiStateParameterRequestWrapper extends HttpServletRequestWrapper {
+
+    private final Map<String, String> fallbackParams;
+
+    UiStateParameterRequestWrapper(HttpServletRequest request, Map<String, String> fallbackParams) {
+        super(request);
+        this.fallbackParams = fallbackParams;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        String value = super.getParameter(name);
+        return value != null ? value : fallbackParams.get(name);
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        String[] values = super.getParameterValues(name);
+        if (values != null) return values;
+        String fallback = fallbackParams.get(name);
+        return fallback != null ? new String[]{fallback} : null;
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        Map<String, String[]> merged = new HashMap<>();
+        fallbackParams.forEach((k, v) -> merged.put(k, new String[]{v}));
+        merged.putAll(super.getParameterMap()); // actual params take precedence
+        return Collections.unmodifiableMap(merged);
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        Set<String> names = new LinkedHashSet<>(fallbackParams.keySet());
+        Collections.list(super.getParameterNames()).forEach(names::add);
+        return Collections.enumeration(names);
+    }
+}

--- a/src/main/java/org/tb/dailyreport/controller/DailyController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DailyController.java
@@ -24,14 +24,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.tb.auth.domain.Authorized;
 import org.tb.common.exception.ErrorCodeException;
-import org.tb.common.web.UiState;
-import org.tb.employee.controller.EmployeeUiStateKeyContributor;
 import org.tb.common.viewhelper.ErrorCodeViewHelper;
 import org.tb.dailyreport.domain.Workingday;
 import org.tb.dailyreport.service.DailyService;
 import org.tb.dailyreport.service.MatrixService;
 import org.tb.dailyreport.service.TimereportService;
 import org.tb.dailyreport.service.WorkingdayService;
+import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeeService;
 import org.tb.employee.service.EmployeecontractService;
 import java.time.Duration;
@@ -55,10 +54,10 @@ public class DailyController {
     private final EmployeeorderService employeeorderService;
     private final MessageSourceAccessor messages;
     private final ErrorCodeViewHelper errorCodeViewHelper;
-    private final UiState uiState;
 
     @GetMapping
     public String show(
+            @RequestParam(required = false) Long employeeContractId,
             @RequestParam(required = false) String mode,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @RequestParam(required = false) Integer month,
@@ -67,7 +66,7 @@ public class DailyController {
 
         var today = today();
         var contracts = employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(today);
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
 
         String effectiveMode = (mode != null && mode.equals("list")) ? "list" : "daily";
 
@@ -132,16 +131,17 @@ public class DailyController {
     @PostMapping("/workingday")
     @PreAuthorize("isAuthenticated()")
     public String saveWorkingday(
+            @RequestParam(required = false) Long employeeContractId,
             @ModelAttribute WorkingdayForm form,
             HttpServletRequest request,
             HttpServletResponse response,
             Model model,
             RedirectAttributes redirectAttributes) {
-        long employeeContractId = effectiveContractId();
+        long effEmployeeContractId = effectiveContractId(employeeContractId);
         LocalDate date = form.getDate();
         try {
-            var contract = employeecontractService.getEmployeecontractById(employeeContractId);
-            Workingday workingday = workingdayService.getWorkingday(employeeContractId, date);
+            var contract = employeecontractService.getEmployeecontractById(effEmployeeContractId);
+            Workingday workingday = workingdayService.getWorkingday(effEmployeeContractId, date);
             if (workingday == null) {
                 workingday = new Workingday();
                 workingday.setEmployeecontract(contract);
@@ -164,7 +164,7 @@ public class DailyController {
             }
             workingdayService.upsertWorkingday(workingday);
             if ("true".equals(request.getHeader("HX-Request"))) {
-                var dailyData = dailyService.buildDailyView(date, employeeContractId);
+                var dailyData = dailyService.buildDailyView(date, effEmployeeContractId);
                 model.addAttribute("dailyData", dailyData);
                 model.addAttribute("weekStripData", dailyData.weekStrip());
                 var updatedForm = new WorkingdayForm();
@@ -175,7 +175,7 @@ public class DailyController {
                 updatedForm.setBreakTime(dailyData.breakTime());
                 model.addAttribute("workingdayForm", updatedForm);
                 model.addAttribute("date", date);
-                model.addAttribute("selectedContractId", employeeContractId);
+                model.addAttribute("selectedContractId", effEmployeeContractId);
                 model.addAttribute("isHtmxRequest", true);
                 model.addAttribute("isDailyMode", true);
                 model.addAttribute("favorites", buildFavoriteViews());
@@ -188,7 +188,7 @@ public class DailyController {
                 .map(Object::toString).findFirst().orElse("Error");
             if ("true".equals(request.getHeader("HX-Request"))) {
                 response.setHeader("HX-Trigger", "{\"showError\":\"" + errMsg.replace("\"", "'") + "\"}");
-                var dailyData = dailyService.buildDailyView(date, employeeContractId);
+                var dailyData = dailyService.buildDailyView(date, effEmployeeContractId);
                 model.addAttribute("dailyData", dailyData);
                 model.addAttribute("weekStripData", dailyData.weekStrip());
                 var updatedForm = new WorkingdayForm();
@@ -199,7 +199,7 @@ public class DailyController {
                 updatedForm.setBreakTime(dailyData.breakTime());
                 model.addAttribute("workingdayForm", updatedForm);
                 model.addAttribute("date", date);
-                model.addAttribute("selectedContractId", employeeContractId);
+                model.addAttribute("selectedContractId", effEmployeeContractId);
                 model.addAttribute("isHtmxRequest", true);
                 model.addAttribute("isDailyMode", true);
                 model.addAttribute("favorites", buildFavoriteViews());
@@ -277,12 +277,13 @@ public class DailyController {
     @PostMapping("/apply-favourite")
     @PreAuthorize("isAuthenticated()")
     public String applyFavourite(
+            @RequestParam(required = false) Long employeeContractId,
             @RequestParam Long favoriteId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             HttpServletRequest request,
             HttpServletResponse response,
             Model model) {
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
         try {
             var fav = favoriteService.getFavorite(favoriteId).orElseThrow();
             timereportService.createTimereports(ecId, fav.getEmployeeorderId(), date,
@@ -313,10 +314,11 @@ public class DailyController {
     @PostMapping("/delete-favourite")
     @PreAuthorize("isAuthenticated()")
     public String deleteFavourite(
+            @RequestParam(required = false) Long employeeContractId,
             @RequestParam Long favoriteId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             Model model) {
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
         try {
             favoriteService.deleteFavorite(favoriteId);
         } catch (Exception ex) {
@@ -356,13 +358,14 @@ public class DailyController {
         return new FavoriteView(f.getId(), label, f.getComment(), duration);
     }
 
-    private long effectiveContractId() {
-        Long fromUiState = uiState.getLongValue(EmployeeUiStateKeyContributor.SELECTED_CONTRACT);
-        if (fromUiState != null && fromUiState > 0) return fromUiState;
+    private long effectiveContractId(Long employeeContractId) {
+        if (employeeContractId != null && employeeContractId > 0) {
+            return employeeContractId;
+        }
         var loginEmployee = employeeService.getLoginEmployee();
         return employeecontractService.getCurrentContract(loginEmployee.getId())
-            .map(c -> c.getId())
-            .orElse(-1L);
+                .map(Employeecontract::getId)
+                .orElse(-1L);
     }
 
     private static int[] parseTime(String hhmm, int defaultHour, int defaultMinute) {
@@ -400,10 +403,11 @@ public class DailyController {
     @PostMapping("/fill-not-worked")
     @PreAuthorize("isAuthenticated()")
     public String fillNotWorked(
+            @RequestParam(required = false) Long employeeContractId,
             @RequestParam Integer month,
             @RequestParam Integer year,
             RedirectAttributes redirectAttributes) {
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
         try {
             matrixService.fillNotWorked(YearMonth.of(year, month), ecId);
             redirectAttributes.addFlashAttribute("toastSuccess",

--- a/src/main/java/org/tb/dailyreport/controller/DailyReportCsvController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DailyReportCsvController.java
@@ -12,7 +12,6 @@ import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,11 +29,10 @@ import org.tb.common.exception.AuthorizationException;
 import org.tb.common.exception.BusinessRuleException;
 import org.tb.common.exception.InvalidDataException;
 import org.tb.common.viewhelper.ErrorCodeViewHelper;
-import org.tb.common.web.UiState;
-import org.tb.employee.controller.EmployeeUiStateKeyContributor;
 import org.tb.dailyreport.rest.DailyWorkingReportCsvConverter;
 import org.tb.dailyreport.service.DailyWorkingReportService;
 import org.tb.dailyreport.service.ImportReport;
+import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeecontractService;
 import org.tb.employee.service.EmployeeService;
 
@@ -50,16 +48,15 @@ public class DailyReportCsvController {
     private final EmployeeService employeeService;
     private final MessageSourceAccessor messages;
     private final ErrorCodeViewHelper errorCodeViewHelper;
-    private final UiState uiState;
 
     @GetMapping
-    public String show(Model model) {
+    public String show(@RequestParam(required = false) Long employeeContractId, Model model) {
         YearMonth current = YearMonth.now();
         List<YearMonth> availableMonths = IntStream.range(0, 12)
             .mapToObj(current::minusMonths)
             .toList();
         var contracts = employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(today());
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
         model.addAttribute("employeecontracts", contracts);
         model.addAttribute("selectedContractId", ecId);
         model.addAttribute("availableMonths", availableMonths);
@@ -84,7 +81,7 @@ public class DailyReportCsvController {
                 messages.getMessage("main.dailyreport.csv.import.error.file.required.text"));
             return "redirect:/dailyreport/csv";
         }
-        long ecId = employeeContractId != null ? employeeContractId : effectiveContractId();
+        long ecId = employeeContractId != null ? employeeContractId : effectiveContractId(employeeContractId);
         try {
             var readResult = csvConverter.read(file.getInputStream());
             var importReport = "replace".equals(importMode)
@@ -107,9 +104,9 @@ public class DailyReportCsvController {
     }
 
     @GetMapping("/export")
-    public ResponseEntity<byte[]> exportCsv(@RequestParam String month) throws IOException {
+    public ResponseEntity<byte[]> exportCsv(@RequestParam(required = false) Long employeeContractId, @RequestParam String month) throws IOException {
         YearMonth yearMonth = YearMonth.parse(month);
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
         var reports = dailyWorkingReportService.getReportsForMonth(yearMonth, ecId);
         var baos = new ByteArrayOutputStream();
         csvConverter.write(reports, null, new HttpOutputMessage() {
@@ -122,12 +119,13 @@ public class DailyReportCsvController {
             .body(baos.toByteArray());
     }
 
-    private long effectiveContractId() {
-        Long fromUiState = uiState.getLongValue(EmployeeUiStateKeyContributor.SELECTED_CONTRACT);
-        if (fromUiState != null && fromUiState > 0) return fromUiState;
+    private long effectiveContractId(Long employeeContractId) {
+        if (employeeContractId != null && employeeContractId > 0) {
+            return employeeContractId;
+        }
         var loginEmployee = employeeService.getLoginEmployee();
         return employeecontractService.getCurrentContract(loginEmployee.getId())
-            .map(c -> c.getId())
-            .orElse(-1L);
+                .map(Employeecontract::getId)
+                .orElse(-1L);
     }
 }

--- a/src/main/java/org/tb/dailyreport/controller/DashboardController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DashboardController.java
@@ -25,8 +25,6 @@ import org.tb.auth.domain.AuthorizedUser;
 import org.tb.auth.service.AuthService;
 import org.tb.common.LocalDateRange;
 import org.tb.common.util.DurationUtils;
-import org.tb.common.web.UiState;
-import org.tb.employee.controller.EmployeeUiStateKeyContributor;
 import org.tb.dailyreport.domain.TimereportDTO;
 import org.tb.dailyreport.service.OvertimeService;
 import org.tb.dailyreport.service.PublicholidayService;
@@ -61,11 +59,11 @@ public class DashboardController {
     private final MessageSourceAccessor messageSourceAccessor;
     private final AuthorizedUser authorizedUser;
     private final AuthorizedEmployee authorizedEmployee;
-    private final UiState uiState;
 
     @GetMapping
-    public String dashboard(HttpSession session, Model model) {
-        var employeecontract = currentContract();
+    public String dashboard(@RequestParam(required = false) Long employeeContractId,
+                            HttpSession session, Model model) {
+        var employeecontract = currentContract(employeeContractId);
         session.setAttribute("currentEmployeeId", employeecontract.getEmployee().getId());
         session.setAttribute("currentEmployeeContract", employeecontract);
 
@@ -221,15 +219,14 @@ public class DashboardController {
         return "redirect:/dailyreport/dashboard";
     }
 
-    private Employeecontract currentContract() {
-        Long contractId = uiState.getLongValue(EmployeeUiStateKeyContributor.SELECTED_CONTRACT);
-        if (contractId != null && contractId > 0) {
-            var contract = employeecontractService.getEmployeecontractById(contractId);
+    private Employeecontract currentContract(Long employeeContractId) {
+        if (employeeContractId != null && employeeContractId > 0) {
+            var contract = employeecontractService.getEmployeecontractById(employeeContractId);
             if (contract != null) return contract;
         }
         var loginEmployee = employeeService.getLoginEmployee();
         return employeecontractService.getCurrentContract(loginEmployee.getId())
-            .orElseThrow(() -> new IllegalStateException("No current contract for login employee"));
+                .orElseThrow(() -> new IllegalStateException("No current contract for login employee"));
     }
 
     /** Returns "success", "warning", or "danger" based on total overtime thresholds (in hours). */

--- a/src/main/java/org/tb/dailyreport/controller/MatrixController.java
+++ b/src/main/java/org/tb/dailyreport/controller/MatrixController.java
@@ -16,10 +16,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.tb.auth.domain.Authorized;
 import org.tb.common.exception.ErrorCodeException;
-import org.tb.common.web.UiState;
-import org.tb.employee.controller.EmployeeUiStateKeyContributor;
 import org.tb.common.viewhelper.ErrorCodeViewHelper;
 import org.tb.dailyreport.service.MatrixService;
+import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeecontractService;
 import org.tb.employee.service.EmployeeService;
 
@@ -34,10 +33,10 @@ public class MatrixController {
     private final EmployeeService employeeService;
     private final MessageSourceAccessor messages;
     private final ErrorCodeViewHelper errorCodeViewHelper;
-    private final UiState uiState;
 
     @GetMapping
     public String show(
+            @RequestParam(required = false) Long employeeContractId,
             @RequestParam(required = false) Integer month,
             @RequestParam(required = false) Integer year,
             Model model) {
@@ -47,7 +46,7 @@ public class MatrixController {
         int targetYear = year != null ? year : today.getYear();
         YearMonth yearMonth = YearMonth.of(targetYear, targetMonth);
 
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
 
         var matrixData = matrixService.buildMatrix(yearMonth, ecId);
         var contracts = employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(today);
@@ -90,10 +89,11 @@ public class MatrixController {
     @PostMapping("/fill-not-worked")
     @PreAuthorize("isAuthenticated()")
     public String fillNotWorked(
+            @RequestParam(required = false) Long employeeContractId,
             @RequestParam Integer month,
             @RequestParam Integer year,
             RedirectAttributes redirectAttributes) {
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
         try {
             matrixService.fillNotWorked(YearMonth.of(year, month), ecId);
             redirectAttributes.addFlashAttribute("toastSuccess",
@@ -106,12 +106,13 @@ public class MatrixController {
         return "redirect:/dailyreport/matrix?month=" + month + "&year=" + year;
     }
 
-    private long effectiveContractId() {
-        Long fromUiState = uiState.getLongValue(EmployeeUiStateKeyContributor.SELECTED_CONTRACT);
-        if (fromUiState != null && fromUiState > 0) return fromUiState;
+    private long effectiveContractId(Long employeeContractId) {
+        if (employeeContractId != null && employeeContractId > 0) {
+            return employeeContractId;
+        }
         var loginEmployee = employeeService.getLoginEmployee();
         return employeecontractService.getCurrentContract(loginEmployee.getId())
-            .map(c -> c.getId())
-            .orElse(-1L);
+                .map(Employeecontract::getId)
+                .orElse(-1L);
     }
 }

--- a/src/main/java/org/tb/dailyreport/controller/MyAccountsController.java
+++ b/src/main/java/org/tb/dailyreport/controller/MyAccountsController.java
@@ -23,10 +23,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.tb.common.LocalDateRange;
 import org.tb.common.util.DurationUtils;
-import org.tb.common.web.UiState;
-import org.tb.employee.controller.EmployeeUiStateKeyContributor;
 import org.tb.dailyreport.domain.TimereportDTO;
 import org.tb.dailyreport.service.OvertimeService;
 import org.tb.dailyreport.service.TimereportService;
@@ -57,11 +56,10 @@ public class MyAccountsController {
     private final MessageSourceAccessor messageSourceAccessor;
     private final EmployeecontractService employeecontractService;
     private final EmployeeService employeeService;
-    private final UiState uiState;
 
     @GetMapping
-    public String show(HttpSession session, Model model) {
-        var contract = currentContract();
+    public String show(@RequestParam(required = false) Long employeeContractId, HttpSession session, Model model) {
+        var contract = currentContract(employeeContractId);
         var today = today();
         var currentYear = today.getYear();
         var yearStart = LocalDate.of(currentYear, 1, 1);
@@ -315,10 +313,9 @@ public class MyAccountsController {
         return timereport.isTraining() || COMPLETE_ORDER_SIGN_TRAINING.equals(timereport.getCompleteOrderSign());
     }
 
-    private Employeecontract currentContract() {
-        Long contractId = uiState.getLongValue(EmployeeUiStateKeyContributor.SELECTED_CONTRACT);
-        if (contractId != null && contractId > 0) {
-            var contract = employeecontractService.getEmployeecontractById(contractId);
+    private Employeecontract currentContract(Long employeeContractId) {
+        if (employeeContractId != null && employeeContractId > 0) {
+            var contract = employeecontractService.getEmployeecontractById(employeeContractId);
             if (contract != null) return contract;
         }
         var loginEmployee = employeeService.getLoginEmployee();

--- a/src/main/java/org/tb/dailyreport/controller/OvertimeController.java
+++ b/src/main/java/org/tb/dailyreport/controller/OvertimeController.java
@@ -4,6 +4,7 @@ import static org.tb.common.util.DateUtils.today;
 
 import java.time.Duration;
 import java.time.LocalDate;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -12,10 +13,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.tb.auth.domain.Authorized;
-import org.tb.common.web.UiState;
-import org.tb.employee.controller.EmployeeUiStateKeyContributor;
 import org.tb.dailyreport.domain.OvertimeReport;
 import org.tb.dailyreport.service.OvertimeService;
 import org.tb.employee.domain.Employeecontract;
@@ -32,12 +32,11 @@ public class OvertimeController {
     private final EmployeecontractService employeecontractService;
     private final EmployeeService employeeService;
     private final MessageSourceAccessor messages;
-    private final UiState uiState;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
-    public String show(Model model) {
-        long ecId = effectiveContractId();
+    public String show(@RequestParam(required = false) Long employeeContractId, Model model) {
+        long ecId = effectiveContractId(employeeContractId);
         var contracts = employeecontractService
             .getViewableEmployeeContractsForAuthorizedUserValidAt(today());
         OvertimeReport report = ecId > 0
@@ -79,8 +78,8 @@ public class OvertimeController {
 
     @PostMapping("/correct")
     @PreAuthorize("hasRole('MANAGER')")
-    public String correctOvertime(RedirectAttributes redirectAttributes) {
-        long ecId = effectiveContractId();
+    public String correctOvertime(@RequestParam(required = false) Long employeeContractId, RedirectAttributes redirectAttributes) {
+        long ecId = effectiveContractId(employeeContractId);
         if (ecId > 0) {
             overtimeService.updateOvertimeStatic(ecId);
             redirectAttributes.addFlashAttribute("toastSuccess",
@@ -89,9 +88,10 @@ public class OvertimeController {
         return "redirect:/dailyreport/overtime";
     }
 
-    private long effectiveContractId() {
-        Long fromUiState = uiState.getLongValue(EmployeeUiStateKeyContributor.SELECTED_CONTRACT);
-        if (fromUiState != null && fromUiState > 0) return fromUiState;
+    private long effectiveContractId(Long employeeContractId) {
+        if (employeeContractId != null && employeeContractId > 0) {
+            return employeeContractId;
+        }
         var loginEmployee = employeeService.getLoginEmployee();
         return employeecontractService.getCurrentContract(loginEmployee.getId())
             .map(Employeecontract::getId)

--- a/src/main/java/org/tb/dailyreport/controller/TimereportController.java
+++ b/src/main/java/org/tb/dailyreport/controller/TimereportController.java
@@ -20,15 +20,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.tb.auth.domain.Authorized;
 import org.tb.auth.domain.AuthorizedUser;
-import org.tb.common.web.UiState;
-import org.tb.employee.controller.EmployeeUiStateKeyContributor;
 import org.tb.common.exception.ErrorCodeException;
 import org.tb.common.exception.InvalidDataException;
 import org.tb.common.viewhelper.ErrorCodeViewHelper;
 import org.tb.dailyreport.domain.Workingday;
 import org.tb.dailyreport.service.TimereportService;
 import org.tb.dailyreport.service.WorkingdayService;
-import org.tb.employee.domain.AuthorizedEmployee;
+import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeeService;
 import org.tb.employee.service.EmployeecontractService;
 import org.tb.favorites.domain.Favorite;
@@ -55,18 +53,16 @@ public class TimereportController {
     private final FavoriteService favoriteService;
     private final EmployeeService employeeService;
     private final AuthorizedUser authorizedUser;
-    private final AuthorizedEmployee authorizedEmployee;
     private final MessageSourceAccessor messages;
     private final ErrorCodeViewHelper errorCodeViewHelper;
-    private final UiState uiState;
 
     @GetMapping("/new")
-    public String createForm(
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+    public String createForm(@RequestParam(required = false) Long employeeContractId,
+                             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             Model model) {
 
         LocalDate effectiveDate = date != null ? date : today();
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
 
         var orders = customerorderService.getCustomerordersWithValidEmployeeOrders(ecId, effectiveDate);
         Long firstOrderId = orders.isEmpty() ? null : orders.get(0).getId();
@@ -84,12 +80,12 @@ public class TimereportController {
         form.setOrderId(firstOrderId);
         form.setSuborderId(firstSuborderId);
 
-        populateModel(model, form, orders, suborders, ecId, effectiveDate, false);
+        populateModel(employeeContractId, model, form, orders, suborders, ecId, effectiveDate, false);
         return "dailyreport/timereport-form";
     }
 
     @GetMapping("/{id}/edit")
-    public String editForm(@PathVariable Long id, Model model) {
+    public String editForm(@PathVariable Long id, @RequestParam(required = false) Long employeeContractId, Model model) {
         var tr = timereportService.getTimereportById(id);
         if (tr == null) {
             return "redirect:/dailyreport/daily";
@@ -113,34 +109,36 @@ public class TimereportController {
         var orders = customerorderService.getCustomerordersWithValidEmployeeOrders(ecId, date);
         var suborders = suborderOptions(ecId, tr.getCustomerorderId(), date);
 
-        populateModel(model, form, orders, suborders, ecId, date, true);
+        populateModel(employeeContractId, model, form, orders, suborders, ecId, date, true);
         return "dailyreport/timereport-form";
     }
 
     @PostMapping
     @PreAuthorize("isAuthenticated()")
     public String create(
+            @RequestParam(required = false) Long employeeContractId,
             @ModelAttribute TimereportForm form,
             RedirectAttributes redirectAttributes,
             Model model) {
-        return saveTimereport(form, false, redirectAttributes, model);
+        return saveTimereport(employeeContractId, form, false, redirectAttributes, model);
     }
 
     @PostMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public String update(
             @PathVariable Long id,
+            @RequestParam(required = false) Long employeeContractId,
             @ModelAttribute TimereportForm form,
             RedirectAttributes redirectAttributes,
             Model model) {
         form.setId(id);
-        return saveTimereport(form, true, redirectAttributes, model);
+        return saveTimereport(employeeContractId, form, true, redirectAttributes, model);
     }
 
     @PostMapping("/refresh-orders")
     @PreAuthorize("isAuthenticated()")
-    public String refreshOrders(@ModelAttribute TimereportForm form, Model model) {
-        long ecId = effectiveContractId();
+    public String refreshOrders(@RequestParam(required = false) Long employeeContractId, @ModelAttribute TimereportForm form, Model model) {
+        long ecId = effectiveContractId(employeeContractId);
         LocalDate date = form.getReferenceday();
 
         List<Customerorder> orders = List.of();
@@ -173,7 +171,7 @@ public class TimereportController {
         model.addAttribute("orders", orders);
         model.addAttribute("suborders", suborders);
         model.addAttribute("commentNecessary", commentNecessaryOrders);
-        model.addAttribute("recentComments", loadRecentComments(form));
+        model.addAttribute("recentComments", loadRecentComments(employeeContractId, form));
         if (ecId > 0 && date != null) {
             model.addAttribute("todaysBookings",
                 timereportService.getTimereportsByDateAndEmployeeContractId(ecId, date));
@@ -191,8 +189,8 @@ public class TimereportController {
 
     @PostMapping("/refresh-suborders")
     @PreAuthorize("isAuthenticated()")
-    public String refreshSuborders(@ModelAttribute TimereportForm form, Model model) {
-        long ecId = effectiveContractId();
+    public String refreshSuborders(@RequestParam(required = false) Long employeeContractId, @ModelAttribute TimereportForm form, Model model) {
+        long ecId = effectiveContractId(employeeContractId);
         LocalDate date = form.getReferenceday();
 
         List<SuborderOption> suborders = List.of();
@@ -210,7 +208,7 @@ public class TimereportController {
         model.addAttribute("selectedContractId", ecId);
         model.addAttribute("suborders", suborders);
         model.addAttribute("commentNecessary", commentNecessarySuborders);
-        model.addAttribute("recentComments", loadRecentComments(form));
+        model.addAttribute("recentComments", loadRecentComments(employeeContractId, form));
         if (ecId > 0 && date != null) {
             model.addAttribute("todaysBookings",
                 timereportService.getTimereportsByDateAndEmployeeContractId(ecId, date));
@@ -228,8 +226,8 @@ public class TimereportController {
 
     @PostMapping("/refresh-sidebar")
     @PreAuthorize("isAuthenticated()")
-    public String refreshSidebar(@ModelAttribute TimereportForm form, Model model) {
-        long ecId = effectiveContractId();
+    public String refreshSidebar(@RequestParam(required = false) Long employeeContractId, @ModelAttribute TimereportForm form, Model model) {
+        long ecId = effectiveContractId(employeeContractId);
         model.addAttribute("timereportForm", form);
         model.addAttribute("selectedContractId", ecId);
         if (ecId > 0 && form.getReferenceday() != null) {
@@ -238,7 +236,7 @@ public class TimereportController {
         } else {
             model.addAttribute("todaysBookings", List.of());
         }
-        model.addAttribute("recentComments", loadRecentComments(form));
+        model.addAttribute("recentComments", loadRecentComments(employeeContractId, form));
         if (authorizedUser.isPeopleLead()) {
             model.addAttribute("employeecontracts",
                 employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(
@@ -249,10 +247,10 @@ public class TimereportController {
 
     // ---- private helpers ----
 
-    private String saveTimereport(TimereportForm form, boolean isEdit,
+    private String saveTimereport(Long employeeContractId, TimereportForm form, boolean isEdit,
             RedirectAttributes redirectAttributes, Model model) {
 
-        long ecId = effectiveContractId();
+        long ecId = effectiveContractId(employeeContractId);
         LocalDate date = form.getReferenceday();
 
         long durationHours;
@@ -263,11 +261,11 @@ public class TimereportController {
             int[] end = parseTime(form.getEndTime());
             long totalMinutes = (end[0] * 60L + end[1]) - (begin[0] * 60L + begin[1]);
             if (totalMinutes <= 0) {
-                return reRenderFormWithError(model, form, ecId, date, isEdit,
+                return reRenderFormWithError(employeeContractId, model, form, ecId, date, isEdit,
                         errorCodeViewHelper.toViewMessage("main.timereport.form.validation.duration.positive"));
             }
             if (totalMinutes > 1440) {
-                return reRenderFormWithError(model, form, ecId, date, isEdit,
+                return reRenderFormWithError(employeeContractId, model, form, ecId, date, isEdit,
                         errorCodeViewHelper.toViewMessage("main.timereport.form.validation.duration.range"));
 
             }
@@ -277,7 +275,7 @@ public class TimereportController {
             int[] parts = parseTime(form.getDurationTime());
             long totalMinutes = parts[0] * 60L + parts[1];
             if (totalMinutes <= 0 || totalMinutes > 1440) {
-                return reRenderFormWithError(model, form, ecId, date, isEdit,
+                return reRenderFormWithError(employeeContractId, model, form, ecId, date, isEdit,
                         errorCodeViewHelper.toViewMessage("main.timereport.form.validation.duration.range"));
             }
             durationHours = parts[0];
@@ -285,7 +283,7 @@ public class TimereportController {
         }
 
         if (form.getSuborderId() == null) {
-            return reRenderFormWithError(model, form, ecId, date, isEdit,
+            return reRenderFormWithError(employeeContractId, model, form, ecId, date, isEdit,
                     errorCodeViewHelper.toViewMessage("main.timereport.form.validation.suborder.required"));
         }
 
@@ -337,24 +335,24 @@ public class TimereportController {
             var suborders = form.getOrderId() != null
                 ? suborderOptions(ecId, form.getOrderId(), date)
                 : List.<SuborderOption>of();
-            populateModel(model, form, orders, suborders, ecId, date, isEdit);
+            populateModel(employeeContractId, model, form, orders, suborders, ecId, date, isEdit);
             model.addAttribute("errors", errorCodeViewHelper.toViewMessages(ex));
             return "dailyreport/timereport-form";
         }
     }
 
-    private String reRenderFormWithError(Model model, TimereportForm form, long ecId, LocalDate date,
+    private String reRenderFormWithError(Long employeeContractId, Model model, TimereportForm form, long ecId, LocalDate date,
             boolean isEdit, ErrorCodeViewHelper.ViewMessage errorMessage) {
         var orders = customerorderService.getCustomerordersWithValidEmployeeOrders(ecId, date);
         var suborders = form.getOrderId() != null
             ? suborderOptions(ecId, form.getOrderId(), date)
             : List.<SuborderOption>of();
-        populateModel(model, form, orders, suborders, ecId, date, isEdit);
+        populateModel(employeeContractId, model, form, orders, suborders, ecId, date, isEdit);
         model.addAttribute("errors", List.of(errorMessage));
         return "dailyreport/timereport-form";
     }
 
-    private void populateModel(Model model, TimereportForm form, List<Customerorder> orders,
+    private void populateModel(Long employeeContractId, Model model, TimereportForm form, List<Customerorder> orders,
             List<SuborderOption> suborders, long ecId, LocalDate date, boolean isEdit) {
         boolean commentNecessary = suborders.stream()
             .filter(s -> s.id().equals(form.getSuborderId()))
@@ -367,7 +365,7 @@ public class TimereportController {
         model.addAttribute("isEdit", isEdit);
         var todaysBookings = timereportService.getTimereportsByDateAndEmployeeContractId(ecId, date);
         model.addAttribute("todaysBookings", todaysBookings);
-        model.addAttribute("recentComments", loadRecentComments(form));
+        model.addAttribute("recentComments", loadRecentComments(employeeContractId, form));
         if (!isEdit && date != null && date.equals(today())) {
             var workingday = workingdayService.getWorkingday(ecId, date);
             if (workingday != null && (workingday.getStarttimehour() > 0 || workingday.getStarttimeminute() > 0)) {
@@ -394,9 +392,9 @@ public class TimereportController {
         }
     }
 
-    private List<String> loadRecentComments(TimereportForm form) {
+    private List<String> loadRecentComments(Long employeeContractId, TimereportForm form) {
         if (form.getSuborderId() != null) {
-            long ecId = effectiveContractId();
+            long ecId = effectiveContractId(employeeContractId);
             if (ecId > 0) {
                 return timereportService.getRecentComments(ecId, form.getSuborderId());
             }
@@ -435,13 +433,14 @@ public class TimereportController {
             .toList();
     }
 
-    private long effectiveContractId() {
-        Long fromUiState = uiState.getLongValue(EmployeeUiStateKeyContributor.SELECTED_CONTRACT);
-        if (fromUiState != null && fromUiState > 0) return fromUiState;
+    private long effectiveContractId(Long employeeContractId) {
+        if (employeeContractId != null && employeeContractId > 0) {
+            return employeeContractId;
+        }
         var loginEmployee = employeeService.getLoginEmployee();
         return employeecontractService.getCurrentContract(loginEmployee.getId())
-            .map(c -> c.getId())
-            .orElse(-1L);
+                .map(Employeecontract::getId)
+                .orElse(-1L);
     }
 
     private static int[] parseTime(String hhmm) {

--- a/src/main/resources/templates/dailyreport/overtime.html
+++ b/src/main/resources/templates/dailyreport/overtime.html
@@ -100,7 +100,7 @@
 
     <!-- Recalculate — only shown when stored static overtime is stale -->
     <form th:if="${@authorizedUser.manager and overtimeMismatch != null}"
-          method="post" th:action="@{/dailyreport/overtime/correct}" class="card">
+          method="post" th:action="@{/dailyreport/overtime/correct(employeeContractId=${selectedContractId})}" class="card">
       <div class="card-body border-bottom pb-3 mb-3">
         <div class="text-muted small mb-1" th:text="#{main.overtime.mismatch.text}"></div>
         <div class="fw-semibold"

--- a/src/test/java/org/tb/common/filter/UiStateFilterTest.java
+++ b/src/test/java/org/tb/common/filter/UiStateFilterTest.java
@@ -101,6 +101,7 @@ class UiStateFilterTest {
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.setCookies(new Cookie(COOKIE_NAME, encode("_ls=alice&contract=42")));
+        req.addParameter(PARAM, "99"); // request param overrides cookie → dirty = true
         MockHttpServletResponse res = new MockHttpServletResponse();
 
         filter.doFilter(req, res, mock(FilterChain.class));
@@ -110,7 +111,20 @@ class UiStateFilterTest {
         String cookieValue = setCookie.split(";")[0].split("=", 2)[1];
         String decoded = new String(Base64.getUrlDecoder().decode(cookieValue), StandardCharsets.UTF_8);
         assertThat(decoded).contains(COOKIE_KEY_LOGIN_SIGN + "=alice");
-        assertThat(decoded).contains("contract=42");
+        assertThat(decoded).contains("contract=99");
+    }
+
+    @Test
+    void noCookieWrittenWhenStateUnchanged() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode("_ls=alice&contract=42")));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        assertThat(res.getHeader("Set-Cookie")).isNull();
     }
 
     @Test
@@ -125,6 +139,37 @@ class UiStateFilterTest {
         filter.doFilter(req, res, mock(FilterChain.class));
 
         assertThat(uiState.getValue(KEY)).isEqualTo("99");
+    }
+
+    @Test
+    void uiStateValuesExposedAsFallbackRequestParameters() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode("_ls=alice&contract=42")));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        var seenParam = new String[1];
+        filter.doFilter(req, res, (chainReq, chainRes) ->
+            seenParam[0] = ((HttpServletRequest) chainReq).getParameter(PARAM));
+
+        assertThat(seenParam[0]).isEqualTo("42");
+    }
+
+    @Test
+    void explicitRequestParamNotOverriddenByUiStateFallback() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addParameter(PARAM, "77");
+        req.setCookies(new Cookie(COOKIE_NAME, encode("_ls=alice&contract=42")));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        var seenParam = new String[1];
+        filter.doFilter(req, res, (chainReq, chainRes) ->
+            seenParam[0] = ((HttpServletRequest) chainReq).getParameter(PARAM));
+
+        assertThat(seenParam[0]).isEqualTo("77");
     }
 
     private static String encode(String plain) {


### PR DESCRIPTION
## Summary

- New `UiStateParameterRequestWrapper` wraps the `HttpServletRequest` with UiState values as fallback request parameters (only when no explicit param is present for that name)
- `UiStateFilter` Phase 3: after Phases 1+2, build the fallback map and wrap the request before passing to the filter chain
- All 7 dailyreport controllers refactored: removed `UiState` injection, added `@RequestParam(required = false) Long employeeContractId` to handler methods; `effectiveContractId`/`currentContract` helpers now take the value as a parameter
- `UiStateFilterTest` fixed (pre-existing failure from the dirty-flag cookie guard) and extended with Phase 3 wrapper tests
- ADR-0014 updated to document the new controller pattern

## Test plan

- [x] `jenv exec ./mvnw verify` passes (242 tests, 0 failures)
- [x] Navigate to Daily / Dashboard / Timereport / Matrix / Overtime / CSV — correct contract pre-selected without URL parameter
- [x] Switch contract via UI (`employeeContractId` param sent) — selection persists across navigation
- [x] Trigger an error page — UiState section appears in error detail text

Closes #732

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.