### PR TITLE
Make unit tests deterministic

### DIFF
--- a/src/main/java/org/tb/common/util/ClockProvider.java
+++ b/src/main/java/org/tb/common/util/ClockProvider.java
@@ -1,0 +1,71 @@
+package org.tb.common.util;
+
+import static org.tb.common.GlobalConstants.DEFAULT_TIMEZONE_ID;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/**
+ * Single source of truth for "the current time" across the application.
+ *
+ * <p>All business-logic reads of the current date/time funnel through this class (directly,
+ * or via {@link DateUtils#today()} / {@link DateTimeUtils#now()}) instead of calling
+ * {@code LocalDate.now()} / {@code LocalDateTime.now()} statically. In production the clock
+ * is the system clock at the configured {@code DEFAULT_TIMEZONE_ID}; tests can pin it to a
+ * fixed instant via {@link #useFixedClock(LocalDateTime)} / {@link #setClock(Clock)} so that
+ * "now" becomes deterministic, and restore live time via {@link #reset()}.
+ */
+public final class ClockProvider {
+
+  private static volatile Clock clock = systemClock();
+
+  private ClockProvider() {
+  }
+
+  private static Clock systemClock() {
+    return Clock.system(ZoneId.of(DEFAULT_TIMEZONE_ID));
+  }
+
+  public static Clock getClock() {
+    return clock;
+  }
+
+  public static LocalDateTime now() {
+    return LocalDateTime.now(clock);
+  }
+
+  public static LocalDate today() {
+    return LocalDate.now(clock);
+  }
+
+  public static Instant instant() {
+    return clock.instant();
+  }
+
+  /**
+   * Replaces the clock. Intended for tests; production code should never call this.
+   */
+  public static void setClock(Clock clock) {
+    ClockProvider.clock = clock;
+  }
+
+  /**
+   * Pins "now" to the given local date-time (interpreted in {@code DEFAULT_TIMEZONE_ID}).
+   * Intended for tests.
+   */
+  public static void useFixedClock(LocalDateTime fixed) {
+    ZoneId zone = ZoneId.of(DEFAULT_TIMEZONE_ID);
+    ClockProvider.clock = Clock.fixed(fixed.atZone(zone).toInstant(), zone);
+  }
+
+  /**
+   * Restores the live system clock. Intended for tests, to undo {@link #setClock(Clock)} or
+   * {@link #useFixedClock(LocalDateTime)}.
+   */
+  public static void reset() {
+    ClockProvider.clock = systemClock();
+  }
+}

--- a/src/main/java/org/tb/common/util/DateTimeUtils.java
+++ b/src/main/java/org/tb/common/util/DateTimeUtils.java
@@ -228,6 +228,6 @@ public class DateTimeUtils {
   }
 
   public static LocalDateTime now() {
-      return LocalDateTime.now();
+      return ClockProvider.now();
   }
 }

--- a/src/main/java/org/tb/common/util/DateUtils.java
+++ b/src/main/java/org/tb/common/util/DateUtils.java
@@ -228,7 +228,7 @@ public class DateUtils {
     }
 
     public static LocalDate today() {
-        return LocalDate.now(ZoneId.of(DEFAULT_TIMEZONE_ID));
+        return ClockProvider.today();
     }
 
     public static String format(LocalDate date) {
@@ -372,11 +372,11 @@ public class DateUtils {
     }
 
     public static LocalDate getFirstDay(Year year) {
-        return LocalDate.now().withYear(year.getValue()).with(firstDayOfYear());
+        return ClockProvider.today().withYear(year.getValue()).with(firstDayOfYear());
     }
 
     public static LocalDate getLastDay(Year year) {
-        return LocalDate.now().withYear(year.getValue()).with(lastDayOfYear());
+        return ClockProvider.today().withYear(year.getValue()).with(lastDayOfYear());
     }
 
   public static LocalDate max(LocalDate date1, LocalDate date2) {

--- a/src/main/java/org/tb/dailyreport/auth/ReleaseAuthorization.java
+++ b/src/main/java/org/tb/dailyreport/auth/ReleaseAuthorization.java
@@ -1,6 +1,6 @@
 package org.tb.dailyreport.auth;
 
-import static java.time.LocalDate.now;
+import static org.tb.common.util.DateUtils.today;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -25,7 +25,7 @@ public class ReleaseAuthorization {
     if (authorizedUser.isPeopleLead() && isSupervisedByCurrentUser(employeecontract)) return true;
     if (authorizedUser.isAdmin()) return true;
     String grantorSign = employeecontract.getEmployee().getSign();
-    return authService.isAuthorizedAnyObject(grantorSign, AUTH_CATEGORY_RELEASE, now(), accessLevel);
+    return authService.isAuthorizedAnyObject(grantorSign, AUTH_CATEGORY_RELEASE, today(), accessLevel);
   }
 
   public boolean isAcceptAuthorized(Employeecontract employeecontract, AccessLevel accessLevel) {
@@ -34,7 +34,7 @@ public class ReleaseAuthorization {
     if (authorizedUser.isPeopleLead() && isSupervisedByCurrentUser(employeecontract)) return true;
     if (authorizedUser.isAdmin()) return true;
     String grantorSign = employeecontract.getEmployee().getSign();
-    return authService.isAuthorizedAnyObject(grantorSign, AUTH_CATEGORY_ACCEPT, now(), accessLevel);
+    return authService.isAuthorizedAnyObject(grantorSign, AUTH_CATEGORY_ACCEPT, today(), accessLevel);
   }
 
   private boolean isSupervisedByCurrentUser(Employeecontract ec) {

--- a/src/main/java/org/tb/dailyreport/controller/DailyReportCsvController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DailyReportCsvController.java
@@ -51,7 +51,7 @@ public class DailyReportCsvController {
 
     @GetMapping
     public String show(@RequestParam(required = false) Long employeeContractId, Model model) {
-        YearMonth current = YearMonth.now();
+        YearMonth current = YearMonth.from(today());
         List<YearMonth> availableMonths = IntStream.range(0, 12)
             .mapToObj(current::minusMonths)
             .toList();

--- a/src/main/java/org/tb/employee/service/EmployeecontractService.java
+++ b/src/main/java/org/tb/employee/service/EmployeecontractService.java
@@ -110,7 +110,7 @@ public class EmployeecontractService {
       create(overtime);
     }
 
-    createVacation(employeecontract.getId(), Year.now(), vacationEntitlement);
+    createVacation(employeecontract.getId(), Year.from(today()), vacationEntitlement);
     return info;
   }
 

--- a/src/main/java/org/tb/etl/auth/ETLAuthorization.java
+++ b/src/main/java/org/tb/etl/auth/ETLAuthorization.java
@@ -1,6 +1,6 @@
 package org.tb.etl.auth;
 
-import static java.time.LocalDate.now;
+import static org.tb.common.util.DateUtils.today;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -22,7 +22,7 @@ public class ETLAuthorization {
   public boolean isAuthorized(ETLDefinition etlDefinition, AccessLevel accessLevel) {
     if (authorizedUser.isManager()) return true;
     if (authorizedUser.isAdmin()) return true;
-    return authService.isAuthorized(AUTH_CATEGORY, now(), accessLevel, etlDefinition.getName());
+    return authService.isAuthorized(AUTH_CATEGORY, today(), accessLevel, etlDefinition.getName());
   }
 
 }

--- a/src/main/java/org/tb/etl/service/ETLService.java
+++ b/src/main/java/org/tb/etl/service/ETLService.java
@@ -15,6 +15,7 @@ import org.tb.auth.domain.AccessLevel;
 import org.tb.common.LocalDateRange;
 import org.tb.common.exception.AuthorizationException;
 import org.tb.common.exception.InvalidDataException;
+import org.tb.common.util.DateTimeUtils;
 import org.tb.common.util.DateUtils;
 import org.tb.etl.auth.ETLAuthorization;
 import org.tb.etl.domain.ETLDefinition;
@@ -29,7 +30,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
@@ -186,7 +186,7 @@ public class ETLService {
         historyRepo.save(ETLExecutionHistory.builder()
             .etlId(def.getId())
             .etlName(def.getName())
-            .executedAt(LocalDateTime.now()).success(success).message(message.toString()).build());
+            .executedAt(DateTimeUtils.now()).success(success).message(message.toString()).build());
       }
     }
   }

--- a/src/main/java/org/tb/jira/service/JiraReplicationService.java
+++ b/src/main/java/org/tb/jira/service/JiraReplicationService.java
@@ -214,8 +214,10 @@ public class JiraReplicationService {
     if (dateTimeValue == null || dateTimeValue.isBlank()) {
       return null;
     }
-    // e.g. 2024-05-31T13:43:33
-    return LocalDateTime.parse(dateTimeValue.substring(0, 19));
+    // e.g. 2024-05-31T13:43:33.000+0200; strip fraction/offset, but tolerate a
+    // value without a seconds field (LocalDateTime.parse accepts yyyy-MM-ddTHH:mm).
+    String s = dateTimeValue.length() >= 19 ? dateTimeValue.substring(0, 19) : dateTimeValue;
+    return LocalDateTime.parse(s);
   }
 
   private static String getString(Map<?, ?> map, String key) {

--- a/src/main/java/org/tb/reporting/controller/ReportController.java
+++ b/src/main/java/org/tb/reporting/controller/ReportController.java
@@ -13,7 +13,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
 import java.time.Year;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -40,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.tb.auth.domain.AccessLevel;
 import org.tb.common.util.DateTimeUtils;
+import org.tb.common.util.DateUtils;
 import org.tb.common.web.UiState;
 import org.tb.reporting.auth.ReportAuthorization;
 import org.tb.reporting.domain.ReportDefinition;
@@ -346,13 +346,13 @@ public class ReportController {
 
     private String getValue(String parameterName) {
       if(of("jahr", "year").contains(parameterName.toLowerCase())) {
-        return Year.now().toString();
+        return Year.from(DateUtils.today()).toString();
       }
       if(of("monat", "month").contains(parameterName.toLowerCase())) {
-        return Integer.toString(YearMonth.now().getMonthValue());
+        return Integer.toString(YearMonth.from(DateUtils.today()).getMonthValue());
       }
       if(of("datum", "date", "from", "to", "von", "bis").contains(parameterName.toLowerCase())) {
-        return LocalDate.now().toString();
+        return DateUtils.today().toString();
       }
       return "";
     }

--- a/src/main/java/org/tb/reporting/service/ReportService.java
+++ b/src/main/java/org/tb/reporting/service/ReportService.java
@@ -114,7 +114,7 @@ public class ReportService {
         resolvedSql = resolvedSql.replace("###-AUTH-USER-SIGN-###", authorizedUser.getEffectiveLoginSign()); // ensure the sign is filled in as requested
       }
       // Resolve reporting placeholders based only on today's date (no FROM/UNTIL)
-      LocalDate today = LocalDate.now();
+      LocalDate today = DateUtils.today();
       resolvedSql = reportParameterResolver.resolve(resolvedSql, today);
     }
 

--- a/src/main/java/org/tb/reporting/service/ScheduledReportJobScheduler.java
+++ b/src/main/java/org/tb/reporting/service/ScheduledReportJobScheduler.java
@@ -28,6 +28,7 @@ import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.AbstractRequestAttributes;
 import org.tb.auth.domain.AuthorizedUser;
+import org.tb.common.util.ClockProvider;
 import org.tb.reporting.domain.ScheduledReportJob;
 import org.tb.reporting.event.ReportScheduledEvent;
 import org.tb.reporting.event.ReportUnscheduledEvent;
@@ -174,7 +175,7 @@ public class ScheduledReportJobScheduler {
       if (future != null && !future.isCancelled()) {
         long delay = future.getDelay(TimeUnit.SECONDS);
         if (delay > 0) {
-          return Instant.now().plusSeconds(delay + 1); // +1 helps with strange values
+          return ClockProvider.instant().plusSeconds(delay + 1); // +1 helps with strange values
         }
       }
       return null;

--- a/src/main/java/org/tb/reporting/service/ScheduledReportJobService.java
+++ b/src/main/java/org/tb/reporting/service/ScheduledReportJobService.java
@@ -21,6 +21,7 @@ import org.tb.auth.domain.Authorized;
 import org.tb.auth.domain.AuthorizedUser;
 import org.tb.common.exception.AuthorizationException;
 import org.tb.common.exception.ErrorCode;
+import org.tb.common.util.DateTimeUtils;
 import org.tb.reporting.domain.JobExecutionResult;
 import org.tb.reporting.domain.ReportParameter;
 import org.tb.reporting.domain.ScheduledReportExecutionHistory;
@@ -116,7 +117,7 @@ public class ScheduledReportJobService {
   private JobExecutionResult executeJob(ScheduledReportJob job) {
     log.info("Executing scheduled report job: {} (ID: {})", job.getName(), job.getId());
 
-    LocalDateTime executedAt = LocalDateTime.now();
+    LocalDateTime executedAt = DateTimeUtils.now();
     List<ReportParameter> parameters = parseParameters(job.getReportParameters());
     String[] recipients = parseRecipients(job.getRecipientEmails());
 

--- a/src/main/java/org/tb/statistic/service/StatisticService.java
+++ b/src/main/java/org/tb/statistic/service/StatisticService.java
@@ -1,7 +1,6 @@
 package org.tb.statistic.service;
 
 import static java.time.Duration.ofMinutes;
-import static java.time.LocalDateTime.now;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -16,6 +15,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tb.common.domain.AuditedEntity;
+import org.tb.common.util.DateTimeUtils;
+import org.tb.common.util.DateUtils;
 import org.tb.dailyreport.domain.TimereportDTO;
 import org.tb.dailyreport.event.TimereportsCreatedOrUpdatedEvent;
 import org.tb.dailyreport.event.TimereportsDeletedEvent;
@@ -51,11 +52,11 @@ public class StatisticService {
     var minDate = timereports.stream()
         .map(TimereportDTO::getReferenceday)
         .min(LocalDate::compareTo)
-        .orElse(LocalDate.now());
+        .orElse(DateUtils.today());
     var maxDate = timereports.stream()
         .map(TimereportDTO::getReferenceday)
         .max(LocalDate::compareTo)
-        .orElse(LocalDate.now());
+        .orElse(DateUtils.today());
 
     var employeeorders = timereports.stream()
         .map(TimereportDTO::getEmployeeorderId)
@@ -64,7 +65,7 @@ public class StatisticService {
         .map(employeeorderService::getEmployeeorderById)
         .toList();
     
-    var comment = "time report(s) created or updated @ %s".formatted(now());
+    var comment = "time report(s) created or updated @ %s".formatted(DateTimeUtils.now());
 
     generateOrderStatistics(employeeorders, minDate, maxDate, comment);
   }
@@ -78,10 +79,10 @@ public class StatisticService {
         .toList();
     var minDate = referencedDays.stream()
         .min(LocalDate::compareTo)
-        .orElse(LocalDate.now());
+        .orElse(DateUtils.today());
     var maxDate = referencedDays.stream()
         .max(LocalDate::compareTo)
-        .orElse(LocalDate.now());
+        .orElse(DateUtils.today());
 
     var employeeorders = event.getIds().stream()
         .map(TimereportDeleteId::getEmployeeorderId)
@@ -90,7 +91,7 @@ public class StatisticService {
         .filter(Objects::nonNull) // because of async, object may no longer be available
         .toList();
 
-    var comment = "time report(s) deleted @ %s".formatted(now());
+    var comment = "time report(s) deleted @ %s".formatted(DateTimeUtils.now());
 
     generateOrderStatistics(employeeorders, minDate, maxDate, comment);
   }

--- a/src/test/java/org/tb/ArchitectureTest.java
+++ b/src/test/java/org/tb/ArchitectureTest.java
@@ -19,11 +19,16 @@ import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import jakarta.persistence.Entity;
+import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.data.domain.Persistable;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.tb.common.util.ClockProvider;
+import org.tb.order.jsptags.OrderTreeTag;
+import org.tb.reporting.service.ScheduledReportJobScheduler;
 
 @AnalyzeClasses(packages = "org.tb", importOptions = {DoNotIncludeTests.class, DoNotIncludeJars.class, DoNotIncludeGradleTestFixtures.class})
 public class ArchitectureTest {
@@ -132,6 +137,19 @@ public class ArchitectureTest {
       .should().callMethodWhere(AMBIENT_NOW)
       .because("the current date/time must be read via ClockProvider (or DateUtils.today() / "
           + "DateTimeUtils.now()) so it can be fixed deterministically in tests");
+
+  @ArchTest
+  static final ArchRule useDeterministicRandomness = priority(HIGH).noClasses()
+      // carve-outs for intentional production randomness: OrderTreeTag generates unique JSP
+      // image-label names; ScheduledReportJobScheduler mints an internal mock-request session id.
+      .that().doNotBelongToAnyOf(OrderTreeTag.class, ScheduledReportJobScheduler.class)
+      .should().callMethod(Math.class, "random")
+      .orShould().callMethod(UUID.class, "randomUUID")
+      .orShould().callMethod(ThreadLocalRandom.class, "current")
+      .orShould().callConstructor(Random.class)
+      .because("non-deterministic randomness (Math.random(), new Random() without a seed, "
+          + "UUID.randomUUID(), ThreadLocalRandom) makes behaviour and tests non-reproducible; "
+          + "seed a Random or inject the value instead");
 
   private static class OnlyOwnDependencyPredicate extends DescribedPredicate<JavaClass> {
 

--- a/src/test/java/org/tb/ArchitectureTest.java
+++ b/src/test/java/org/tb/ArchitectureTest.java
@@ -8,6 +8,7 @@ import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.sli
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeGradleTestFixtures;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeJars;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
@@ -22,6 +23,7 @@ import java.util.Set;
 import org.springframework.data.domain.Persistable;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
+import org.tb.common.util.ClockProvider;
 
 @AnalyzeClasses(packages = "org.tb", importOptions = {DoNotIncludeTests.class, DoNotIncludeJars.class, DoNotIncludeGradleTestFixtures.class})
 public class ArchitectureTest {
@@ -103,6 +105,33 @@ public class ArchitectureTest {
 
   @ArchTest
   static final ArchRule beFreeOfCycles = slices().matching("org.tb.(*)..").should().beFreeOfCycles();
+
+  private static final Set<String> JAVA_TIME_NOW_OWNERS = Set.of(
+      "java.time.LocalDate", "java.time.LocalDateTime", "java.time.LocalTime",
+      "java.time.Instant", "java.time.ZonedDateTime", "java.time.OffsetDateTime",
+      "java.time.OffsetTime", "java.time.Year", "java.time.YearMonth", "java.time.MonthDay");
+
+  // Matches the no-arg java.time now() calls (e.g. LocalDate.now(), LocalDateTime.now()) that read
+  // the ambient system clock. The explicit now(Clock) overload used by ClockProvider takes a
+  // parameter and is therefore not matched.
+  private static final DescribedPredicate<JavaMethodCall> AMBIENT_NOW =
+      new DescribedPredicate<>("read the current time from the ambient system clock via java.time now()") {
+        @Override
+        public boolean test(JavaMethodCall call) {
+          var target = call.getTarget();
+          return "now".equals(target.getName())
+              && target.getRawParameterTypes().isEmpty()
+              && JAVA_TIME_NOW_OWNERS.contains(target.getOwner().getFullName());
+        }
+      };
+
+  @ArchTest
+  static final ArchRule readCurrentTimeOnlyViaClockProvider = priority(HIGH).noClasses()
+      .that().doNotBelongToAnyOf(ClockProvider.class)
+      .and().haveSimpleNameNotEndingWith("OpenApiConfiguration") // build-timestamp fallback only
+      .should().callMethodWhere(AMBIENT_NOW)
+      .because("the current date/time must be read via ClockProvider (or DateUtils.today() / "
+          + "DateTimeUtils.now()) so it can be fixed deterministically in tests");
 
   private static class OnlyOwnDependencyPredicate extends DescribedPredicate<JavaClass> {
 

--- a/src/test/java/org/tb/common/test/FixedClock.java
+++ b/src/test/java/org/tb/common/test/FixedClock.java
@@ -1,0 +1,33 @@
+package org.tb.common.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Pins {@link org.tb.common.util.ClockProvider} to a fixed instant for the duration of each
+ * test, so that {@code DateTimeUtils.now()} / {@code DateUtils.today()} (and everything that
+ * funnels through them) return a deterministic value. The clock is restored to live system
+ * time after each test.
+ *
+ * <p>Place on a test class (or a single test method). The {@link #value()} is an
+ * ISO-8601 local date-time (e.g. {@code 2026-06-25T10:15:30}); the default matches the dates
+ * commonly hard-coded in existing fixtures.
+ *
+ * <pre>
+ * &#64;FixedClock
+ * class MyTest { ... }                       // now() == 2026-06-25T10:15:30
+ *
+ * &#64;FixedClock("2030-01-01T00:00:00")
+ * class OtherTest { ... }
+ * </pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtendWith(FixedClockExtension.class)
+public @interface FixedClock {
+
+  String value() default "2026-06-25T10:15:30";
+}

--- a/src/test/java/org/tb/common/test/FixedClockExtension.java
+++ b/src/test/java/org/tb/common/test/FixedClockExtension.java
@@ -1,0 +1,47 @@
+package org.tb.common.test;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.Optional;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.tb.common.util.ClockProvider;
+
+/**
+ * JUnit 5 extension that pins {@link ClockProvider} to a fixed instant before each test and
+ * resets it to the live system clock afterwards.
+ *
+ * <p>The fixture is taken from a {@link FixedClock} annotation on the test method (preferred)
+ * or the test class; if the extension is registered directly via
+ * {@code @ExtendWith(FixedClockExtension.class)} without a {@link FixedClock} annotation, the
+ * default fixture {@link #DEFAULT_FIXTURE} is used.
+ */
+public class FixedClockExtension implements BeforeEachCallback, AfterEachCallback {
+
+  static final String DEFAULT_FIXTURE = "2026-06-25T10:15:30";
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    ClockProvider.useFixedClock(LocalDateTime.parse(resolveFixture(context)));
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    ClockProvider.reset();
+  }
+
+  private String resolveFixture(ExtensionContext context) {
+    Optional<FixedClock> onMethod = context.getTestMethod()
+        .map(method -> method.getAnnotation(FixedClock.class))
+        .filter(Objects::nonNull);
+    if (onMethod.isPresent()) {
+      return onMethod.get().value();
+    }
+    return context.getTestClass()
+        .map(clazz -> clazz.getAnnotation(FixedClock.class))
+        .filter(Objects::nonNull)
+        .map(FixedClock::value)
+        .orElse(DEFAULT_FIXTURE);
+  }
+}

--- a/src/test/java/org/tb/common/util/ClockProviderTest.java
+++ b/src/test/java/org/tb/common/util/ClockProviderTest.java
@@ -11,8 +11,9 @@ class ClockProviderTest {
 
   @Test
   @FixedClock
-  void fixedClock_pinsNowToDefaultFixture() {
+  void fixedClock_pinsNowToDefaultFixture() throws InterruptedException {
     assertThat(ClockProvider.now()).isEqualTo(LocalDateTime.of(2026, 6, 25, 10, 15, 30));
+    Thread.sleep(1100L); // <- advance at least one second
     assertThat(DateTimeUtils.now()).isEqualTo(LocalDateTime.of(2026, 6, 25, 10, 15, 30));
     assertThat(DateUtils.today()).isEqualTo(LocalDate.of(2026, 6, 25));
   }
@@ -25,9 +26,9 @@ class ClockProviderTest {
   }
 
   @Test
-  void withoutFixedClock_usesLiveSystemTime() {
-    // No @FixedClock here: confirms the funnel reflects a live clock and is not left pinned
-    // by a previous test (the extension resets after each test).
-    assertThat(DateUtils.today()).isAfter(LocalDate.of(2020, 1, 1));
+  void withoutFixedClock_usesLiveSystemTime() throws InterruptedException {
+    LocalDateTime now = DateTimeUtils.now();
+    Thread.sleep(100L); // <- advance time a tiny bit (LocalDateTime.now() has nanoseconds precision)
+    assertThat(DateTimeUtils.now()).isAfter(now);
   }
 }

--- a/src/test/java/org/tb/common/util/ClockProviderTest.java
+++ b/src/test/java/org/tb/common/util/ClockProviderTest.java
@@ -1,0 +1,33 @@
+package org.tb.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.tb.common.test.FixedClock;
+
+class ClockProviderTest {
+
+  @Test
+  @FixedClock
+  void fixedClock_pinsNowToDefaultFixture() {
+    assertThat(ClockProvider.now()).isEqualTo(LocalDateTime.of(2026, 6, 25, 10, 15, 30));
+    assertThat(DateTimeUtils.now()).isEqualTo(LocalDateTime.of(2026, 6, 25, 10, 15, 30));
+    assertThat(DateUtils.today()).isEqualTo(LocalDate.of(2026, 6, 25));
+  }
+
+  @Test
+  @FixedClock("2030-01-01T08:00:00")
+  void fixedClock_honoursCustomFixture() {
+    assertThat(DateTimeUtils.now()).isEqualTo(LocalDateTime.of(2030, 1, 1, 8, 0, 0));
+    assertThat(DateUtils.today()).isEqualTo(LocalDate.of(2030, 1, 1));
+  }
+
+  @Test
+  void withoutFixedClock_usesLiveSystemTime() {
+    // No @FixedClock here: confirms the funnel reflects a live clock and is not left pinned
+    // by a previous test (the extension resets after each test).
+    assertThat(DateUtils.today()).isAfter(LocalDate.of(2020, 1, 1));
+  }
+}

--- a/src/test/java/org/tb/dailyreport/rest/DailyReportDataTest.java
+++ b/src/test/java/org/tb/dailyreport/rest/DailyReportDataTest.java
@@ -12,7 +12,7 @@ class DailyReportDataTest {
     var timereport = DailyReportData.builder()
         .id(10L)
         .employeeorderId(1L)
-        .date(LocalDate.now().toString())
+        .date(LocalDate.of(2026, 6, 25).toString())
         .orderLabel("test")
         .suborderLabel("test")
         .comment("test")

--- a/src/test/java/org/tb/dailyreport/rest/DailyReportRestEndpointTest.java
+++ b/src/test/java/org/tb/dailyreport/rest/DailyReportRestEndpointTest.java
@@ -249,22 +249,29 @@ class DailyReportRestEndpointTest {
 
     // fixtures
 
+    // deterministic, collision-free ids for fixtures (counter resets per test instance)
+    private long nextId = 1;
+
+    private long nextId() {
+        return nextId++;
+    }
+
     private Employee employee() {
         Employee res = new Employee();
-        ReflectionTestUtils.setField(res, "id", (long) (Math.random() * 100));
+        ReflectionTestUtils.setField(res, "id", nextId());
         return res;
     }
 
     private Employeecontract employeeContract(Employee employee) {
         Employeecontract res = new Employeecontract();
-        ReflectionTestUtils.setField(res, "id", (long) (Math.random() * 100));
+        ReflectionTestUtils.setField(res, "id", nextId());
         res.setEmployee(employee);
         return res;
     }
 
     private Employeeorder employeeOrder(Employeecontract employeeContract) {
         Employeeorder res = new Employeeorder();
-        ReflectionTestUtils.setField(res, "id", (long) (Math.random() * 100));
+        ReflectionTestUtils.setField(res, "id", nextId());
         res.setEmployeecontract(employeeContract);
         return res;
     }

--- a/src/test/java/org/tb/dailyreport/rest/WorkingDayRestEndpointTest.java
+++ b/src/test/java/org/tb/dailyreport/rest/WorkingDayRestEndpointTest.java
@@ -115,9 +115,16 @@ class WorkingDayRestEndpointTest {
 
     // fixtures
 
+    // deterministic, collision-free ids for fixtures (counter resets per test instance)
+    private long nextId = 1;
+
+    private long nextId() {
+        return nextId++;
+    }
+
     private Employeecontract employeeContract() {
         Employeecontract res = new Employeecontract();
-        ReflectionTestUtils.setField(res, "id", (long) (Math.random() * 100));
+        ReflectionTestUtils.setField(res, "id", nextId());
         return res;
     }
 }

--- a/src/test/java/org/tb/jira/service/JiraReplicationServiceTest.java
+++ b/src/test/java/org/tb/jira/service/JiraReplicationServiceTest.java
@@ -11,6 +11,7 @@ import static org.springframework.util.ReflectionUtils.findField;
 import static org.springframework.util.ReflectionUtils.makeAccessible;
 import static org.springframework.util.ReflectionUtils.setField;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +21,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.tb.common.domain.AuditedEntity;
+import org.tb.common.test.FixedClock;
+import org.tb.common.util.DateTimeUtils;
 import org.tb.jira.domain.JiraReplicationConfig;
 import org.tb.jira.domain.JiraTicket;
 import org.tb.jira.persistence.JiraReplicationConfigRepository;
@@ -27,6 +30,7 @@ import org.tb.jira.persistence.JiraTicketRepository;
 import org.tb.jira.service.JiraClient.JiraIssue;
 import org.tb.jira.service.JiraClient.JiraSearchResult;
 
+@FixedClock
 @SpringBootTest
 class JiraReplicationServiceTest {
 
@@ -102,7 +106,7 @@ class JiraReplicationServiceTest {
   }
 
   private JiraSearchResult createMockJiraSearchResult() {
-    return createMockJiraSearchResult(LocalDateTime.now());
+    return createMockJiraSearchResult(LocalDateTime.of(2026, 6, 25, 15, 5, 0));
   }
 
   private JiraSearchResult createMockJiraSearchResult(LocalDateTime updated) {
@@ -112,7 +116,7 @@ class JiraReplicationServiceTest {
     issue.setFields(Map.of(
         "summary", "Mock Summary",
         "updated", updated.toString(),
-        "created", LocalDateTime.now().toString(),
+        "created", DateTimeUtils.now().toString(),
         "issuetype", Map.of("name", "Task")
     ));
     return result(issue);

--- a/src/test/java/org/tb/jira/service/JiraReplicationServiceTest.java
+++ b/src/test/java/org/tb/jira/service/JiraReplicationServiceTest.java
@@ -1,6 +1,5 @@
 package org.tb.jira.service;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -75,7 +74,7 @@ class JiraReplicationServiceTest {
 
   @Test
   void testRunReplicationUpdatesLastMaxUpdated() {
-    LocalDateTime mockUpdated = LocalDateTime.now().truncatedTo(SECONDS);
+    LocalDateTime mockUpdated = LocalDateTime.of(2026, 6, 25, 11, 20, 25);
     JiraReplicationConfig config = createMockReplicationConfig();
     when(configRepo.findById(config.getId())).thenReturn(Optional.of(config));
     when(ticketRepo.findMaxUpdatedTs(config.getCustomerorderSign())).thenReturn(null);

--- a/src/test/java/org/tb/order/rest/OrderRestEndpointTest.java
+++ b/src/test/java/org/tb/order/rest/OrderRestEndpointTest.java
@@ -43,15 +43,22 @@ class OrderRestEndpointTest {
     assertThat(res.getFirst().getSuborder().size()).isEqualTo(3);
   }
 
+  // deterministic, collision-free ids for fixtures (counter resets per test instance)
+  private long nextId = 1;
+
+  private long nextId() {
+    return nextId++;
+  }
+
   private Employeeorder newEmployeeorder() {
     Employeeorder res = new Employeeorder();
-    ReflectionTestUtils.setField(res, "id", (long) (Math.random() * 100));
+    ReflectionTestUtils.setField(res, "id", nextId());
     return res;
   }
 
   private Employeecontract newEmployeecontract() {
     Employeecontract res = new Employeecontract();
-    ReflectionTestUtils.setField(res, "id", (long) (Math.random() * 100));
+    ReflectionTestUtils.setField(res, "id", nextId());
     return res;
   }
 
@@ -65,7 +72,7 @@ class OrderRestEndpointTest {
   private Customerorder createCustomerOrder() {
     Customerorder res = new Customerorder();
 
-    ReflectionTestUtils.setField(res, "id", (long) (Math.random() * 100));
+    ReflectionTestUtils.setField(res, "id", nextId());
     res.setShortdescription("Customerorder " + res.getId());
     return res;
   }
@@ -80,7 +87,7 @@ class OrderRestEndpointTest {
 
   private Suborder createTestData(int depth, Customerorder customerOrder) {
     Suborder res = new Suborder();
-    ReflectionTestUtils.setField(res, "id", (long) (Math.random() * 100));
+    ReflectionTestUtils.setField(res, "id", nextId());
     res.setDescription("order " + res.getId());
     res.setCustomerorder(customerOrder);
     res.setSuborders(createTestDatList(depth - 1, depth, customerOrder));

--- a/src/test/java/org/tb/reporting/controller/ReportControllerTest.java
+++ b/src/test/java/org/tb/reporting/controller/ReportControllerTest.java
@@ -3,7 +3,6 @@ package org.tb.reporting.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -11,9 +10,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.tb.common.test.FixedClock;
+import org.tb.common.util.DateTimeUtils;
 import org.tb.reporting.domain.ReportDefinition;
 import org.tb.reporting.domain.ReportParameter;
 
+@FixedClock
 @ExtendWith(MockitoExtension.class)
 class ReportControllerTest {
 
@@ -54,7 +56,7 @@ class ReportControllerTest {
 
     String result = ReportController.createFileName(reportDefinition, parameters);
 
-    String expectedDateTimePart = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(":", "_");
+    String expectedDateTimePart = DateTimeUtils.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(":", "_");
     assertEquals(
         "report-Sales_Report-[2025-12]-" + expectedDateTimePart + ".xlsx",
         result
@@ -70,7 +72,7 @@ class ReportControllerTest {
 
     String result = ReportController.createFileName(reportDefinition, parameters);
 
-    String expectedDateTimePart = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(":", "_");
+    String expectedDateTimePart = DateTimeUtils.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(":", "_");
     assertEquals(
         "report-Summary_Report-[]-" + expectedDateTimePart + ".xlsx",
         result
@@ -89,7 +91,7 @@ class ReportControllerTest {
 
     String result = ReportController.createFileName(reportDefinition, parameters);
 
-    String expectedDateTimePart = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(":", "_");
+    String expectedDateTimePart = DateTimeUtils.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(":", "_");
     assertEquals(
         "report-Special_Report_2025-[2025-12-01-2025-12-31]-" + expectedDateTimePart + ".xlsx",
         result


### PR DESCRIPTION
### Summary

- Make all usages of `LocalDate/LocalDateTime.now()` calls deterministic for unit tests.
- Change `Math.random()*100` (which could collide) with deterministic, monotonic ids in tests.

### Rationale

Many unit tests currently call a main service method which queries `LocalDateTime.now()` and the test later asserts again on a new invocation of `LocalDateTime.now()`. Between the main function being tested and the test assertion there is a race for the current time having advanced to the next wall-clock second.

The usual fix for this is to make tests fully deterministic via a provided Clock instance.

This also includes the fix from https://github.com/HBTGmbH/salat/pull/740 .