### PR TITLE
Fix flaky JiraReplicationServiceTest; harden Jira timestamp parsing

### DIFF
--- a/src/main/java/org/tb/jira/service/JiraReplicationService.java
+++ b/src/main/java/org/tb/jira/service/JiraReplicationService.java
@@ -214,8 +214,10 @@ public class JiraReplicationService {
     if (dateTimeValue == null || dateTimeValue.isBlank()) {
       return null;
     }
-    // e.g. 2024-05-31T13:43:33
-    return LocalDateTime.parse(dateTimeValue.substring(0, 19));
+    // e.g. 2024-05-31T13:43:33.000+0200; strip fraction/offset, but tolerate a
+    // value without a seconds field (LocalDateTime.parse accepts yyyy-MM-ddTHH:mm).
+    String s = dateTimeValue.length() >= 19 ? dateTimeValue.substring(0, 19) : dateTimeValue;
+    return LocalDateTime.parse(s);
   }
 
   private static String getString(Map<?, ?> map, String key) {

--- a/src/test/java/org/tb/jira/service/JiraReplicationServiceTest.java
+++ b/src/test/java/org/tb/jira/service/JiraReplicationServiceTest.java
@@ -1,6 +1,5 @@
 package org.tb.jira.service;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -75,7 +74,7 @@ class JiraReplicationServiceTest {
 
   @Test
   void testRunReplicationUpdatesLastMaxUpdated() {
-    LocalDateTime mockUpdated = LocalDateTime.now().truncatedTo(SECONDS);
+    LocalDateTime mockUpdated = LocalDateTime.of(2026, 6, 25, 11, 20, 25);
     JiraReplicationConfig config = createMockReplicationConfig();
     when(configRepo.findById(config.getId())).thenReturn(Optional.of(config));
     when(ticketRepo.findMaxUpdatedTs(config.getCustomerorderSign())).thenReturn(null);


### PR DESCRIPTION
### Summary

Currently, we have flaky tests in JiraReplicationServiceTest whose success depends on the current time and it already made a few commits fail spuriously in the unit tests job.

The test built its mock "updated" timestamp from LocalDateTime.now().truncatedTo(SECONDS). When the current second was 0, toString() omitted the seconds field, yielding a 16-char value. The parser's substring(0, 19) then threw, the per-issue catch swallowed it, and configRepo.save() was never invoked, failing the verify().
This flaky test would fail whenever it was run at second 0.

To fix this, we use a fixed timestamp in the test, and guard toDateTime so values shorter than 19 chars are parsed as-is (LocalDateTime accepts an ISO value without seconds).

This fixes the transient unit test failures, such as in:
- https://github.com/HBTGmbH/salat/actions/runs/28082598636/job/83140834735
- https://github.com/HBTGmbH/salat/actions/runs/28054721085/job/83054062705