### PR TITLE
Remove favorite table creation from testdb.sql

### DIFF
--- a/testdb/testdb.sql
+++ b/testdb/testdb.sql
@@ -657,17 +657,6 @@ UNLOCK TABLES;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2019-09-11  7:07:08
-
-DROP TABLE IF EXISTS `favorite`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `favorite` (
-                            `id` bigint(20) NOT NULL AUTO_INCREMENT,
-                            `employeeId`bigint(20) NOT NULL,
-                            `employeeorderId` bigint(20) NOT NULL,
-                            `hours` int(11) NOT NULL,
-                            `minutes` int(11) NOT NULL,
-                            `comment` text COLLATE utf8_bin DEFAULT NULL,
-                            PRIMARY KEY (`id`),
-) ENGINE=InnoDB AUTO_INCREMENT=183915 DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
-/*!40101 SET character_set_client = @saved_cs_client */;
+-- Note: the `favorite` table is intentionally NOT created here — it is managed by
+-- Liquibase (db.changelog-master.yaml). Creating it in this seed dump collides with
+-- the Liquibase changeset ("Table 'favorite' already exists") and aborts startup.


### PR DESCRIPTION
### Description

When actually trying to run the docker compose setup, mentioned on the README.md, there are two problems:

1. the database testdb.sql import fails with an SQL syntax error, because of a trailing comma here:
```sql
...
                            `comment` text COLLATE utf8_bin DEFAULT NULL,
                            PRIMARY KEY (`id`), <----- HERE!
) ENGINE=InnoDB AUTO_INCREMENT=183915 DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
```
3. when fixing that, the testdb.sql import successfully works with MySQL, but starting the app errors because Liquibase also owns the "favorites" table in a changeset and cannot create it (because it already exists via the testdb.sql import)

The fix is to simply _not_ create the "favorites" table via the testdb.sql script.