### PR TITLE
Centralize employee contract selector in app frame (#742)

### DIFF
--- a/src/main/java/org/tb/common/web/UiState.java
+++ b/src/main/java/org/tb/common/web/UiState.java
@@ -21,7 +21,7 @@ public class UiState {
 
     public Long getLongValue(UiStateKey key) {
         var value = values.get(key);
-        return value != null ? Long.valueOf(value) : null;
+        return value != null && !value.isBlank() ? Long.valueOf(value) : null;
     }
 
     public void clearState(UiStateKey key) {

--- a/src/main/java/org/tb/dailyreport/controller/AcceptanceController.java
+++ b/src/main/java/org/tb/dailyreport/controller/AcceptanceController.java
@@ -81,10 +81,10 @@ public class AcceptanceController {
         model.addAttribute("releaseDateStr", defaultReleaseDateStr(selected));
         model.addAttribute("acceptanceDateStr", defaultAcceptanceDateStr(selected));
         model.addAttribute("reopenDateStr", defaultReleaseDateStr(selected));
-        model.addAttribute("section", "dailyreport");
+        model.addAttribute("section", "backoffice");
         model.addAttribute("subSection", "acceptance");
         model.addAttribute("pageTitle", messages.getMessage("main.general.mainmenu.acceptance.text"));
-        model.addAttribute("sectionTitle", messages.getMessage("main.general.mainmenu.timereports.text"));
+        model.addAttribute("sectionTitle", messages.getMessage("main.general.mainmenu.backoffice.text"));
         return "dailyreport/acceptance";
     }
 

--- a/src/main/java/org/tb/dailyreport/controller/DailyController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DailyController.java
@@ -65,13 +65,18 @@ public class DailyController {
             Model model) {
 
         var today = today();
-        var contracts = employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(today);
         long ecId = effectiveContractId(employeeContractId);
 
         String effectiveMode = (mode != null && mode.equals("list")) ? "list" : "daily";
 
-        model.addAttribute("employeecontracts", contracts);
         model.addAttribute("selectedContractId", ecId);
+        if (ecId > 0) {
+            var ec = employeecontractService.getEmployeecontractById(ecId);
+            if (ec != null) {
+                model.addAttribute("selectedEmployeeName", ec.getEmployee().getName() + " | " + ec.getEmployee().getSign()
+                    + "  (" + ec.getTimeString() + (ec.getOpenEnd() ? " ∞" : "") + ")");
+            }
+        }
         model.addAttribute("mode", effectiveMode);
         model.addAttribute("section", "dailyreport");
         model.addAttribute("subSection", "daily");
@@ -400,7 +405,7 @@ public class DailyController {
         return "redirect:/dailyreport/daily?mode=daily&date=" + date;
     }
 
-    @PostMapping("/fill-not-worked")
+    @GetMapping("/fill-not-worked")
     @PreAuthorize("isAuthenticated()")
     public String fillNotWorked(
             @RequestParam(required = false) Long employeeContractId,

--- a/src/main/java/org/tb/dailyreport/controller/DailyReportCsvController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DailyReportCsvController.java
@@ -1,7 +1,6 @@
 package org.tb.dailyreport.controller;
 
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
-import static org.tb.common.util.DateUtils.today;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -55,10 +54,14 @@ public class DailyReportCsvController {
         List<YearMonth> availableMonths = IntStream.range(0, 12)
             .mapToObj(current::minusMonths)
             .toList();
-        var contracts = employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(today());
         long ecId = effectiveContractId(employeeContractId);
-        model.addAttribute("employeecontracts", contracts);
-        model.addAttribute("selectedContractId", ecId);
+        if (ecId > 0) {
+            var ec = employeecontractService.getEmployeecontractById(ecId);
+            if (ec != null) {
+                model.addAttribute("selectedEmployeeName", ec.getEmployee().getName() + " | " + ec.getEmployee().getSign()
+                    + "  (" + ec.getTimeString() + (ec.getOpenEnd() ? " ∞" : "") + ")");
+            }
+        }
         model.addAttribute("availableMonths", availableMonths);
         model.addAttribute("selectedMonth", current.toString());
         model.addAttribute("section", "dailyreport");

--- a/src/main/java/org/tb/dailyreport/controller/DashboardController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DashboardController.java
@@ -65,7 +65,6 @@ public class DashboardController {
     public String dashboard(@RequestParam(required = false) Long employeeContractId, Model model) {
         var employeecontract = currentContract(employeeContractId);
         var loginEmployees = employeeService.getLoginEmployees();
-        var employeecontracts = employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(today());
 
         var overtimeStatus = overtimeService.calculateOvertime(employeecontract.getId(), true);
         var vacations = vacationService.getVacations(employeecontract).stream()
@@ -78,9 +77,7 @@ public class DashboardController {
         model.addAttribute("section", "dailyreport");
         model.addAttribute("subSection", "dashboard");
         model.addAttribute("sectionTitle", messageSourceAccessor.getMessage("main.general.mainmenu.timereports.text"));
-        model.addAttribute("employeecontracts", employeecontracts);
         model.addAttribute("loginEmployees", loginEmployees);
-        model.addAttribute("currentEmployeeContractId", employeecontract.getId());
         model.addAttribute("currentLoginEmployeeId", authorizedEmployee.getEmployeeId());
         model.addAttribute("effectiveLoginSign", authorizedUser.getEffectiveLoginSign());
         model.addAttribute("displayEmployeeInfo", displayEmployeeInfo);

--- a/src/main/java/org/tb/dailyreport/controller/MatrixController.java
+++ b/src/main/java/org/tb/dailyreport/controller/MatrixController.java
@@ -10,7 +10,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -66,8 +65,10 @@ public class MatrixController {
             .map(c -> c.getReportReleaseDate() != null && !c.getReportReleaseDate().isBefore(yearMonth.atEndOfMonth()))
             .orElse(false);
 
+        selectedContract.ifPresent(c -> model.addAttribute("selectedEmployeeName",
+            c.getEmployee().getName() + " | " + c.getEmployee().getSign()
+                + "  (" + c.getTimeString() + (c.getOpenEnd() ? " ∞" : "") + ")"));
         model.addAttribute("matrixData", matrixData);
-        model.addAttribute("employeecontracts", contracts);
         model.addAttribute("selectedContractId", ecId);
         model.addAttribute("monthReleased", monthReleased);
         model.addAttribute("showBeginBreakEnd", showBeginBreakEnd);
@@ -86,7 +87,7 @@ public class MatrixController {
         return "dailyreport/matrix";
     }
 
-    @PostMapping("/fill-not-worked")
+    @GetMapping("/fill-not-worked")
     @PreAuthorize("isAuthenticated()")
     public String fillNotWorked(
             @RequestParam(required = false) Long employeeContractId,

--- a/src/main/java/org/tb/dailyreport/controller/MoveTimereportsController.java
+++ b/src/main/java/org/tb/dailyreport/controller/MoveTimereportsController.java
@@ -190,8 +190,8 @@ public class MoveTimereportsController {
   }
 
   private void addSectionAttributes(Model model) {
-    model.addAttribute("section", "dailyreport");
+    model.addAttribute("section", "backoffice");
     model.addAttribute("subSection", "move-timereports");
-    model.addAttribute("sectionTitle", messages.getMessage("main.general.mainmenu.timereports.text"));
+    model.addAttribute("sectionTitle", messages.getMessage("main.general.mainmenu.backoffice.text"));
   }
 }

--- a/src/main/java/org/tb/dailyreport/controller/OvertimeController.java
+++ b/src/main/java/org/tb/dailyreport/controller/OvertimeController.java
@@ -37,8 +37,6 @@ public class OvertimeController {
     @PreAuthorize("isAuthenticated()")
     public String show(@RequestParam(required = false) Long employeeContractId, Model model) {
         long ecId = effectiveContractId(employeeContractId);
-        var contracts = employeecontractService
-            .getViewableEmployeeContractsForAuthorizedUserValidAt(today());
         OvertimeReport report = ecId > 0
             ? overtimeService.createDetailedReportForEmployee(ecId)
             : null;
@@ -55,15 +53,13 @@ public class OvertimeController {
                     overtimeMismatch = detailed.minus(stored);
                 }
             }
-            var contract = contracts.stream()
-                .filter(ec -> ec.getId() == ecId)
-                .findFirst()
-                .orElseGet(() -> employeecontractService.getEmployeecontractById(ecId));
+            var contract = employeecontractService.getEmployeecontractById(ecId);
             reportReleaseDate = contract.getReportReleaseDate();
             reportAcceptanceDate = contract.getReportAcceptanceDate();
+            model.addAttribute("selectedEmployeeName", contract.getEmployee().getName() + " | " + contract.getEmployee().getSign()
+                + "  (" + contract.getTimeString() + (contract.getOpenEnd() ? " ∞" : "") + ")");
         }
 
-        model.addAttribute("employeecontracts", contracts);
         model.addAttribute("selectedContractId", ecId);
         model.addAttribute("overtimeReport", report);
         model.addAttribute("overtimeMismatch", overtimeMismatch);

--- a/src/main/java/org/tb/dailyreport/controller/ReleaseController.java
+++ b/src/main/java/org/tb/dailyreport/controller/ReleaseController.java
@@ -37,15 +37,17 @@ public class ReleaseController {
     private final ErrorCodeViewHelper errorCodeViewHelper;
 
     @GetMapping
-    public String show(Model model) {
-        var loginEmployee = employeeService.getLoginEmployee();
-        var contract = employeecontractService.getCurrentContract(loginEmployee.getId()).orElse(null);
+    public String show(@RequestParam(required = false) Long employeeContractId, Model model) {
 
-        model.addAttribute("loginEmployee", loginEmployee);
-        model.addAttribute("loginEmployeeContract", contract);
+        var effectiveContractId = effectiveContractId(employeeContractId);
+        var contract = employeecontractService.getEmployeecontractById(effectiveContractId);
+        var employee = contract.getEmployee();
+
+        model.addAttribute("employee", employee);
+        model.addAttribute("employeeContract", contract);
         model.addAttribute("selfReleaseDateStr", defaultReleaseDateStr(contract));
-        model.addAttribute("releasedUntil", contract != null ? format(contract.getReportReleaseDate()) : "");
-        model.addAttribute("acceptedUntil", contract != null ? format(contract.getReportAcceptanceDate()) : "");
+        model.addAttribute("releasedUntil", format(contract.getReportReleaseDate()));
+        model.addAttribute("acceptedUntil", format(contract.getReportAcceptanceDate()));
         model.addAttribute("section", "dailyreport");
         model.addAttribute("subSection", "release");
         model.addAttribute("pageTitle", messages.getMessage("main.general.mainmenu.release.text"));
@@ -54,10 +56,11 @@ public class ReleaseController {
     }
 
     @PostMapping
-    public String release(@RequestParam(required = false) String selfReleaseDate,
+    public String release(@RequestParam(required = false) Long employeeContractId,
+                          @RequestParam(required = false) String selfReleaseDate,
                           RedirectAttributes redirectAttributes) {
-        var loginEmployee = employeeService.getLoginEmployee();
-        var contract = employeecontractService.getCurrentContract(loginEmployee.getId()).orElse(null);
+        var effectiveContractId = effectiveContractId(employeeContractId);
+        var contract = employeecontractService.getEmployeecontractById(effectiveContractId);
         if (contract == null) {
             return "redirect:/release";
         }
@@ -69,6 +72,16 @@ public class ReleaseController {
             redirectAttributes.addFlashAttribute("toastErrors", allMessages(ex));
         }
         return "redirect:/release";
+    }
+
+    private long effectiveContractId(Long employeeContractId) {
+        if (employeeContractId != null && employeeContractId > 0) {
+            return employeeContractId;
+        }
+        var loginEmployee = employeeService.getLoginEmployee();
+        return employeecontractService.getCurrentContract(loginEmployee.getId())
+                .map(Employeecontract::getId)
+                .orElse(-1L);
     }
 
     private String defaultReleaseDateStr(Employeecontract contract) {

--- a/src/main/java/org/tb/dailyreport/controller/TimereportController.java
+++ b/src/main/java/org/tb/dailyreport/controller/TimereportController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.tb.auth.domain.Authorized;
-import org.tb.auth.domain.AuthorizedUser;
 import org.tb.common.exception.ErrorCodeException;
 import org.tb.common.exception.InvalidDataException;
 import org.tb.common.viewhelper.ErrorCodeViewHelper;
@@ -52,7 +51,6 @@ public class TimereportController {
     private final WorkingdayService workingdayService;
     private final FavoriteService favoriteService;
     private final EmployeeService employeeService;
-    private final AuthorizedUser authorizedUser;
     private final MessageSourceAccessor messages;
     private final ErrorCodeViewHelper errorCodeViewHelper;
 
@@ -178,11 +176,6 @@ public class TimereportController {
         } else {
             model.addAttribute("todaysBookings", List.of());
         }
-        if (authorizedUser.isPeopleLead()) {
-            model.addAttribute("employeecontracts",
-                employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(
-                    date != null ? date : today()));
-        }
         model.addAttribute("oobSidebar", true);
         return "dailyreport/timereport-form :: ordersRefreshCompositeFragment";
     }
@@ -215,11 +208,6 @@ public class TimereportController {
         } else {
             model.addAttribute("todaysBookings", List.of());
         }
-        if (authorizedUser.isPeopleLead()) {
-            model.addAttribute("employeecontracts",
-                employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(
-                    date != null ? date : today()));
-        }
         model.addAttribute("oobSidebar", true);
         return "dailyreport/timereport-form :: suborderRefreshCompositeFragment";
     }
@@ -237,11 +225,6 @@ public class TimereportController {
             model.addAttribute("todaysBookings", List.of());
         }
         model.addAttribute("recentComments", loadRecentComments(employeeContractId, form));
-        if (authorizedUser.isPeopleLead()) {
-            model.addAttribute("employeecontracts",
-                employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(
-                    form.getReferenceday() != null ? form.getReferenceday() : today()));
-        }
         return "dailyreport/timereport-form :: sidebarFragment";
     }
 
@@ -378,6 +361,13 @@ public class TimereportController {
                 model.addAttribute("liveBookingStartMinutes", startMinutes);
             }
         }
+        if (ecId > 0) {
+            var ec = employeecontractService.getEmployeecontractById(ecId);
+            if (ec != null) {
+                model.addAttribute("selectedEmployeeName", ec.getEmployee().getName() + " | " + ec.getEmployee().getSign()
+                    + "  (" + ec.getTimeString() + (ec.getOpenEnd() ? " ∞" : "") + ")");
+            }
+        }
         model.addAttribute("section", "dailyreport");
         model.addAttribute("subSection", "timereports");
         model.addAttribute("sectionTitle",
@@ -386,10 +376,6 @@ public class TimereportController {
             messages.getMessage(isEdit
                 ? "main.timereport.form.title.edit"
                 : "main.timereport.form.title.create"));
-        if (authorizedUser.isPeopleLead()) {
-            model.addAttribute("employeecontracts",
-                employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(date));
-        }
     }
 
     private List<String> loadRecentComments(Long employeeContractId, TimereportForm form) {

--- a/src/main/java/org/tb/employee/viewhelper/EmployeeContractSelectorViewHelper.java
+++ b/src/main/java/org/tb/employee/viewhelper/EmployeeContractSelectorViewHelper.java
@@ -1,0 +1,47 @@
+package org.tb.employee.viewhelper;
+
+import static org.springframework.web.context.WebApplicationContext.SCOPE_REQUEST;
+import static org.tb.common.util.DateUtils.today;
+import static org.tb.employee.controller.EmployeeUiStateKeyContributor.EMPLOYEE_CONTRACT_ID;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.tb.common.domain.AuditedEntity;
+import org.tb.common.web.UiState;
+import org.tb.employee.domain.AuthorizedEmployee;
+import org.tb.employee.domain.Employeecontract;
+import org.tb.employee.service.EmployeecontractService;
+
+@Component
+@Scope(value = SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@RequiredArgsConstructor
+public class EmployeeContractSelectorViewHelper {
+
+    private final EmployeecontractService employeecontractService;
+    private final UiState uiState;
+    private final AuthorizedEmployee authorizedEmployee;
+
+    private List<Employeecontract> cachedContracts;
+
+    public List<Employeecontract> getViewableContracts() {
+        if (cachedContracts == null) {
+            cachedContracts = employeecontractService.getViewableEmployeeContractsForAuthorizedUserValidAt(today());
+        }
+        return cachedContracts;
+    }
+
+    public boolean isVisible() {
+        return getViewableContracts().size() > 1;
+    }
+
+    public Long getSelectedContractId() {
+        var id = uiState.getLongValue(EMPLOYEE_CONTRACT_ID);
+        return id != null ? id : employeecontractService.getCurrentContract(authorizedEmployee.getEmployeeId())
+                .map(AuditedEntity::getId)
+                .orElse(null);
+    }
+
+}

--- a/src/main/java/org/tb/order/controller/EmployeeorderController.java
+++ b/src/main/java/org/tb/order/controller/EmployeeorderController.java
@@ -36,7 +36,6 @@ import org.tb.common.util.DurationUtils;
 import org.tb.common.viewhelper.ErrorCodeViewHelper;
 import org.tb.common.web.UiState;
 import org.tb.customer.service.CustomerService;
-import org.tb.employee.domain.AuthorizedEmployee;
 import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeecontractService;
 import org.tb.order.domain.Customerorder;
@@ -59,14 +58,13 @@ public class EmployeeorderController {
     private final EmployeecontractService employeecontractService;
     private final CustomerorderService customerorderService;
     private final SuborderService suborderService;
-    private final AuthorizedEmployee authorizedEmployee;
     private final MessageSourceAccessor messages;
     private final ErrorCodeViewHelper errorCodeViewHelper;
     private final UiState uiState;
 
     @GetMapping
     public String list(
-            @RequestParam(required = false) Long employeeContractId,
+            @RequestParam(required = false) Long eoEmployeeContractId,
             @RequestParam(required = false) Long customerId,
             @RequestParam(required = false) Long orderId,
             @RequestParam(required = false) Long suborderId,
@@ -77,21 +75,21 @@ public class EmployeeorderController {
             HttpServletRequest request,
             Model model) {
         var employeeContracts = employeecontractService.getVisibleEmployeeContracts();
-        if (employeeContractId == null && employeeContracts.size() == 1) {
-            employeeContractId = employeeContracts.getFirst().getId();
+        if (eoEmployeeContractId == null && employeeContracts.size() == 1) {
+            eoEmployeeContractId = employeeContracts.getFirst().getId();
         }
         var orders = customerorderService.getCustomerordersByFilters(eoShowInvalid, eoFilter, customerId, eoShowHidden);
 
         var filterSet = (eoFilter != null && !eoFilter.isEmpty()) ||
                         customerId != null ||
-                        employeeContractId != null ||
+                        eoEmployeeContractId != null ||
                         orderId != null ||
                         suborderId != null;
 
         List<EmployeeorderListItemDTO> employeeOrders = List.of();
         if(filterSet) {
             employeeOrders = employeeorderService.getEmployeeorderListItemsByFilters(
-                eoShowInvalid, eoFilter, employeeContractId, customerId, orderId, suborderId, Boolean.TRUE.equals(eoShowActualHours), eoShowHidden);
+                eoShowInvalid, eoFilter, eoEmployeeContractId, customerId, orderId, suborderId, Boolean.TRUE.equals(eoShowActualHours), eoShowHidden);
         }
 
         List<Suborder> suborders = List.of();
@@ -104,7 +102,7 @@ public class EmployeeorderController {
         model.addAttribute("orders", orders);
         model.addAttribute("suborders", suborders);
         model.addAttribute("employeeorders", employeeOrders);
-        model.addAttribute("employeeContractId", employeeContractId);
+        model.addAttribute("eoEmployeeContractId", eoEmployeeContractId);
         model.addAttribute("orderId", orderId);
         model.addAttribute("suborderId", suborderId);
         model.addAttribute("eoFilter", eoFilter);
@@ -120,7 +118,7 @@ public class EmployeeorderController {
     @PreAuthorize("hasRole('MANAGER')")
     @GetMapping("/create")
     public String createForm(
-            @RequestParam(required = false) Long employeeContractId,
+            @RequestParam(required = false) Long eoEmployeeContractId,
             @RequestParam(required = false) Long customerId,
             @RequestParam(required = false) Long orderId,
             @RequestParam(required = false) Long suborderId,
@@ -129,7 +127,7 @@ public class EmployeeorderController {
         var form = (EmployeeorderForm) model.asMap().get("prefillForm");
         if (form == null) {
             form = new EmployeeorderForm();
-            form.setEmployeeContractId(employeeContractId);
+            form.setEmployeeContractId(eoEmployeeContractId);
             form.setCustomerId(customerId);
             form.setOrderId(orderId);
             form.setSuborderId(suborderId);
@@ -316,14 +314,14 @@ public class EmployeeorderController {
     @PreAuthorize("hasRole('MANAGER')")
     @PostMapping("/adjust-dates")
     public String adjustDates(
-            @RequestParam(required = false, defaultValue = "-1") Long employeeContractId,
+            @RequestParam(required = false, defaultValue = "-1") Long eoEmployeeContractId,
             @RequestParam(required = false, defaultValue = "-1") Long orderId,
             @RequestParam(required = false, defaultValue = "-1") Long suborderId,
             @RequestParam(required = false) String filter,
             @RequestParam(required = false) Boolean show,
             RedirectAttributes redirectAttributes) {
 
-        Long filterEmployeeContractId = employeeContractId == -1 ? null : employeeContractId;
+        Long filterEmployeeContractId = eoEmployeeContractId == -1 ? null : eoEmployeeContractId;
         Long filterOrderId = orderId == -1 ? null : orderId;
         Long filterSuborderId = suborderId == -1 ? null : suborderId;
         var employeeOrders = employeeorderService.getEmployeeordersByFilters(show, filter, filterEmployeeContractId, filterOrderId, filterSuborderId, null);

--- a/src/main/java/org/tb/order/controller/OrderUiStateKeyContributor.java
+++ b/src/main/java/org/tb/order/controller/OrderUiStateKeyContributor.java
@@ -21,6 +21,7 @@ public class OrderUiStateKeyContributor implements UiStateKeyContributor {
     public static final UiStateKey SUBORDER_SHOW_INVALID = new UiStateKey("suborder.ShowInvalid");
     public static final UiStateKey SUBORDER_SHOW_HIDDEN = new UiStateKey("suborder.ShowHidden");
     public static final UiStateKey SUBORDER_SHOW_ACTUAL_HOURS = new UiStateKey("suborder.ShowActualHours");
+    public static final UiStateKey EMPLOYEEORDER_EMPLOYEE_CONTRACT_ID = new UiStateKey("employeeOrder.EmployeeContract.Id");
     public static final UiStateKey EMPLOYEEORDER_FILTER = new UiStateKey("employeeOrder.Filter");
     public static final UiStateKey EMPLOYEEORDER_SHOW_INVALID = new UiStateKey("employeeOrder.ShowInvalid");
     public static final UiStateKey EMPLOYEEORDER_SHOW_HIDDEN = new UiStateKey("employeeOrder.ShowHidden");
@@ -40,7 +41,8 @@ public class OrderUiStateKeyContributor implements UiStateKeyContributor {
         map.put("soFilter", SUBORDER_FILTER);
         map.put("soShowInvalid", SUBORDER_SHOW_INVALID);
         map.put("soShowHidden", SUBORDER_SHOW_HIDDEN);
-        map.put("csoShowActualHours", SUBORDER_SHOW_ACTUAL_HOURS);
+        map.put("soShowActualHours", SUBORDER_SHOW_ACTUAL_HOURS);
+        map.put("eoEmployeeContractId", EMPLOYEEORDER_EMPLOYEE_CONTRACT_ID);
         map.put("eoFilter", EMPLOYEEORDER_FILTER);
         map.put("eoShowInvalid", EMPLOYEEORDER_SHOW_INVALID);
         map.put("eoShowHidden", EMPLOYEEORDER_SHOW_HIDDEN);

--- a/src/main/resources/templates/dailyreport/csv.html
+++ b/src/main/resources/templates/dailyreport/csv.html
@@ -154,14 +154,9 @@
             <p class="text-muted" th:text="#{main.dailyreport.csv.import.desc.text}">
               Upload a CSV file to load working day data and time bookings.
             </p>
-            <div class="mb-3" th:if="${#lists.size(employeecontracts) > 1}">
-              <label class="form-label" th:text="#{main.timereport.sidebar.employee.title}">Mitarbeiter</label>
-              <select class="form-select tomselect" name="employeeContractId">
-                <option th:each="ec : ${employeecontracts}"
-                        th:value="${ec.id}"
-                        th:text="${ec.employee.name}"
-                        th:selected="${ec.id == selectedContractId}"></option>
-              </select>
+            <div th:if="${selectedEmployeeName != null}" class="mb-3">
+              <div class="form-label mb-1" th:text="#{main.employeecontract.employee.text}">Mitarbeiter</div>
+              <div th:text="${selectedEmployeeName}"></div>
             </div>
             <div class="mb-3">
               <label class="form-label required" th:text="#{main.dailyreport.csv.import.file.label.text}">CSV file</label>
@@ -213,16 +208,9 @@
           <p class="text-muted" th:text="#{main.dailyreport.csv.export.desc.text}">
             Download all working day data and time bookings for a month as CSV.
           </p>
-          <div class="mb-3" th:if="${#lists.size(employeecontracts) > 1}">
-            <label class="form-label" th:text="#{main.timereport.sidebar.employee.title}">Mitarbeiter</label>
-            <form th:action="@{/dailyreport/csv}" method="get">
-              <select class="form-select tomselect" name="employeeContractId" onchange="this.form.submit()">
-                <option th:each="ec : ${employeecontracts}"
-                        th:value="${ec.id}"
-                        th:text="${ec.employee.name}"
-                        th:selected="${ec.id == selectedContractId}"></option>
-              </select>
-            </form>
+          <div th:if="${selectedEmployeeName != null}" class="mb-3">
+            <div class="form-label mb-1" th:text="#{main.employeecontract.employee.text}">Mitarbeiter</div>
+            <div th:text="${selectedEmployeeName}"></div>
           </div>
           <div class="mb-3">
             <label class="form-label required" th:text="#{main.dailyreport.csv.export.period.label.text}">Period</label>

--- a/src/main/resources/templates/dailyreport/daily.html
+++ b/src/main/resources/templates/dailyreport/daily.html
@@ -402,26 +402,6 @@
     <!-- Sidebar -->
     <div class="col-lg-4" th:if="${dailyData != null}">
 
-      <!-- Employee selector (People Lead / Manager only) -->
-      <form th:if="${#lists.size(employeecontracts) > 1}" method="get"
-            th:action="@{/dailyreport/daily}" class="card mb-3">
-        <div class="card-header">
-          <h3 class="card-title">
-            <span th:text="#{main.timereport.sidebar.employee.title}">Mitarbeiter</span>
-          </h3>
-        </div>
-        <div class="card-body">
-          <input type="hidden" name="mode" value="daily"/>
-          <input type="hidden" name="date" th:value="${date}"/>
-          <select class="form-select tomselect" name="employeeContractId" onchange="this.form.submit()">
-            <option th:each="ec : ${employeecontracts}"
-                    th:value="${ec.id}"
-                    th:text="${ec.employee.name}"
-                    th:selected="${ec.id == selectedContractId}"></option>
-          </select>
-        </div>
-      </form>
-
       <!-- Week strip -->
       <div class="card mb-3">
         <div class="card-header">
@@ -515,9 +495,6 @@
 <div th:if="${mode == 'list'}">
   <div class="row align-items-start">
 
-    <!-- Main column -->
-    <div class="col-lg-8">
-
       <!-- Month navigation card -->
       <div class="card mb-3">
         <div class="card-body text-center py-3">
@@ -536,6 +513,10 @@
           <a class="btn btn-sm btn-outline-primary"
              th:href="@{/dailyreport/daily(mode='list')}">
             <span th:text="#{main.daily.nav.today.text}">Heute</span>
+          </a>
+          <a th:if="${!listData.monthReleased and selectedContractId > 0 and listData != null}" class="btn btn-sm btn-outline-secondary"
+             th:href="@{/dailyreport/daily/fill-not-worked(month=${yearMonth.monthValue},year=${yearMonth.year})}">
+            <span th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</span>
           </a>
         </div>
       </div>
@@ -622,45 +603,6 @@
       </span>
     </div>
       </div><!-- end day list card -->
-
-    </div><!-- end main col -->
-
-    <!-- Sidebar -->
-    <div class="col-lg-4">
-
-      <!-- Employee selector (People Lead / Manager only) -->
-      <form th:if="${#lists.size(employeecontracts) > 1}" method="get"
-            th:action="@{/dailyreport/daily}" class="card mb-3">
-        <div class="card-header">
-          <h3 class="card-title">
-            <span th:text="#{main.timereport.sidebar.employee.title}">Mitarbeiter</span>
-          </h3>
-        </div>
-        <div class="card-body">
-          <input type="hidden" name="mode" value="list"/>
-          <input type="hidden" th:if="${yearMonth != null}" name="month" th:value="${yearMonth.monthValue}"/>
-          <input type="hidden" th:if="${yearMonth != null}" name="year" th:value="${yearMonth.year}"/>
-          <select class="form-select tomselect" name="employeeContractId" onchange="this.form.submit()">
-            <option th:each="ec : ${employeecontracts}"
-                    th:value="${ec.id}"
-                    th:text="${ec.employee.name}"
-                    th:selected="${ec.id == selectedContractId}"></option>
-          </select>
-        </div>
-      </form>
-
-      <!-- Fill not worked -->
-      <form th:if="${selectedContractId > 0 and listData != null}" method="post"
-            th:action="@{/dailyreport/daily/fill-not-worked}">
-        <input type="hidden" name="month" th:value="${yearMonth.monthValue}"/>
-        <input type="hidden" name="year" th:value="${yearMonth.year}"/>
-        <button type="submit" class="btn btn-outline-secondary w-100"
-                th:disabled="${listData.monthReleased}"
-                th:title="${listData.monthReleased} ? #{main.matrix.fillnotworked.disabled.title} : null"
-                th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</button>
-      </form>
-
-    </div><!-- end sidebar -->
 
   </div>
 </div><!-- end list mode -->

--- a/src/main/resources/templates/dailyreport/dashboard.html
+++ b/src/main/resources/templates/dailyreport/dashboard.html
@@ -8,22 +8,11 @@
   <form th:action="@{/dailyreport/dashboard}" method="post" id="dashboardForm">
     <input type="hidden" name="task" id="dashboardTask" value=""/>
 
-    <div class="card mb-3" th:if="${employeecontracts.size() > 1 || loginEmployees.size() > 1}">
+    <div class="card mb-3" th:if="${loginEmployees.size() > 1}">
       <div class="card-body">
         <div class="row g-3 align-items-end">
 
-          <div class="col-12 col-md-6" th:if="${employeecontracts.size() > 1}">
-            <label class="form-label" th:text="#{main.employeecontract.employee.text}"></label>
-            <select name="employeeContractId" class="form-select tomselect" onchange="submitDashboardTask('refresh')">
-              <option th:each="ec : ${employeecontracts}"
-                      th:value="${ec.id}"
-                      th:selected="${ec.id == currentEmployeeContractId}"
-                      th:text="${ec.employee.name + ' | ' + ec.employee.sign + '  (' + ec.timeString + (ec.openEnd ? ' ∞' : '') + ')'}">
-              </option>
-            </select>
-          </div>
-
-          <div class="col-12 col-md-4" th:if="${loginEmployees.size() > 1}">
+          <div class="col-12 col-md-4">
             <label class="form-label" th:text="#{main.welcome.switchlogin.text}"></label>
             <select name="loginEmployeeId" class="form-select tomselect" onchange="submitDashboardTask('switch-login')">
               <option th:each="emp : ${loginEmployees}"

--- a/src/main/resources/templates/dailyreport/matrix.html
+++ b/src/main/resources/templates/dailyreport/matrix.html
@@ -117,32 +117,10 @@
         </a>
       </div>
       <a class="btn btn-sm btn-outline-secondary" th:href="@{/dailyreport/matrix}">Heute</a>
-
-      <!-- Fill not worked -->
-      <form th:if="${selectedContractId > 0}" method="post" th:action="@{/dailyreport/matrix/fill-not-worked}">
-        <input type="hidden" name="month" th:value="${yearMonth.monthValue}"/>
-        <input type="hidden" name="year" th:value="${yearMonth.year}"/>
-        <button type="submit" class="btn btn-sm btn-outline-secondary"
-                th:disabled="${monthReleased}"
-                th:title="${monthReleased} ? #{main.matrix.fillnotworked.disabled.title} : null"
-                th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</button>
-      </form>
-
-      <!-- Employee selector (only when multiple contracts are viewable) -->
-      <form class="ms-auto" method="get" th:action="@{/dailyreport/matrix}"
-            th:if="${#lists.size(employeecontracts) > 1}">
-        <input type="hidden" name="month" th:value="${yearMonth.monthValue}"/>
-        <input type="hidden" name="year" th:value="${yearMonth.year}"/>
-        <select name="employeeContractId" class="form-select form-select-sm tomselect"
-                onchange="this.form.submit()" style="min-width: 200px">
-          <option th:each="ec : ${employeecontracts}"
-                  th:value="${ec.id}"
-                  th:text="${ec.employee.name}"
-                  th:selected="${ec.id == selectedContractId}">
-          </option>
-        </select>
-      </form>
-
+      <a th:if="${!monthReleased and selectedContractId > 0}"
+         class="btn btn-sm btn-outline-secondary"
+         th:href="@{/dailyreport/matrix/fill-not-worked(month=${yearMonth.monthValue},year=${yearMonth.year})}"
+         th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</a>
     </div>
   </div>
 </div>

--- a/src/main/resources/templates/dailyreport/overtime.html
+++ b/src/main/resources/templates/dailyreport/overtime.html
@@ -4,43 +4,38 @@
       layout:decorate="~{layout/base}" th:with="title=${pageTitle}">
 <section layout:fragment="content">
 
-<div class="row align-items-start">
-
-  <!-- ===== Main content column ===== -->
-  <div class="col">
-
-    <div th:if="${overtimeReport != null}" class="card">
-      <div class="table-responsive">
-        <table class="table table-vcenter table-sm card-table table-striped">
-          <thead>
-            <tr>
-              <th class="w-100" th:text="#{main.headlinedescription.overtime.report.yearmonth.text}"></th>
-              <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.actual.text}"></th>
-              <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.adjustment.text}"></th>
-              <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.sum.text}"></th>
-              <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.target.text}"></th>
-              <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.diff.text}"></th>
-              <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.diffcumulative.text}"></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="fw-bold">
-              <td th:text="#{main.headlinedescription.overtime.report.total.text}"></td>
-              <td class="text-end text-nowrap" th:text="${@durationUtils.format(overtimeReport.total.actual)}"></td>
-              <td class="text-end text-nowrap" th:text="${@durationUtils.format(overtimeReport.total.adjustment)}"></td>
-              <td class="text-end text-nowrap" th:text="${@durationUtils.format(overtimeReport.total.sum)}"></td>
-              <td class="text-end text-nowrap" th:text="${@durationUtils.format(overtimeReport.total.target)}"></td>
-              <td class="text-end text-nowrap"
-                  th:classappend="${overtimeReport.total.diff.negative} ? 'text-danger' : ''"
-                  th:text="${@durationUtils.format(overtimeReport.total.diff)}"></td>
-              <td class="text-end text-nowrap"
-                  th:classappend="${overtimeReport.total.diffCumulative.negative} ? 'text-danger' : ''"
-                  th:text="${@durationUtils.format(overtimeReport.total.diffCumulative)}"></td>
-            </tr>
-            <tr th:each="month : ${overtimeReport.months}">
-              <td class="d-flex justify-content-between align-items-center">
-                <span th:text="${@dateUtils.format(month.yearMonth)}"></span>
-                <span>
+  <div th:if="${overtimeReport != null}" class="card">
+    <div class="table-responsive">
+      <table class="table table-vcenter card-table table-striped">
+        <thead>
+        <tr>
+          <th class="w-100" th:text="#{main.headlinedescription.overtime.report.yearmonth.text}"></th>
+          <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.actual.text}"></th>
+          <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.adjustment.text}"></th>
+          <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.sum.text}"></th>
+          <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.target.text}"></th>
+          <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.diff.text}"></th>
+          <th class="text-end text-nowrap" th:text="#{main.headlinedescription.overtime.report.diffcumulative.text}"></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr class="fw-bold">
+          <td th:text="#{main.headlinedescription.overtime.report.total.text}"></td>
+          <td class="text-end text-nowrap" th:text="${@durationUtils.format(overtimeReport.total.actual)}"></td>
+          <td class="text-end text-nowrap" th:text="${@durationUtils.format(overtimeReport.total.adjustment)}"></td>
+          <td class="text-end text-nowrap" th:text="${@durationUtils.format(overtimeReport.total.sum)}"></td>
+          <td class="text-end text-nowrap" th:text="${@durationUtils.format(overtimeReport.total.target)}"></td>
+          <td class="text-end text-nowrap"
+              th:classappend="${overtimeReport.total.diff.negative} ? 'text-danger' : ''"
+              th:text="${@durationUtils.format(overtimeReport.total.diff)}"></td>
+          <td class="text-end text-nowrap"
+              th:classappend="${overtimeReport.total.diffCumulative.negative} ? 'text-danger' : ''"
+              th:text="${@durationUtils.format(overtimeReport.total.diffCumulative)}"></td>
+        </tr>
+        <tr th:each="month : ${overtimeReport.months}">
+          <td class="d-flex justify-content-between align-items-center">
+            <span th:text="${@dateUtils.format(month.yearMonth)}"></span>
+            <span>
                   <span th:if="${reportReleaseDate != null and !month.yearMonth.atEndOfMonth().isAfter(reportReleaseDate)}"
                         class="badge bg-teal-lt ms-2"
                         th:title="#{main.release.released.until.text}">
@@ -52,70 +47,47 @@
                     <i class="bi bi-patch-check"></i>
                   </span>
                 </span>
-              </td>
-              <td class="text-end text-nowrap" th:text="${@durationUtils.format(month.actual)}"></td>
-              <td class="text-end text-nowrap" th:text="${@durationUtils.format(month.adjustment)}"></td>
-              <td class="text-end text-nowrap" th:text="${@durationUtils.format(month.sum)}"></td>
-              <td class="text-end text-nowrap" th:text="${@durationUtils.format(month.target)}"></td>
-              <td class="text-end text-nowrap"
-                  th:classappend="${month.diff.negative} ? 'text-danger' : ''"
-                  th:text="${@durationUtils.format(month.diff)}"></td>
-              <td class="text-end text-nowrap"
-                  th:classappend="${month.diffCumulative.negative} ? 'text-danger' : ''"
-                  th:text="${@durationUtils.format(month.diffCumulative)}"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+          </td>
+          <td class="text-end text-nowrap" th:text="${@durationUtils.format(month.actual)}"></td>
+          <td class="text-end text-nowrap" th:text="${@durationUtils.format(month.adjustment)}"></td>
+          <td class="text-end text-nowrap" th:text="${@durationUtils.format(month.sum)}"></td>
+          <td class="text-end text-nowrap" th:text="${@durationUtils.format(month.target)}"></td>
+          <td class="text-end text-nowrap"
+              th:classappend="${month.diff.negative} ? 'text-danger' : ''"
+              th:text="${@durationUtils.format(month.diff)}"></td>
+          <td class="text-end text-nowrap"
+              th:classappend="${month.diffCumulative.negative} ? 'text-danger' : ''"
+              th:text="${@durationUtils.format(month.diffCumulative)}"></td>
+        </tr>
+        </tbody>
+      </table>
     </div>
+  </div>
 
-    <div th:if="${overtimeReport == null}" class="card">
-      <div class="card-body text-center text-muted py-4">
-        <span th:text="#{main.general.noentries.text}"></span>
-      </div>
+  <div th:if="${overtimeReport == null}" class="card">
+    <div class="card-body text-center text-muted py-4">
+      <span th:text="#{main.general.noentries.text}"></span>
     </div>
+  </div>
 
-  </div><!-- end main col -->
+  <div class="card mb-3" th:if="${@authorizedUser.manager and overtimeMismatch != null}">
 
-  <!-- ===== Sidebar column ===== -->
-  <div class="col-lg-4" th:if="${#lists.size(employeecontracts) > 1}">
-
-    <!-- Employee selector -->
-    <form method="get" th:action="@{/dailyreport/overtime}" class="card mb-3">
-      <div class="card-header">
-        <h3 class="card-title" th:text="#{main.overtime.employeecontract.text}"></h3>
-      </div>
-      <div class="card-body">
-        <select name="employeeContractId" class="form-select tomselect"
-                onchange="this.form.submit()">
-          <option th:each="ec : ${employeecontracts}"
-                  th:value="${ec.id}"
-                  th:selected="${ec.id == selectedContractId}"
-                  th:text="${ec.employee.name + ' | ' + ec.employee.sign
-                             + '  (' + ec.timeString + (ec.openEnd ? ' ∞' : '') + ')'}">
-          </option>
-        </select>
-      </div>
-    </form>
-
-    <!-- Recalculate — only shown when stored static overtime is stale -->
-    <form th:if="${@authorizedUser.manager and overtimeMismatch != null}"
-          method="post" th:action="@{/dailyreport/overtime/correct(employeeContractId=${selectedContractId})}" class="card">
-      <div class="card-body border-bottom pb-3 mb-3">
-        <div class="text-muted small mb-1" th:text="#{main.overtime.mismatch.text}"></div>
-        <div class="fw-semibold"
-             th:classappend="${overtimeMismatch.negative} ? 'text-danger' : 'text-warning'"
-             th:text="${@durationUtils.format(overtimeMismatch)}"></div>
-      </div>
-      <div class="card-body pt-0">
-        <button type="submit" class="btn btn-outline-secondary w-100"
-                th:text="#{main.overtime.employeecontract.correct.label}"></button>
-      </div>
-    </form>
-
-  </div><!-- end sidebar col -->
-
-</div><!-- end row -->
+    <div class="card-body py-2">
+      <!-- Recalculate — only shown when stored static overtime is stale -->
+      <form method="post" th:action="@{/dailyreport/overtime/correct(employeeContractId=${selectedContractId})}" class="card">
+        <div class="card-body border-bottom pb-3 mb-3">
+          <div class="text-muted small mb-1" th:text="#{main.overtime.mismatch.text}"></div>
+          <div class="fw-semibold"
+               th:classappend="${overtimeMismatch.negative} ? 'text-danger' : 'text-warning'"
+               th:text="${@durationUtils.format(overtimeMismatch)}"></div>
+        </div>
+        <div class="card-body pt-0">
+          <button type="submit" class="btn btn-outline-secondary w-100"
+                  th:text="#{main.overtime.employeecontract.correct.label}"></button>
+        </div>
+      </form>
+    </div>
+  </div>
 
 </section>
 </html>

--- a/src/main/resources/templates/dailyreport/release.html
+++ b/src/main/resources/templates/dailyreport/release.html
@@ -7,7 +7,7 @@
 
   <div class="card">
     <div class="card-header">
-      <h3 class="card-title" th:text="${loginEmployee.name}"></h3>
+      <h3 class="card-title" th:text="${employee.name}"></h3>
       <div class="card-options d-none d-sm-flex">
         <span class="text-muted small">
           <span th:text="#{main.release.released.until.text}">freigegeben bis</span>:
@@ -22,7 +22,7 @@
     </div>
     <div class="card-body">
 
-      <form th:if="${loginEmployeeContract != null}" method="post" th:action="@{/release}">
+      <form th:if="${employeeContract != null}" method="post" th:action="@{/release}">
         <label class="form-label fw-semibold" th:text="#{main.release.release.until.text}">Buchungen freigeben bis (incl.)</label>
         <div class="row g-2 align-items-center">
           <div class="col-auto">
@@ -36,7 +36,7 @@
         </div>
       </form>
 
-      <div th:if="${loginEmployeeContract == null}" class="text-muted">
+      <div th:if="${employeeContract == null}" class="text-muted">
         <i class="bi bi-info-circle me-1"></i>
         <span th:text="#{main.release.no.active.contract.text}">Kein aktiver Mitarbeitervertrag gefunden.</span>
       </div>

--- a/src/main/resources/templates/dailyreport/timereport-form.html
+++ b/src/main/resources/templates/dailyreport/timereport-form.html
@@ -22,6 +22,11 @@
 
           <div class="card-body">
 
+            <div th:if="${selectedEmployeeName != null}" class="mb-3">
+              <div class="form-label mb-1" th:text="#{main.employeecontract.employee.text}">Mitarbeiter</div>
+              <div th:text="${selectedEmployeeName}"></div>
+            </div>
+
             <!-- Row 1: Date + Duration/Begin-End -->
             <div class="row g-3 mb-3">
 
@@ -195,26 +200,6 @@
     <div class="col-lg-5">
       <div id="form-sidebar" th:fragment="sidebarFragment"
            th:attr="hx-swap-oob=${oobSidebar == true ? 'outerHTML' : null}">
-
-        <!-- Employee selector (People Lead / Manager only) -->
-        <form th:if="${employeecontracts != null}" method="get"
-              th:action="@{/dailyreport/timereports/new}"
-              class="card mb-3">
-          <div class="card-header">
-            <h3 class="card-title">
-              <span th:text="#{main.timereport.sidebar.employee.title}">Mitarbeiter</span>
-            </h3>
-          </div>
-          <div class="card-body">
-            <input type="hidden" name="date" th:value="${timereportForm.referenceday}"/>
-            <select class="form-select tomselect" name="employeeContractId" onchange="this.form.submit()">
-              <option th:each="ec : ${employeecontracts}"
-                      th:value="${ec.id}"
-                      th:text="${ec.employee.name}"
-                      th:selected="${ec.id == selectedContractId}"></option>
-            </select>
-          </div>
-        </form>
 
         <!-- Today's bookings -->
         <div class="card mb-3">

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -290,13 +290,26 @@
           </div>
           <!-- Page title actions -->
           <div class="col-auto ms-auto d-print-none">
-            <div class="btn-list">
-              <button class="btn hide-theme-dark" aria-label="Enable dark mode" onclick="toggleTheme('dark')">
-                <i class="ti ti-moon ti-size-3"></i>
-              </button>
-              <button class="btn hide-theme-light" aria-label="Enable light mode" onclick="toggleTheme('light')">
-                <i class="ti ti-sun-high ti-size-3"></i>
-              </button>
+            <div class="d-flex align-items-center gap-2">
+              <div th:if="${@employeeContractSelectorViewHelper.visible}" style="min-width: 220px">
+                <select class="form-select tomselect" id="globalEmployeeContractId"
+                        onchange="selectContract(this.value)">
+                  <option th:each="ec : ${@employeeContractSelectorViewHelper.viewableContracts}"
+                          th:value="${ec.id}"
+                          th:selected="${ec.id == @employeeContractSelectorViewHelper.selectedContractId}"
+                          th:text="${ec.employee.name + ' | ' + ec.employee.sign
+                                    + '  (' + ec.timeString + (ec.openEnd ? ' ∞' : '') + ')'}">
+                  </option>
+                </select>
+              </div>
+              <div class="btn-list">
+                <button class="btn hide-theme-dark" aria-label="Enable dark mode" onclick="toggleTheme('dark')">
+                  <i class="ti ti-moon ti-size-3"></i>
+                </button>
+                <button class="btn hide-theme-light" aria-label="Enable light mode" onclick="toggleTheme('light')">
+                  <i class="ti ti-sun-high ti-size-3"></i>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -430,6 +443,12 @@
   function toggleTheme(theme) {
     localStorage.setItem('tabler-theme', theme)
     document.documentElement.setAttribute('data-bs-theme', theme)
+  }
+  function selectContract(id) {
+    // Preserves all existing GET query params; only sets/replaces employeeContractId.
+    const url = new URL(window.location.href)
+    url.searchParams.set('employeeContractId', id)
+    window.location.href = url.toString()
   }
 </script>
 <script th:src="@{/webjars/htmx.org/dist/htmx.min.js}"></script>

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -291,7 +291,7 @@
           <!-- Page title actions -->
           <div class="col-auto ms-auto d-print-none">
             <div class="d-flex align-items-center gap-2">
-              <div th:if="${@employeeContractSelectorViewHelper.visible}" style="min-width: 220px">
+              <div th:if="${section == 'dailyreport' and @employeeContractSelectorViewHelper.visible}" style="min-width: 220px">
                 <select class="form-select tomselect" id="globalEmployeeContractId"
                         onchange="selectContract(this.value)">
                   <option th:each="ec : ${@employeeContractSelectorViewHelper.viewableContracts}"

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -110,18 +110,6 @@
                      th:text="#{main.general.mainmenu.release.text}">
                     Freigabe
                   </a>
-                  <a class="dropdown-item" th:href="@{/acceptance}"
-                     th:if="${#authorization.expression('hasRole(''PEOPLE_LEAD'')')}"
-                     th:classappend="${subSection == 'acceptance'} ? 'active' : ''"
-                     th:text="#{main.general.mainmenu.acceptance.text}">
-                    Abnahme
-                  </a>
-                  <a class="dropdown-item" th:href="@{/dailyreports/move}"
-                     th:if="${#authorization.expression('hasRole(''MANAGER'')')}"
-                     th:classappend="${subSection == 'move-timereports'} ? 'active' : ''">
-                    <span th:text="#{main.general.mainmenu.movetimereports.text}">Buchungen umbuchen</span>
-                    <span class="badge bg-purple-lt ms-1">New</span>
-                  </a>
                   <a class="dropdown-item" th:href="@{/my-accounts}"
                      th:if="${not #authorization.expression('hasRole(''RESTRICTED'')')}"
                      th:classappend="${subSection == 'my-accounts'} ? 'active' : ''"
@@ -236,6 +224,18 @@
                      th:classappend="${subSection == 'invoice'} ? 'active' : ''"
                      th:if="${#authorization.expression('hasRole(''BACKOFFICE'')')}">
                     Rechnungsanlage
+                  </a>
+                  <a class="dropdown-item" th:href="@{/acceptance}"
+                     th:if="${#authorization.expression('hasRole(''PEOPLE_LEAD'')')}"
+                     th:classappend="${subSection == 'acceptance'} ? 'active' : ''"
+                     th:text="#{main.general.mainmenu.acceptance.text}">
+                    Abnahme
+                  </a>
+                  <a class="dropdown-item" th:href="@{/dailyreports/move}"
+                     th:if="${#authorization.expression('hasRole(''MANAGER'')')}"
+                     th:classappend="${subSection == 'move-timereports'} ? 'active' : ''">
+                    <span th:text="#{main.general.mainmenu.movetimereports.text}">Buchungen umbuchen</span>
+                    <span class="badge bg-purple-lt ms-1">New</span>
                   </a>
                   <a class="dropdown-item" th:href="@{/orders/revenue-upload}"
                      th:classappend="${subSection == 'revenue-upload'} ? 'active' : ''"

--- a/src/main/resources/templates/order/employee-order-list.html
+++ b/src/main/resources/templates/order/employee-order-list.html
@@ -15,12 +15,12 @@
         <div class="row g-2 align-items-end">
           <div class="col-md-8">
             <label class="form-label" th:text="#{main.employeecontract.employee.text}">Employee</label>
-            <select class="form-select tomselect" name="employeeContractId">
+            <select class="form-select tomselect" name="eoEmployeeContractId">
               <option value="" th:text="#{main.employee.select.please}">--- Please select ---</option>
               <option th:each="ec : ${employeecontracts}"
                       th:value="${ec.id}"
                       th:text="${ec.employee.name + ' | ' + ec.employee.sign + '  (' + ec.timeString + (ec.openEnd ? ' &infin;' : '') + ')'}"
-                      th:selected="${employeeContractId != null and employeeContractId == ec.id}"></option>
+                      th:selected="${eoEmployeeContractId != null and eoEmployeeContractId == ec.id}"></option>
             </select>
           </div>
           <div class="col-md-auto ms-auto" th:if="${#authorization.expression('hasRole(''MANAGER'')')}">


### PR DESCRIPTION
## Summary

- Add `EmployeeContractSelectorViewHelper` (request-scoped bean in `employee/viewhelper`) that exposes viewable contracts and the currently selected contract ID via UiState
- Add a TomSelect dropdown in `layout/base.html` header, visible only when `viewableContracts.size() > 1` (people leads and managers), restricted to the `dailyreport` section
- Selection persists via the existing `UiStateFilter` + cookie mechanism — no session state
- Remove per-page `employeecontracts` list population from all affected controllers (Dashboard, Daily, Timereport, Overtime, Matrix, Csv, Release)
- Remove per-page contract `<select>` elements from all affected templates
- Add read-only `selectedEmployeeName` display (label + normal-weight value, format: `name | sign  (timeString ∞)`) to all data-capture forms
- Rename `employeeContractId` → `eoEmployeeContractId` in the employee-order list to avoid UiState key collision; register dedicated `EMPLOYEEORDER_EMPLOYEE_CONTRACT_ID` key
- Move Acceptance and MoveTimereports nav items to the Backoffice section
- Wire `ReleaseController` to the global selector via `effectiveContractId()` helper

## Test plan

- [x] Manager login: global selector appears in header on dailyreport pages; selecting a contract reloads the page; subsequent pages remember the selection (cookie)
- [x] People lead login: selector shows only supervised employee contracts
- [x] Regular employee login: selector is hidden (only one contract)
- [x] Per-page dropdowns are gone: dashboard, daily, overtime, timereport-form, matrix, csv no longer show their own contract selects
- [x] Read-only employee name display (with label) appears on data-capture forms when a non-own contract is selected
- [x] Switching contract on matrix page preserves month/year params in URL
- [x] Employee order list filter still works with `eoEmployeeContractId` param
- [x] Release page respects the globally selected contract
- [x] Dark mode toggle still present and functional alongside the new selector
- [x] Build passes: `jenv exec ./mvnw verify`

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #742