### PR TITLE
Add zizmor workflow and update all GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
     open-pull-requests-limit: 20
     schedule:
       interval: "daily"
+    cooldown: # Wait before adopting freshly published versions (supply-chain hygiene)
+      default-days: 7
+  - package-ecosystem: "github-actions" # Keep SHA-pinned action versions current
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -9,33 +9,44 @@ on:
       - reopened
       - synchronize
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: hbtgmbh/salat
 
 jobs:
   build:
+    name: Build and publish
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: read   # checkout the repository
+      packages: write  # push the image to GHCR
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5
         with:
           distribution: temurin
           java-version: '25'
-          cache: maven
+          # Maven dependency cache. Accepted risk: publish steps are gated to tag
+          # pushes, so a PR cannot poison a cache used by a release build.
+          cache: maven  # zizmor: ignore[cache-poisoning]
 
       - name: Log in to Container Registry
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -49,18 +60,20 @@ jobs:
 
       - name: Build Docker image with Paketo
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        env:
+          IMAGE_TAG: ${{ github.run_number }}
         run: |
           ./mvnw spring-boot:build-image \
             --batch-mode \
             --no-transfer-progress \
             -DskipTests \
-            -Dsalat.image.name=${{ env.IMAGE_NAME }} \
-            -Dsalat.image.tag=${{ github.run_number }}
+            -Dsalat.image.name="$IMAGE_NAME" \
+            -Dsalat.image.tag="$IMAGE_TAG"
 
       - name: Extract metadata
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -70,9 +83,11 @@ jobs:
 
       - name: Push Docker image
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          SOURCE_IMAGE: ${{ env.IMAGE_NAME }}:${{ github.run_number }}
         run: |
-          TAGS="${{ steps.meta.outputs.tags }}"
           while IFS= read -r tag; do
-            docker tag ${{ env.IMAGE_NAME }}:${{ github.run_number }} "$tag"
+            docker tag "$SOURCE_IMAGE" "$tag"
             docker push "$tag"
           done <<< "$TAGS"

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -28,15 +28,15 @@ jobs:
       packages: write  # push the image to GHCR
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5.3.0
         with:
           distribution: temurin
           java-version: '25'
@@ -46,7 +46,7 @@ jobs:
 
       - name: Log in to Container Registry
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -73,7 +73,7 @@ jobs:
       - name: Extract metadata
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -17,7 +17,6 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: hbtgmbh/salat
 
 jobs:
   build:
@@ -31,6 +30,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
+
+      - name: Resolve image name
+        # Derive owner/repo from the repo coordinates, lowercased (GHCR requires
+        # lowercase; github.repository preserves the original casing).
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,15 +8,21 @@ on:
   schedule:
     - cron: '0 2 * * 0'
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read           # resolve workflow run metadata for analysis
+      contents: read          # checkout the repository
+      security-events: write  # upload CodeQL results to code scanning
 
     strategy:
       fail-fast: false
@@ -25,17 +31,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5
         with:
           distribution: 'temurin'
           java-version: '25'
           cache: 'maven'  # Speed up builds
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           languages: ${{ matrix.language }}
 
@@ -43,6 +51,6 @@ jobs:
         run: ./mvnw clean package -DskipTests
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           upload: true  # Explicit upload to GitHub Security tab

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,19 +31,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 
       - name: Set up JDK 25
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5.3.0
         with:
           distribution: 'temurin'
           java-version: '25'
           cache: 'maven'  # Speed up builds
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           languages: ${{ matrix.language }}
 
@@ -51,6 +51,6 @@ jobs:
         run: ./mvnw clean package -DskipTests
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           upload: true  # Explicit upload to GitHub Security tab

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,34 @@
+name: GitHub Actions Security
+
+on:
+  push:
+    branches: [main]
+    paths: [".github/**"]
+  pull_request:
+    branches: [main]
+    paths: [".github/**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Audit workflows
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload zizmor findings to code scanning
+      contents: read          # checkout the workflows to audit
+      actions: read           # resolve referenced actions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa  # v0.5.7
+        with:
+          version: v1.26.1
+          persona: pedantic


### PR DESCRIPTION
### Changes

1. Introduce [zizmor](https://github.com/zizmorcore/zizmor), a static analysis tool for Github actions as well as the dependabot.yml to fix security issues/vulnerabilities/misconfigurations
2. Pin GitHub actions versions by sha to avoid supply-chain attacks (re-published GitHub actions under the same tag/version)
3. Add a dependabot.yml section to periodically update GitHub actions versions (not only Maven dependencies)
4. Add a cooldown setting to dependabot.yml to delay updating to latest versions to avoid introducing supply-chain/security issues (this is also flagged by Zizmor and is now best-practice)
5. Also: Make the build/push workflow project-forkable: Currently, when people fork this project they cannot push to their own project's ghcr.io.

### Actions after this PR is merged

1. set Settings / Actions / General / "Actions permissions: Require actions to be pinned to a full-length commit SHA"
2. set Settings / Actions / General / "Workflow permissions: Read repository contents and packages permissions" (instead of "Read and write permissions")