### PR TITLE
Remove HttpSession from AuthorizedUser, AuthorizedEmployee, and LocalDevSecurityConfiguration

### DIFF
--- a/src/main/java/org/tb/auth/configuration/LocalDevSecurityConfiguration.java
+++ b/src/main/java/org/tb/auth/configuration/LocalDevSecurityConfiguration.java
@@ -1,6 +1,13 @@
 package org.tb.auth.configuration;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +50,8 @@ public class LocalDevSecurityConfiguration {
   private final AuthorizedUser authorizedUser;
   private final Set<AuthViewHelper> authViewHelpers;
   private final AuthService authService;
+
+  private static final String DEV_LOGIN_COOKIE = "salat_dev_login";
 
   private static final String[] UNAUTHENTICATED_URL_PATTERNS = {
       "/*.png",
@@ -109,8 +118,8 @@ public class LocalDevSecurityConfiguration {
         .authorizeHttpRequests(authz -> authz.anyRequest().authenticated())
         .exceptionHandling(e -> e.authenticationEntryPoint((request, response, authException) -> {
           String loginName = request.getParameter("login-name");
-          Object sessionLogin = request.getSession(false) != null ? request.getSession(false).getAttribute("login-name") : null;
-          if ((loginName == null || loginName.isBlank()) && (sessionLogin == null || sessionLogin.toString().isBlank())) {
+          String cookieLogin = readLoginCookie(request);
+          if ((loginName == null || loginName.isBlank()) && (cookieLogin == null || cookieLogin.isBlank())) {
             response.sendRedirect("/?login-name=bm");
           } else {
             response.sendError(401);
@@ -131,12 +140,25 @@ public class LocalDevSecurityConfiguration {
   private AbstractPreAuthenticatedProcessingFilter preAuthenticatedProcessingFilter(AuthenticationManager authenticationManager, boolean useSession) {
     AbstractPreAuthenticatedProcessingFilter preAuthenticatedProcessingFilter = new AbstractPreAuthenticatedProcessingFilter() {
       @Override
+      public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+        if (useSession) {
+          HttpServletRequest request = (HttpServletRequest) req;
+          HttpServletResponse response = (HttpServletResponse) res;
+          String loginName = request.getParameter("login-name");
+          if (loginName != null && !loginName.isBlank()) {
+            Cookie cookie = new Cookie(DEV_LOGIN_COOKIE, loginName);
+            cookie.setPath("/");
+            response.addCookie(cookie);
+          }
+        }
+        super.doFilter(req, res, chain);
+      }
+
+      @Override
       protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
         String loginName = request.getParameter("login-name");
-        if(loginName == null && useSession) {
-          loginName = (String) request.getSession().getAttribute("login-name");
-        } else if(useSession) {
-          request.getSession().setAttribute("login-name", loginName);
+        if (loginName == null && useSession) {
+          loginName = readLoginCookie(request);
         }
         return loginName;
       }
@@ -149,6 +171,18 @@ public class LocalDevSecurityConfiguration {
     preAuthenticatedProcessingFilter.setAuthenticationManager(authenticationManager);
     preAuthenticatedProcessingFilter.setCheckForPrincipalChanges(true);
     return preAuthenticatedProcessingFilter;
+  }
+
+  private static String readLoginCookie(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (DEV_LOGIN_COOKIE.equals(cookie.getName())) {
+          return cookie.getValue();
+        }
+      }
+    }
+    return null;
   }
 
   @Bean

--- a/src/main/java/org/tb/auth/configuration/LocalDevSecurityConfiguration.java
+++ b/src/main/java/org/tb/auth/configuration/LocalDevSecurityConfiguration.java
@@ -148,6 +148,7 @@ public class LocalDevSecurityConfiguration {
           if (loginName != null && !loginName.isBlank()) {
             Cookie cookie = new Cookie(DEV_LOGIN_COOKIE, loginName);
             cookie.setPath("/");
+            cookie.setSecure(true);
             response.addCookie(cookie);
           }
         }

--- a/src/main/java/org/tb/auth/domain/AuthUiStateKeyContributor.java
+++ b/src/main/java/org/tb/auth/domain/AuthUiStateKeyContributor.java
@@ -1,0 +1,26 @@
+package org.tb.auth.domain;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import org.tb.common.web.SensitiveUiStateKey;
+import org.tb.common.web.UiStateKey;
+import org.tb.common.web.UiStateKeyContributor;
+
+@Component
+public class AuthUiStateKeyContributor implements UiStateKeyContributor {
+
+    public static final SensitiveUiStateKey IMPERSONATE_LOGIN_SIGN =
+        new SensitiveUiStateKey("impersonateLoginSign");
+
+    @Override
+    public Map<String, UiStateKey> getParamToKeyMappings() {
+        return Map.of();
+    }
+
+    @Override
+    public Collection<UiStateKey> getAllKeys() {
+        return Set.of(IMPERSONATE_LOGIN_SIGN);
+    }
+}

--- a/src/main/java/org/tb/auth/domain/AuthUiStateKeyContributor.java
+++ b/src/main/java/org/tb/auth/domain/AuthUiStateKeyContributor.java
@@ -14,6 +14,9 @@ public class AuthUiStateKeyContributor implements UiStateKeyContributor {
     public static final SensitiveUiStateKey IMPERSONATE_LOGIN_SIGN =
         new SensitiveUiStateKey("impersonateLoginSign");
 
+    public static final SensitiveUiStateKey IMPERSONATE_LOGIN_STATUS =
+        new SensitiveUiStateKey("impersonateLoginStatus");
+
     @Override
     public Map<String, UiStateKey> getParamToKeyMappings() {
         return Map.of();
@@ -21,6 +24,6 @@ public class AuthUiStateKeyContributor implements UiStateKeyContributor {
 
     @Override
     public Collection<UiStateKey> getAllKeys() {
-        return Set.of(IMPERSONATE_LOGIN_SIGN);
+        return Set.of(IMPERSONATE_LOGIN_SIGN, IMPERSONATE_LOGIN_STATUS);
     }
 }

--- a/src/main/java/org/tb/auth/domain/AuthorizedUser.java
+++ b/src/main/java/org/tb/auth/domain/AuthorizedUser.java
@@ -1,84 +1,119 @@
 package org.tb.auth.domain;
 
-import static org.springframework.web.context.WebApplicationContext.SCOPE_SESSION;
 import static org.tb.common.GlobalConstants.EMPLOYEE_STATUS_ADM;
 import static org.tb.common.GlobalConstants.EMPLOYEE_STATUS_BL;
 import static org.tb.common.GlobalConstants.EMPLOYEE_STATUS_BO;
+import static org.tb.common.GlobalConstants.EMPLOYEE_STATUS_MA;
 import static org.tb.common.GlobalConstants.EMPLOYEE_STATUS_PV;
+import static org.tb.common.GlobalConstants.EMPLOYEE_STATUS_RESTRICTED;
 
-import java.io.Serializable;
-import java.util.Objects;
-
-import lombok.Getter;
-import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 import org.tb.common.web.LoginSignProvider;
+import org.tb.common.web.UiState;
 
-// ADR-0013: Ausnahme — session-scoped Bean für Sicherheits- und Identitätszustand des eingeloggten
-// Nutzers (Rollen, Login-Kennung). Session-Scope ist hier korrekt; dies ist kein UI-Selektionszustand.
-// Die Impersonation (impersonate/login) ist ebenfalls erlaubt: sie ist ein Identitätswechsel für
-// Support-Zwecke, kein UI-Zustand der per URL oder Cookie ausgedrückt werden könnte.
 @Component
-@Scope(value = SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
-@Getter
-public class AuthorizedUser implements Serializable, LoginSignProvider {
+@RequestScope(proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class AuthorizedUser implements LoginSignProvider {
 
-  private static final long serialVersionUID = 1L;
+    private final UiState uiState;
 
-  private boolean authenticated;
-  private String loginSign;
-  private String loginStatus;
-  private boolean restricted;
-  private boolean backoffice;
-  private boolean admin;
-  private boolean manager;
-  private boolean peopleLead;
+    // Set only during scheduled job execution (no HTTP request / no SecurityContext available).
+    private boolean jobMode = false;
+    private boolean jobAuthenticated;
+    private String jobLoginSign;
+    private String jobLoginStatus;
+    private boolean jobRestricted;
+    private boolean jobAdmin;
+    private boolean jobManager;
+    private boolean jobPeopleLead;
+    private boolean jobBackoffice;
 
-  private String impersonateLoginSign;
-
-  public String getEffectiveLoginSign() {
-    return impersonateLoginSign != null ? impersonateLoginSign : loginSign;
-  }
-
-  public void impersonate(SalatUser user) {
-    this.impersonateLoginSign = user.getLoginname();
-    setPermissions(user);
-    if(Objects.equals(loginSign, impersonateLoginSign)) {
-      impersonateLoginSign = null;
+    public AuthorizedUser(UiState uiState) {
+        this.uiState = uiState;
     }
-  }
 
-  public void login(SalatUser user) {
-    this.loginSign = user.getLoginname();
-    this.impersonateLoginSign = null;
-    this.authenticated = true;
-    setPermissions(user);
-  }
+    public void initForJob() {
+        jobMode = true;
+        jobAuthenticated = true;
+        jobLoginSign = "SYSTEM";
+        jobLoginStatus = "job";
+        jobRestricted = false;
+        jobAdmin = false;
+        jobManager = true;
+        jobPeopleLead = true;
+        jobBackoffice = true;
+    }
 
-  public void initForJob() {
-    authenticated = true;
-    loginSign = "SYSTEM";
-    loginStatus = "job";
-    restricted = false;
-    admin = false;
-    manager = true;
-    peopleLead = true;
-    backoffice = true;
-    impersonateLoginSign = null;
-  }
+    public boolean isAuthenticated() {
+        if (jobMode) return jobAuthenticated;
+        Authentication auth = getAuth();
+        return auth != null && auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken);
+    }
 
-  private void setPermissions(SalatUser user) {
-    this.restricted = user.isRestricted();
-    this.loginStatus = user.getStatus();
-    boolean isAdmin = loginStatus.equals(EMPLOYEE_STATUS_ADM);
-    this.admin = isAdmin;
-    boolean isManager = loginStatus.equals(EMPLOYEE_STATUS_BL);
-    this.manager = isAdmin || isManager;
-    boolean isPeopleLead = loginStatus.equals(EMPLOYEE_STATUS_PV);
-    this.peopleLead = isAdmin || isManager || isPeopleLead;
-    boolean isBackoffice = loginStatus.equals(EMPLOYEE_STATUS_BO);
-    this.backoffice = isBackoffice || isManager || isAdmin;
-  }
+    public String getLoginSign() {
+        if (jobMode) return jobLoginSign;
+        Authentication auth = getAuth();
+        return auth != null ? auth.getName() : null;
+    }
 
+    public String getImpersonateLoginSign() {
+        if (jobMode) return null;
+        return uiState.getValue(AuthUiStateKeyContributor.IMPERSONATE_LOGIN_SIGN);
+    }
+
+    @Override
+    public String getEffectiveLoginSign() {
+        String impersonate = getImpersonateLoginSign();
+        return impersonate != null ? impersonate : getLoginSign();
+    }
+
+    public String getLoginStatus() {
+        if (jobMode) return jobLoginStatus;
+        if (hasAuthority("ROLE_ADMIN")) return EMPLOYEE_STATUS_ADM;
+        if (hasAuthority("ROLE_MANAGER")) return EMPLOYEE_STATUS_BL;
+        if (hasAuthority("ROLE_PEOPLE_LEAD")) return EMPLOYEE_STATUS_PV;
+        if (hasAuthority("ROLE_BACKOFFICE")) return EMPLOYEE_STATUS_BO;
+        if (hasAuthority("ROLE_RESTRICTED")) return EMPLOYEE_STATUS_RESTRICTED;
+        return EMPLOYEE_STATUS_MA;
+    }
+
+    public boolean isRestricted() {
+        if (jobMode) return jobRestricted;
+        return hasAuthority("ROLE_RESTRICTED");
+    }
+
+    public boolean isAdmin() {
+        if (jobMode) return jobAdmin;
+        return hasAuthority("ROLE_ADMIN");
+    }
+
+    public boolean isManager() {
+        if (jobMode) return jobManager;
+        return hasAuthority("ROLE_MANAGER");
+    }
+
+    public boolean isPeopleLead() {
+        if (jobMode) return jobPeopleLead;
+        return hasAuthority("ROLE_PEOPLE_LEAD");
+    }
+
+    public boolean isBackoffice() {
+        if (jobMode) return jobBackoffice;
+        return hasAuthority("ROLE_BACKOFFICE");
+    }
+
+    private Authentication getAuth() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    private boolean hasAuthority(String role) {
+        Authentication auth = getAuth();
+        return auth != null && auth.getAuthorities().stream()
+            .anyMatch(ga -> role.equals(ga.getAuthority()));
+    }
 }

--- a/src/main/java/org/tb/auth/domain/AuthorizedUser.java
+++ b/src/main/java/org/tb/auth/domain/AuthorizedUser.java
@@ -74,6 +74,8 @@ public class AuthorizedUser implements LoginSignProvider {
 
     public String getLoginStatus() {
         if (jobMode) return jobLoginStatus;
+        String impersonateStatus = getImpersonateLoginStatus();
+        if (impersonateStatus != null) return impersonateStatus;
         if (hasAuthority("ROLE_ADMIN")) return EMPLOYEE_STATUS_ADM;
         if (hasAuthority("ROLE_MANAGER")) return EMPLOYEE_STATUS_BL;
         if (hasAuthority("ROLE_PEOPLE_LEAD")) return EMPLOYEE_STATUS_PV;
@@ -84,27 +86,54 @@ public class AuthorizedUser implements LoginSignProvider {
 
     public boolean isRestricted() {
         if (jobMode) return jobRestricted;
+        String impersonateStatus = getImpersonateLoginStatus();
+        if (impersonateStatus != null) return EMPLOYEE_STATUS_RESTRICTED.equalsIgnoreCase(impersonateStatus);
         return hasAuthority("ROLE_RESTRICTED");
     }
 
     public boolean isAdmin() {
         if (jobMode) return jobAdmin;
+        String impersonateStatus = getImpersonateLoginStatus();
+        if (impersonateStatus != null) return EMPLOYEE_STATUS_ADM.equalsIgnoreCase(impersonateStatus);
         return hasAuthority("ROLE_ADMIN");
     }
 
     public boolean isManager() {
         if (jobMode) return jobManager;
+        String impersonateStatus = getImpersonateLoginStatus();
+        if (impersonateStatus != null) {
+            return EMPLOYEE_STATUS_ADM.equalsIgnoreCase(impersonateStatus)
+                || EMPLOYEE_STATUS_BL.equalsIgnoreCase(impersonateStatus);
+        }
         return hasAuthority("ROLE_MANAGER");
     }
 
     public boolean isPeopleLead() {
         if (jobMode) return jobPeopleLead;
+        String impersonateStatus = getImpersonateLoginStatus();
+        if (impersonateStatus != null) {
+            return EMPLOYEE_STATUS_ADM.equalsIgnoreCase(impersonateStatus)
+                || EMPLOYEE_STATUS_BL.equalsIgnoreCase(impersonateStatus)
+                || EMPLOYEE_STATUS_PV.equalsIgnoreCase(impersonateStatus);
+        }
         return hasAuthority("ROLE_PEOPLE_LEAD");
     }
 
     public boolean isBackoffice() {
         if (jobMode) return jobBackoffice;
+        String impersonateStatus = getImpersonateLoginStatus();
+        if (impersonateStatus != null) {
+            return EMPLOYEE_STATUS_ADM.equalsIgnoreCase(impersonateStatus)
+                || EMPLOYEE_STATUS_BL.equalsIgnoreCase(impersonateStatus)
+                || EMPLOYEE_STATUS_BO.equalsIgnoreCase(impersonateStatus);
+        }
         return hasAuthority("ROLE_BACKOFFICE");
+    }
+
+    private String getImpersonateLoginStatus() {
+        if (jobMode) return null;
+        if (getImpersonateLoginSign() == null) return null;
+        return uiState.getValue(AuthUiStateKeyContributor.IMPERSONATE_LOGIN_STATUS);
     }
 
     private Authentication getAuth() {

--- a/src/main/java/org/tb/auth/service/AuthService.java
+++ b/src/main/java/org/tb/auth/service/AuthService.java
@@ -23,9 +23,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.tb.auth.domain.AccessLevel;
+import org.tb.auth.domain.AuthUiStateKeyContributor;
 import org.tb.auth.domain.Authorized;
 import org.tb.auth.domain.AuthorizedUser;
 import org.tb.auth.event.AuthorizedUserChangedEvent;
@@ -34,6 +34,7 @@ import org.tb.auth.persistence.SalatUserRepository;
 import org.tb.common.LocalDateRange;
 import org.tb.common.SalatProperties;
 import org.tb.common.exception.AuthorizationException;
+import org.tb.common.web.UiState;
 
 @Service
 @RequiredArgsConstructor
@@ -46,6 +47,7 @@ public class AuthService {
   private final SalatUserRepository salatUserRepository;
   private final SalatProperties salatProperties;
   private final ApplicationEventPublisher applicationEventPublisher;
+  private final UiState uiState;
 
   private long cacheExpiryMillis;
   private Map<String, Set<Rule>> cacheEntries = new HashMap<>();
@@ -58,27 +60,19 @@ public class AuthService {
 
   @EventListener
   public void onApplicationEvent(AuthenticationSuccessEvent event) {
-    Authentication authentication = event.getAuthentication();
-    if(!authorizedUser.isAuthenticated() || !authorizedUser.getLoginSign().equals(authentication.getName())) {
-      var loginname = authentication.getName();
-      var user = salatUserRepository.findByLoginname(loginname).orElseThrow();
-      authorizedUser.login(user);
-      applicationEventPublisher.publishEvent(new AuthorizedUserChangedEvent(this));
-    } else {
-      // already logged in
-    }
+    applicationEventPublisher.publishEvent(new AuthorizedUserChangedEvent(this));
   }
 
   @Authorized
   public void switchLogin(String loginname) {
-    // check if switch login is allowed
-    if(!authorizedUser.getLoginSign().equals(loginname)) {
-      if(!isAuthorizedAnyObject(loginname, "EMPLOYEE", today(), LOGIN, true)) {
+    if (!authorizedUser.getLoginSign().equals(loginname)) {
+      if (!isAuthorizedAnyObject(loginname, "EMPLOYEE", today(), LOGIN, true)) {
         throw new AuthorizationException(AA_NOT_ATHORIZED);
       }
+      uiState.setValue(AuthUiStateKeyContributor.IMPERSONATE_LOGIN_SIGN, loginname);
+    } else {
+      uiState.clearState(AuthUiStateKeyContributor.IMPERSONATE_LOGIN_SIGN);
     }
-    var user = salatUserRepository.findByLoginname(loginname).orElseThrow();
-    authorizedUser.impersonate(user);
     applicationEventPublisher.publishEvent(new AuthorizedUserChangedEvent(this));
   }
 

--- a/src/main/java/org/tb/auth/service/AuthService.java
+++ b/src/main/java/org/tb/auth/service/AuthService.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.tb.auth.domain.AccessLevel;
 import org.tb.auth.domain.AuthUiStateKeyContributor;
@@ -60,6 +61,7 @@ public class AuthService {
 
   @EventListener
   public void onApplicationEvent(AuthenticationSuccessEvent event) {
+    SecurityContextHolder.getContext().setAuthentication(event.getAuthentication()); // ensure Security Context is set
     applicationEventPublisher.publishEvent(new AuthorizedUserChangedEvent(this));
   }
 

--- a/src/main/java/org/tb/auth/service/AuthService.java
+++ b/src/main/java/org/tb/auth/service/AuthService.java
@@ -72,8 +72,10 @@ public class AuthService {
         throw new AuthorizationException(AA_NOT_ATHORIZED);
       }
       uiState.setValue(AuthUiStateKeyContributor.IMPERSONATE_LOGIN_SIGN, loginname);
+      uiState.setValue(AuthUiStateKeyContributor.IMPERSONATE_LOGIN_STATUS, getStatusByLoginname(loginname));
     } else {
       uiState.clearState(AuthUiStateKeyContributor.IMPERSONATE_LOGIN_SIGN);
+      uiState.clearState(AuthUiStateKeyContributor.IMPERSONATE_LOGIN_STATUS);
     }
     applicationEventPublisher.publishEvent(new AuthorizedUserChangedEvent(this));
   }

--- a/src/main/java/org/tb/common/SalatProperties.java
+++ b/src/main/java/org/tb/common/SalatProperties.java
@@ -16,6 +16,7 @@ public class SalatProperties {
   private String apiDocsUrl;
   private Auth auth;
   private AuthService authService;
+  private UiState uiState = new UiState();
 
   @Data
   public static class Auth {
@@ -46,6 +47,11 @@ public class SalatProperties {
   @Data
   public static class AuthService {
     private Duration cacheExpiry;
+  }
+
+  @Data
+  public static class UiState {
+    private String signingKey;
   }
 
 }

--- a/src/main/java/org/tb/common/filter/UiStateFilter.java
+++ b/src/main/java/org/tb/common/filter/UiStateFilter.java
@@ -1,5 +1,6 @@
 package org.tb.common.filter;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -7,18 +8,23 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.UUID;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingResponseWrapper;
+import org.tb.common.SalatProperties;
 import org.tb.common.web.LoginSignProvider;
+import org.tb.common.web.SensitiveUiStateKey;
 import org.tb.common.web.UiState;
 import org.tb.common.web.UiStateKey;
 import org.tb.common.web.UiStateKeyRegistry;
@@ -43,6 +49,18 @@ public class UiStateFilter extends OncePerRequestFilter {
     private final UiState uiState;
     private final UiStateKeyRegistry uiStateKeyRegistry;
     private final LoginSignProvider loginSignProvider;
+    private final SalatProperties salatProperties;
+
+    private byte[] signingKeyBytes;
+
+    @PostConstruct
+    void initSigningKey() {
+        String configured = salatProperties.getUiState() != null
+            ? salatProperties.getUiState().getSigningKey() : null;
+        String key = (configured != null && !configured.isBlank())
+            ? configured : UUID.randomUUID().toString();
+        signingKeyBytes = key.getBytes(StandardCharsets.UTF_8);
+    }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -58,7 +76,9 @@ public class UiStateFilter extends OncePerRequestFilter {
 
         // Phase 1: fill slots from the cookie, but only when the stored
         // login sign matches the current effective login sign (guards against stale state
-        // left behind by a previous user or an impersonation switch).
+        // left behind by a previous user). At this point UiState is empty, so
+        // getEffectiveLoginSign() returns the base login sign from SecurityContextHolder,
+        // which is what we store in _ls (not the impersonated sign).
         String effectiveLoginSign = loginSignProvider.getEffectiveLoginSign();
         Cookie[] cookies = req.getCookies();
         if (cookies != null) {
@@ -67,12 +87,20 @@ public class UiStateFilter extends OncePerRequestFilter {
                     Map<String, String> parsed = parseCookieValue(c.getValue());
                     String storedLoginSign = parsed.get(COOKIE_KEY_LOGIN_SIGN);
                     if (effectiveLoginSign != null) {
-                        if(effectiveLoginSign.equals(storedLoginSign)) {
-                            parsed.forEach((keyName, value) ->
-                                    uiStateKeyRegistry.findByName(keyName).ifPresent(key -> {
-                                        uiState.setValue(key, value);
-                                    })
-                            );
+                        if (effectiveLoginSign.equals(storedLoginSign)) {
+                            parsed.forEach((keyName, value) -> {
+                                if (keyName.startsWith("_sig_")) return;
+                                uiStateKeyRegistry.findByName(keyName).ifPresent(key -> {
+                                    if (key instanceof SensitiveUiStateKey) {
+                                        String storedSig = parsed.get("_sig_" + keyName);
+                                        if (storedSig == null) return;
+                                        byte[] expected = computeHmacBytes(keyName, value);
+                                        byte[] actual = Base64.getUrlDecoder().decode(storedSig);
+                                        if (!MessageDigest.isEqual(expected, actual)) return;
+                                    }
+                                    uiState.setValue(key, value);
+                                });
+                            });
                         } else {
                             dirty = true;
                         }
@@ -83,7 +111,7 @@ public class UiStateFilter extends OncePerRequestFilter {
         }
 
         // Phase 2: explicit request params take precedence (override cookie value)
-        for(var entry : uiStateKeyRegistry.getParamToKey().entrySet()) {
+        for (var entry : uiStateKeyRegistry.getParamToKey().entrySet()) {
             var param = entry.getKey();
             var key = entry.getValue();
             String raw = req.getParameter(param);
@@ -107,26 +135,32 @@ public class UiStateFilter extends OncePerRequestFilter {
         chain.doFilter(wrappedReq, bufferingRes);
 
         // Write cookie after the chain so any UiState mutations (e.g. clearState) are captured.
-        // BufferingResponseWrapper suppresses all commits, so the response is always uncommitted
-        // here and the Set-Cookie header can always be added.
+        // Always write when state changed (including to empty) so the browser cookie is cleared.
         Map<UiStateKey, String> stateAfterChain = uiState.getAll();
-        if (dirty || !stateAfterChain.equals(stateBeforeChain)) {
-            if (!stateAfterChain.isEmpty()) {
-                writeCookie(bufferingRes, buildCookieValue(stateAfterChain, effectiveLoginSign));
-            }
+        if ((dirty || !stateAfterChain.equals(stateBeforeChain)) && effectiveLoginSign != null) {
+            writeCookie(bufferingRes, buildCookieValue(stateAfterChain, effectiveLoginSign));
         }
         bufferingRes.writeAndCommit();
     }
 
     private String buildCookieValue(Map<UiStateKey, String> all, String loginSign) {
-        String statePart = all.entrySet().stream()
-            .map(e -> e.getKey().getName() + "=" + e.getValue())
-            .collect(Collectors.joining("&"));
-        String plain = loginSign != null
-            ? COOKIE_KEY_LOGIN_SIGN + "=" + loginSign + "&" + statePart
-            : statePart;
+        StringBuilder sb = new StringBuilder();
+        if (loginSign != null) {
+            sb.append(COOKIE_KEY_LOGIN_SIGN).append("=").append(loginSign);
+        }
+        for (Map.Entry<UiStateKey, String> entry : all.entrySet()) {
+            String keyName = entry.getKey().getName();
+            String value = entry.getValue();
+            if (sb.length() > 0) sb.append("&");
+            sb.append(keyName).append("=").append(value);
+            if (entry.getKey() instanceof SensitiveUiStateKey) {
+                String hmac = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(computeHmacBytes(keyName, value));
+                sb.append("&_sig_").append(keyName).append("=").append(hmac);
+            }
+        }
         return Base64.getUrlEncoder().withoutPadding()
-            .encodeToString(plain.getBytes(StandardCharsets.UTF_8));
+            .encodeToString(sb.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     private Map<String, String> parseCookieValue(String raw) {
@@ -141,6 +175,16 @@ public class UiStateFilter extends OncePerRequestFilter {
             }
         } catch (IllegalArgumentException ignored) {}
         return result;
+    }
+
+    private byte[] computeHmacBytes(String keyName, String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(signingKeyBytes, "HmacSHA256"));
+            return mac.doFinal((keyName + "=" + value).getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("HMAC computation failed", e);
+        }
     }
 
     private void writeCookie(HttpServletResponse res, String value) {

--- a/src/main/java/org/tb/common/web/SensitiveUiStateKey.java
+++ b/src/main/java/org/tb/common/web/SensitiveUiStateKey.java
@@ -1,0 +1,8 @@
+package org.tb.common.web;
+
+public class SensitiveUiStateKey extends UiStateKey {
+
+    public SensitiveUiStateKey(String name) {
+        super(name);
+    }
+}

--- a/src/main/java/org/tb/common/web/UiStateKeyContributor.java
+++ b/src/main/java/org/tb/common/web/UiStateKeyContributor.java
@@ -1,5 +1,6 @@
 package org.tb.common.web;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -30,4 +31,8 @@ public interface UiStateKeyContributor {
      * in {@link UiState}.
      */
     Map<String, UiStateKey> getParamToKeyMappings();
+
+    default Collection<UiStateKey> getAllKeys() {
+        return getParamToKeyMappings().values();
+    }
 }

--- a/src/main/java/org/tb/common/web/UiStateKeyRegistry.java
+++ b/src/main/java/org/tb/common/web/UiStateKeyRegistry.java
@@ -24,7 +24,8 @@ public class UiStateKeyRegistry {
         this.paramToKey = contributors.stream()
             .flatMap(c -> c.getParamToKeyMappings().entrySet().stream())
             .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
-        this.nameToKey = paramToKey.values().stream()
+        this.nameToKey = contributors.stream()
+            .flatMap(c -> c.getAllKeys().stream())
             .collect(Collectors.toUnmodifiableMap(UiStateKey::getName, identity(), (a, b) -> a));
     }
 

--- a/src/main/java/org/tb/employee/domain/AuthorizedEmployee.java
+++ b/src/main/java/org/tb/employee/domain/AuthorizedEmployee.java
@@ -1,20 +1,15 @@
 package org.tb.employee.domain;
 
-import static org.springframework.web.context.WebApplicationContext.SCOPE_SESSION;
+import static org.springframework.web.context.WebApplicationContext.SCOPE_REQUEST;
 
-import java.io.Serializable;
 import lombok.Getter;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
-// ADR-0013: Ausnahme — session-scoped Bean für Identitätsdaten des eingeloggten Mitarbeiters
-// (Name, ID, Kennung, E-Mail). Session-Scope ist hier korrekt; dies ist kein UI-Selektionszustand.
 @Component
-@Scope(value = SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
-public class AuthorizedEmployee implements Serializable {
-
-  private static final long serialVersionUID = 1L;
+@Scope(value = SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class AuthorizedEmployee {
 
   @Getter
   private String name;

--- a/src/main/java/org/tb/employee/filter/AuthorizedEmployeeFilter.java
+++ b/src/main/java/org/tb/employee/filter/AuthorizedEmployeeFilter.java
@@ -1,0 +1,57 @@
+package org.tb.employee.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.tb.auth.domain.AuthorizedUser;
+import org.tb.employee.domain.AuthorizedEmployee;
+import org.tb.employee.service.EmployeeService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(103)
+public class AuthorizedEmployeeFilter extends OncePerRequestFilter {
+
+    private static final AntPathMatcher ANT = new AntPathMatcher();
+    private static final List<String> STATIC_PATTERNS = List.of(
+        "/images/**", "/webjars/**",
+        "/**/*.css", "/**/*.js",
+        "/**/*.gif", "/**/*.png", "/**/*.jpg", "/**/*.jpeg",
+        "/**/*.svg", "/**/*.ico",
+        "/**/*.woff", "/**/*.woff2", "/**/*.ttf", "/**/*.eot",
+        "/**/*.map", "/**/*.webp");
+
+    private final AuthorizedUser authorizedUser;
+    private final AuthorizedEmployee authorizedEmployee;
+    private final EmployeeService employeeService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        if (authorizedUser.isAuthenticated()) {
+            var employee = employeeService.getEmployeeByLoginname(authorizedUser.getEffectiveLoginSign());
+            if (employee != null) {
+                authorizedEmployee.login(employee);
+            } else {
+                log.warn("No employee found for login sign '{}'", authorizedUser.getEffectiveLoginSign());
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return STATIC_PATTERNS.stream().anyMatch(p -> ANT.match(p, path));
+    }
+}

--- a/src/main/java/org/tb/employee/listener/AuthorizedUserChangedListener.java
+++ b/src/main/java/org/tb/employee/listener/AuthorizedUserChangedListener.java
@@ -1,8 +1,5 @@
 package org.tb.employee.listener;
 
-import static org.tb.common.util.DateUtils.today;
-
-import java.time.LocalDate;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +10,6 @@ import org.springframework.web.server.ResponseStatusException;
 import org.tb.auth.domain.AuthorizedUser;
 import org.tb.auth.event.AuthorizedUserChangedEvent;
 import org.tb.common.GlobalConstants;
-import org.tb.employee.domain.AuthorizedEmployee;
 import org.tb.employee.domain.Employee;
 import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeeService;
@@ -25,7 +21,6 @@ import org.tb.employee.service.EmployeecontractService;
 public class AuthorizedUserChangedListener {
 
   private final AuthorizedUser authorizedUser;
-  private final AuthorizedEmployee authorizedEmployee;
   private final EmployeeService employeeService;
   private final EmployeecontractService employeecontractService;
 
@@ -39,14 +34,12 @@ public class AuthorizedUserChangedListener {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No matching employee found for " + authorizedUser.getEffectiveLoginSign());
     }
 
-    LocalDate today = today();
     Optional<Employeecontract> employeecontract = employeecontractService.getCurrentContract(loginEmployee.getId());
     if (employeecontract.isEmpty() && !loginEmployee.getStatus().equalsIgnoreCase(GlobalConstants.EMPLOYEE_STATUS_ADM)) {
       log.error("No valid contract found for {}.", loginEmployee.getSign());
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No valid contract found for " + loginEmployee.getSign());
     }
 
-    authorizedEmployee.login(loginEmployee);
   }
 
 }

--- a/src/main/java/org/tb/employee/service/EmployeeService.java
+++ b/src/main/java/org/tb/employee/service/EmployeeService.java
@@ -49,6 +49,10 @@ public class EmployeeService {
   private final AuthorizedUser authorizedUser;
   private final EmployeeAuthorization employeeAuthorization;
 
+  public Employee getEmployeeByLoginname(String loginname) {
+    return employeeDAO.getLoginEmployee(loginname);
+  }
+
   public Employee getLoginEmployee() {
     var loginEmployee = employeeDAO.getLoginEmployee(authorizedUser.getEffectiveLoginSign());
     var allowedLoginEmployees = getLoginEmployees();

--- a/src/test/java/org/tb/common/filter/UiStateFilterTest.java
+++ b/src/test/java/org/tb/common/filter/UiStateFilterTest.java
@@ -11,14 +11,19 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.tb.common.SalatProperties;
 import org.tb.common.web.LoginSignProvider;
+import org.tb.common.web.SensitiveUiStateKey;
 import org.tb.common.web.UiState;
 import org.tb.common.web.UiStateKey;
 import org.tb.common.web.UiStateKeyContributor;
@@ -28,6 +33,8 @@ class UiStateFilterTest {
 
     private static final UiStateKey KEY = new UiStateKey("contract");
     private static final String PARAM = "contractId";
+    private static final SensitiveUiStateKey SENSITIVE_KEY = new SensitiveUiStateKey("sensitiveKey");
+    private static final String SIGNING_KEY = "test-signing-key";
 
     private UiState uiState;
     private UiStateKeyRegistry registry;
@@ -37,10 +44,22 @@ class UiStateFilterTest {
     @BeforeEach
     void setUp() {
         uiState = new UiState();
-        UiStateKeyContributor contributor = () -> Map.of(PARAM, KEY);
+        UiStateKeyContributor contributor = new UiStateKeyContributor() {
+            @Override
+            public Map<String, UiStateKey> getParamToKeyMappings() {
+                return Map.of(PARAM, KEY);
+            }
+            @Override
+            public java.util.Collection<UiStateKey> getAllKeys() {
+                return List.of(KEY, SENSITIVE_KEY);
+            }
+        };
         registry = new UiStateKeyRegistry(List.of(contributor));
         loginSignProvider = mock(LoginSignProvider.class);
-        filter = new UiStateFilter(uiState, registry, loginSignProvider);
+        SalatProperties props = new SalatProperties();
+        props.getUiState().setSigningKey(SIGNING_KEY);
+        filter = new UiStateFilter(uiState, registry, loginSignProvider, props);
+        filter.initSigningKey();
     }
 
     @Test
@@ -182,8 +201,13 @@ class UiStateFilterTest {
 
         filter.doFilter(req, res, (chainReq, chainRes) -> uiState.clearState(KEY));
 
-        // State is now empty — no cookie should be written (nothing to persist)
-        assertThat(res.getHeader("Set-Cookie")).isNull();
+        // State was cleared — cookie IS written to remove the old value from the browser.
+        String setCookie = res.getHeader("Set-Cookie");
+        assertThat(setCookie).isNotNull();
+        String cookieValue = setCookie.split(";")[0].split("=", 2)[1];
+        String decoded = new String(Base64.getUrlDecoder().decode(cookieValue), StandardCharsets.UTF_8);
+        assertThat(decoded).contains(COOKIE_KEY_LOGIN_SIGN + "=alice");
+        assertThat(decoded).doesNotContain("contract=");
         assertThat(uiState.getValue(KEY)).isNull();
     }
 
@@ -222,8 +246,86 @@ class UiStateFilterTest {
         assertThat(decoded).contains("contract=55");
     }
 
+    @Test
+    void sensitiveCookieValueLoadedWhenHmacValid() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        String value = "bob";
+        String hmac = computeHmac("sensitiveKey", value);
+        String cookieContent = "_ls=alice&sensitiveKey=" + value + "&_sig_sensitiveKey=" + hmac;
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode(cookieContent)));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        assertThat(uiState.getValue(SENSITIVE_KEY)).isEqualTo("bob");
+    }
+
+    @Test
+    void sensitiveCookieValueRejectedWhenHmacInvalid() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        String cookieContent = "_ls=alice&sensitiveKey=bob&_sig_sensitiveKey=invalidsig";
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode(cookieContent)));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        assertThat(uiState.getValue(SENSITIVE_KEY)).isNull();
+    }
+
+    @Test
+    void sensitiveCookieValueRejectedWhenHmacMissing() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        String cookieContent = "_ls=alice&sensitiveKey=bob";
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(COOKIE_NAME, encode(cookieContent)));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, mock(FilterChain.class));
+
+        assertThat(uiState.getValue(SENSITIVE_KEY)).isNull();
+    }
+
+    @Test
+    void sensitiveCookieValueWrittenWithHmac() throws Exception {
+        when(loginSignProvider.getEffectiveLoginSign()).thenReturn("alice");
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, (chainReq, chainRes) -> uiState.setValue(SENSITIVE_KEY, "secret"));
+
+        String setCookie = res.getHeader("Set-Cookie");
+        assertThat(setCookie).isNotNull();
+        String cookieValue = setCookie.split(";")[0].split("=", 2)[1];
+        String decoded = new String(Base64.getUrlDecoder().decode(cookieValue), StandardCharsets.UTF_8);
+        assertThat(decoded).contains("sensitiveKey=secret");
+        assertThat(decoded).contains("_sig_sensitiveKey=");
+
+        String expectedHmac = computeHmac("sensitiveKey", "secret");
+        assertThat(decoded).contains("_sig_sensitiveKey=" + expectedHmac);
+    }
+
     private static String encode(String plain) {
         return Base64.getUrlEncoder().withoutPadding()
             .encodeToString(plain.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String computeHmac(String keyName, String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(SIGNING_KEY.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] raw = mac.doFinal((keyName + "=" + value).getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(raw);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/org/tb/employee/EmployeecontractServiceTest.java
+++ b/src/test/java/org/tb/employee/EmployeecontractServiceTest.java
@@ -49,6 +49,9 @@ public class EmployeecontractServiceTest {
 	@MockitoBean
 	private AuthorizedUser authorizedUser;
 
+	@MockitoBean
+	private org.tb.common.web.UiState uiState;
+
 	@BeforeEach
 	public void initAuthorizedUser() {
 		when(authorizedUser.isAuthenticated()).thenReturn(true);

--- a/src/test/java/org/tb/employee/service/EmployeeServiceTest.java
+++ b/src/test/java/org/tb/employee/service/EmployeeServiceTest.java
@@ -45,6 +45,9 @@ public class EmployeeServiceTest {
 	@MockitoBean
 	private AuthorizedUser authorizedUser;
 
+	@MockitoBean
+	private org.tb.common.web.UiState uiState;
+
 	@BeforeEach
 	public void initAuthorizedUser() {
 		when(authorizedUser.isAuthenticated()).thenReturn(true);

--- a/src/test/java/org/tb/reporting/service/ReportServiceTest.java
+++ b/src/test/java/org/tb/reporting/service/ReportServiceTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.context.TestExecutionListeners.MergeMode.
 import static org.tb.common.GlobalConstants.EMPLOYEE_STATUS_BL;
 
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -12,13 +13,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.tb.auth.domain.AuthUiStateKeyContributor;
 import org.tb.auth.domain.AuthorizedUser;
-import org.tb.auth.domain.SalatUser;
 import org.tb.auth.service.AuthService;
 import org.tb.common.GlobalConstants;
 import org.tb.common.SalatProperties;
+import org.tb.common.web.UiState;
 import org.tb.employee.domain.Employee;
 import org.tb.employee.persistence.EmployeeRepository;
 import org.tb.reporting.auth.ReportAuthorization;
@@ -26,7 +31,9 @@ import org.tb.reporting.domain.ReportParameter;
 import org.tb.testutils.WebContextTestExecutionListener;
 
 @DataJpaTest
-@Import({ReportService.class, AuthorizedUser.class, AuthService.class, SalatProperties.class, ReportAuthorization.class, ReportParameterResolver.class})
+@Import({ReportService.class, AuthorizedUser.class, AuthService.class, SalatProperties.class,
+    ReportAuthorization.class, ReportParameterResolver.class, UiState.class,
+    AuthUiStateKeyContributor.class})
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @EnableJpaRepositories
 @WebAppConfiguration
@@ -39,16 +46,25 @@ public class ReportServiceTest {
   @Autowired
   private EmployeeRepository employeeRepository;
 
-  @Autowired
-  private AuthorizedUser authorizedUser;
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void loginAsManager(String loginname) {
+    var authorities = List.of(
+        new SimpleGrantedAuthority("ROLE_USER"),
+        new SimpleGrantedAuthority("ROLE_MANAGER"),
+        new SimpleGrantedAuthority("ROLE_PEOPLE_LEAD"),
+        new SimpleGrantedAuthority("ROLE_BACKOFFICE")
+    );
+    SecurityContextHolder.getContext().setAuthentication(
+        new UsernamePasswordAuthenticationToken(loginname, "N/A", authorities));
+  }
 
   @Test
   public void should_get_report_definitions() {
-    var manager = new SalatUser();
-    manager.setLoginname("test");
-    manager.setRestricted(false);
-    manager.setStatus(EMPLOYEE_STATUS_BL);
-    authorizedUser.login(manager);
+    loginAsManager("test");
 
     var defs = reportService.getReportDefinitions();
     assertThat(defs).isEmpty();
@@ -62,11 +78,7 @@ public class ReportServiceTest {
 
   @Test
   public void should_execute_report_definitions_without_parameters() {
-    var manager = new SalatUser();
-    manager.setLoginname("test");
-    manager.setRestricted(false);
-    manager.setStatus(EMPLOYEE_STATUS_BL);
-    authorizedUser.login(manager);
+    loginAsManager("test");
 
     var defs = reportService.getReportDefinitions();
     assertThat(defs).isEmpty();
@@ -79,11 +91,7 @@ public class ReportServiceTest {
 
   @Test
   public void should_execute_report_definitions_with_parameters_1() {
-    var manager = new SalatUser();
-    manager.setLoginname("test");
-    manager.setRestricted(false);
-    manager.setStatus(EMPLOYEE_STATUS_BL);
-    authorizedUser.login(manager);
+    loginAsManager("test");
 
     Employee employee = new Employee();
     employee.setFirstname("Klaus");
@@ -112,11 +120,7 @@ public class ReportServiceTest {
 
   @Test
   public void should_execute_report_definitions_with_parameters_2() {
-    var manager = new SalatUser();
-    manager.setLoginname("test");
-    manager.setRestricted(false);
-    manager.setStatus(EMPLOYEE_STATUS_BL);
-    authorizedUser.login(manager);
+    loginAsManager("test");
 
     Employee employee = new Employee();
     employee.setFirstname("Klaus");
@@ -148,11 +152,7 @@ public class ReportServiceTest {
 
   @Test
   public void should_respect_alias_names_in_queries() {
-    var manager = new SalatUser();
-    manager.setLoginname("test");
-    manager.setRestricted(false);
-    manager.setStatus(EMPLOYEE_STATUS_BL);
-    authorizedUser.login(manager);
+    loginAsManager("test");
 
     var defs = reportService.getReportDefinitions();
     assertThat(defs).isEmpty();
@@ -167,11 +167,7 @@ public class ReportServiceTest {
 
   @Test
   public void should_execute_report_with_duplicate_column_and_different_alias() {
-    var manager = new SalatUser();
-    manager.setLoginname("test");
-    manager.setRestricted(false);
-    manager.setStatus(EMPLOYEE_STATUS_BL);
-    authorizedUser.login(manager);
+    loginAsManager("test");
 
     Employee employee = new Employee();
     employee.setSign("kr");


### PR DESCRIPTION
## Summary

- **Part 1**: Replace `HttpSession` with a cookie (`salat_dev_login`) in `LocalDevSecurityConfiguration` for local-dev login persistence
- **Part 2**: Make `AuthorizedUser` `@RequestScope`; derive all fields from `SecurityContextHolder`; store impersonation sign + status as HMAC-signed entries in the `salat_uistate` cookie via `UiStateFilter`
- **Part 3**: Make `AuthorizedEmployee` `@RequestScope`; populate it on every request via a new `AuthorizedEmployeeFilter` (`@Order(103)`, after `UiStateFilter`) in the `employee` module; remove `authorizedEmployee.login()` from `AuthorizedUserChangedListener` (validation logic retained)

## Key design decisions

- `IMPERSONATE_LOGIN_SIGN` and `IMPERSONATE_LOGIN_STATUS` are `SensitiveUiStateKey` entries — both HMAC-signed in the cookie to prevent privilege escalation via cookie tampering
- `AuthorizedEmployeeFilter` uses a lightweight `EmployeeService.getEmployeeByLoginname()` (no authorization gate, no full employee list scan) since it runs on every request
- `AuthorizedUserChangedListener` keeps the employee/contract existence validation (throws 403 on missing employee or contract) but no longer populates `AuthorizedEmployee`
- `SecurityContextHolder` is explicitly set in `AuthService.onApplicationEvent` before publishing `AuthorizedUserChangedEvent` to ensure the context is available in the listener

## Test plan

- [x] All 249 existing tests pass (`./mvnw verify`)
- [x] `UiStateFilterTest` covers HMAC signing/validation for sensitive keys
- [x] `ArchitectureTest` passes — `auth` module still only accesses `common`/`auth`; no cycles introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)