### PR TITLE
Enable CSRF protection via Spring Security (cookie token, HTMX)

### DIFF
--- a/docs/adr/0018-csrf-schutz-mit-cookie-tokenrepository.md
+++ b/docs/adr/0018-csrf-schutz-mit-cookie-tokenrepository.md
@@ -7,7 +7,7 @@ Status: Accepted
 
 CSRF-Schutz war in allen Spring Security Filter Chains deaktiviert. Die Anwendung verwendet eine stateless Session-Policy (`STATELESS`), daher ist ein `HttpSession`-basiertes Token-Speichermodell nicht praktikabel. Gleichzeitig werden Thymeleaf-Formulare (reguläre POST-Submissions) und HTMX 2.0 (partielle Updates via `hx-post`) für die UI verwendet.
 
-Ziel: CSRF-Schutz für alle Production-/Staging-/LocalEasyAuth- und LocalDev-Filter-Chains aktivieren, ohne HttpSession-Abhängigkeit einzuführen, und transparent für Thymeleaf-Formulare sowie HTMX-Anfragen.
+Ziel: CSRF-Schutz für Production-/Staging-/LocalEasyAuth-Filter-Chains aktivieren, ohne HttpSession-Abhängigkeit einzuführen, und transparent für Thymeleaf-Formulare sowie HTMX-Anfragen. Der `local`-Profile-Chain bleibt deaktiviert (siehe Consequences).
 
 ## Considered Options
 
@@ -27,6 +27,7 @@ Chosen: **Option A**, weil `CsrfTokenRequestAttributeHandler` cookie-Wert, Formu
 * Good: Nach einem HTMX-Response werden veraltete `_csrf` Hidden-Felder per `htmx:afterSettle`-Handler in `salat.js` aktualisiert.
 * Bad (BREACH-Trade-off): `XorCsrfTokenRequestAttributeHandler` würde pro Render einen anderen XOR-maskierten Wert liefern und damit BREACH-Angriffe erschweren. `CsrfTokenRequestAttributeHandler` omitiert dieses Masking. Für diese Anwendung akzeptabel, weil: (a) ein Angreifer, der komprimierte Antwortinhalte kontrolliert, ein unrealistisches Bedrohungsmodell für eine interne Zeiterfassungsanwendung darstellt; (b) HTMX-Anfragen senden den Raw-Token ohnehin als Header; (c) die Cookie-Refresh-Anforderung macht XOR-Masking ohne server-seitige Koordination nicht praktikabel.
 * Neutral: REST-API-Chains (`/api/**`, `/rest/**`) und statische Ressourcen (Order 0) behalten `csrf(disable)` — sie verwenden Token-basierte Authentifizierung bzw. haben keine State-modifizierenden Formulare.
+* Neutral: `LocalDevSecurityConfiguration` (`local`-Profil) behält `csrf(disable)`. Grund: Chrome sendet Cookies ohne explizites `SameSite`-Attribut bei Plain-HTTP auf localhost nicht zuverlässig, was zu 403-Fehlern beim Lokaltesting führt. Da der lokale Dev-Server nicht aus dem Internet erreichbar ist, ist das Risiko akzeptabel.
 
 ## Token-Speicher und Verarbeitung
 

--- a/docs/adr/0018-csrf-schutz-mit-cookie-tokenrepository.md
+++ b/docs/adr/0018-csrf-schutz-mit-cookie-tokenrepository.md
@@ -1,0 +1,36 @@
+# ADR-0018 CSRF-Schutz mit CookieCsrfTokenRepository und CsrfTokenRequestAttributeHandler
+
+Date: 2026-06-28
+Status: Accepted
+
+## Context and Problem Statement
+
+CSRF-Schutz war in allen Spring Security Filter Chains deaktiviert. Die Anwendung verwendet eine stateless Session-Policy (`STATELESS`), daher ist ein `HttpSession`-basiertes Token-Speichermodell nicht praktikabel. Gleichzeitig werden Thymeleaf-Formulare (reguläre POST-Submissions) und HTMX 2.0 (partielle Updates via `hx-post`) für die UI verwendet.
+
+Ziel: CSRF-Schutz für alle Production-/Staging-/LocalEasyAuth- und LocalDev-Filter-Chains aktivieren, ohne HttpSession-Abhängigkeit einzuführen, und transparent für Thymeleaf-Formulare sowie HTMX-Anfragen.
+
+## Considered Options
+
+* **Option A:** `CookieCsrfTokenRepository` + `CsrfTokenRequestAttributeHandler` (raw token)
+* **Option B:** `CookieCsrfTokenRepository` + `XorCsrfTokenRequestAttributeHandler` (XOR-masked, Spring Security 6 Standard)
+* **Option C:** CSRF-Schutz deaktiviert lassen
+
+## Decision Outcome
+
+Chosen: **Option A**, weil `CsrfTokenRequestAttributeHandler` cookie-Wert, Formularfeld-Wert und HTMX-Header denselben raw Token-Wert tragen — JavaScript kann nach jedem HTMX-Response den `_csrf` Input direkt aus dem Cookie aktualisieren.
+
+### Consequences
+
+* Good: Stateless — kein HttpSession erforderlich; passt zur bestehenden `STATELESS` Session-Policy.
+* Good: Thymeleaf-Formulare funktionieren ohne Template-Änderungen — `CsrfRequestDataValueProcessor` injiziert das Hidden-Feld automatisch über `th:action`.
+* Good: HTMX-Anfragen senden den Token als `X-XSRF-TOKEN`-Header (via `htmx:configRequest`-Listener in `base.html`).
+* Good: Nach einem HTMX-Response werden veraltete `_csrf` Hidden-Felder per `htmx:afterSettle`-Handler in `salat.js` aktualisiert.
+* Bad (BREACH-Trade-off): `XorCsrfTokenRequestAttributeHandler` würde pro Render einen anderen XOR-maskierten Wert liefern und damit BREACH-Angriffe erschweren. `CsrfTokenRequestAttributeHandler` omitiert dieses Masking. Für diese Anwendung akzeptabel, weil: (a) ein Angreifer, der komprimierte Antwortinhalte kontrolliert, ein unrealistisches Bedrohungsmodell für eine interne Zeiterfassungsanwendung darstellt; (b) HTMX-Anfragen senden den Raw-Token ohnehin als Header; (c) die Cookie-Refresh-Anforderung macht XOR-Masking ohne server-seitige Koordination nicht praktikabel.
+* Neutral: REST-API-Chains (`/api/**`, `/rest/**`) und statische Ressourcen (Order 0) behalten `csrf(disable)` — sie verwenden Token-basierte Authentifizierung bzw. haben keine State-modifizierenden Formulare.
+
+## Token-Speicher und Verarbeitung
+
+- **Repository:** `CookieCsrfTokenRepository.withHttpOnlyFalse()` — speichert den Token im Cookie `XSRF-TOKEN`; `httpOnly=false` erlaubt JavaScript den Zugriff.
+- **Handler:** `CsrfTokenRequestAttributeHandler` — Token im Formularfeld = Token im Header = Token im Cookie (raw, kein XOR).
+- **HTMX:** `htmx:configRequest`-Listener in `layout/base.html` liest `XSRF-TOKEN`-Cookie und setzt `X-XSRF-TOKEN`-Header auf jeder HTMX-Anfrage.
+- **Stale Forms:** `htmx:afterSettle`-Handler in `salat.js` refresht alle `input[name="_csrf"]` aus dem aktuellen Cookie-Wert nach jedem HTMX-Response.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,3 +31,4 @@ Format: [MADR](https://adr.github.io/madr/) — Markdown Any Decision Records.
 | [0015](0015-error-modul-fuer-fehlerseite.md) | Eigenes `error`-Modul für die Fehlerseite | Accepted | 2026-06-21 |
 | [0016](0016-uistate-key-ownership-per-modul.md) | UiState-Key-Ownership pro Modul | Accepted | 2026-06-21 |
 | [0017](0017-viewhelper-fuer-darstellungslogik.md) | ViewHelper-Klassen für darstellungsspezifische Aufbereitung | Accepted | 2026-06-22 |
+| [0018](0018-csrf-schutz-mit-cookie-tokenrepository.md) | CSRF-Schutz mit CookieCsrfTokenRepository und CsrfTokenRequestAttributeHandler | Accepted | 2026-06-28 |

--- a/src/main/java/org/tb/auth/configuration/AzureEasyAuthSecurityConfiguration.java
+++ b/src/main/java/org/tb/auth/configuration/AzureEasyAuthSecurityConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.util.Assert;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -105,8 +106,9 @@ public class AzureEasyAuthSecurityConfiguration {
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)))
         .sessionManagement(sm -> sm.sessionCreationPolicy(STATELESS))
         .cors(AbstractHttpConfigurer::disable)
-        .csrf(AbstractHttpConfigurer::disable);
-    ;
+        .csrf(csrf -> csrf
+            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+            .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()));
     return http.build();
   }
 

--- a/src/main/java/org/tb/auth/configuration/AzureEasyAuthSecurityConfiguration.java
+++ b/src/main/java/org/tb/auth/configuration/AzureEasyAuthSecurityConfiguration.java
@@ -107,8 +107,9 @@ public class AzureEasyAuthSecurityConfiguration {
         .sessionManagement(sm -> sm.sessionCreationPolicy(STATELESS))
         .cors(AbstractHttpConfigurer::disable)
         .csrf(csrf -> csrf
-            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-            .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()));
+          .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+          .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+        );
     return http.build();
   }
 

--- a/src/main/java/org/tb/auth/configuration/LocalDevSecurityConfiguration.java
+++ b/src/main/java/org/tb/auth/configuration/LocalDevSecurityConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -113,7 +114,9 @@ public class LocalDevSecurityConfiguration {
         }))
         .sessionManagement(sm -> sm.sessionCreationPolicy(STATELESS))
         .cors(AbstractHttpConfigurer::disable)
-        .csrf(AbstractHttpConfigurer::disable);
+        .csrf(csrf -> csrf
+            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+            .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()));
     return http.build();
   }
 

--- a/src/main/java/org/tb/auth/configuration/LocalDevSecurityConfiguration.java
+++ b/src/main/java/org/tb/auth/configuration/LocalDevSecurityConfiguration.java
@@ -114,9 +114,7 @@ public class LocalDevSecurityConfiguration {
         }))
         .sessionManagement(sm -> sm.sessionCreationPolicy(STATELESS))
         .cors(AbstractHttpConfigurer::disable)
-        .csrf(csrf -> csrf
-            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-            .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()));
+        .csrf(AbstractHttpConfigurer::disable);
     return http.build();
   }
 

--- a/src/main/resources/static/js/salat.js
+++ b/src/main/resources/static/js/salat.js
@@ -1,3 +1,12 @@
+document.addEventListener("htmx:configRequest", function(evt) {
+  const token = document.cookie.split("; ")
+    .find(r => r.startsWith("XSRF-TOKEN="))
+    ?.split("=")[1];
+  if (token) {
+    evt.detail.headers["X-XSRF-TOKEN"] = decodeURIComponent(token);
+  }
+});
+
 document.addEventListener('close.bs.alert', e => {
   const wrapper = e.target.parentElement;
   e.target.addEventListener('closed.bs.alert', () => wrapper?.remove(), { once: true });

--- a/src/main/resources/static/js/salat.js
+++ b/src/main/resources/static/js/salat.js
@@ -46,6 +46,17 @@ document.addEventListener('htmx:afterSettle', function () {
   });
 });
 
+document.addEventListener('htmx:afterSettle', function () {
+  const raw = document.cookie.split('; ')
+    .find(r => r.startsWith('XSRF-TOKEN='))
+    ?.split('=')[1];
+  if (raw) {
+    const token = decodeURIComponent(raw);
+    document.querySelectorAll('input[name="_csrf"]')
+      .forEach(function (el) { el.value = token; });
+  }
+});
+
 function applyFormTabOrder() {
   var wrapper = document.querySelector('.page-body');
   if (!wrapper) return;

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -405,16 +405,6 @@
 </div>
 <script th:src="@{/webjars/tabler__core/dist/js/tabler.min.js}"></script>
 <script th:src="@{/webjars/htmx.org/dist/htmx.min.js}"></script>
-<script>
-  document.addEventListener("htmx:configRequest", function(evt) {
-    const token = document.cookie.split("; ")
-      .find(r => r.startsWith("XSRF-TOKEN="))
-      ?.split("=")[1];
-    if (token) {
-      evt.detail.headers["X-XSRF-TOKEN"] = decodeURIComponent(token);
-    }
-  });
-</script>
 <script th:src="@{/webjars/tom-select/dist/js/tom-select.complete.min.js}"></script>
 <script th:src="@{/js/salat.js}"></script>
 <th:block layout:fragment="scripts"></th:block>

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -405,6 +405,16 @@
 </div>
 <script th:src="@{/webjars/tabler__core/dist/js/tabler.min.js}"></script>
 <script th:src="@{/webjars/htmx.org/dist/htmx.min.js}"></script>
+<script>
+  document.addEventListener("htmx:configRequest", function(evt) {
+    const token = document.cookie.split("; ")
+      .find(r => r.startsWith("XSRF-TOKEN="))
+      ?.split("=")[1];
+    if (token) {
+      evt.detail.headers["X-XSRF-TOKEN"] = decodeURIComponent(token);
+    }
+  });
+</script>
 <script th:src="@{/webjars/tom-select/dist/js/tom-select.complete.min.js}"></script>
 <script th:src="@{/js/salat.js}"></script>
 <th:block layout:fragment="scripts"></th:block>


### PR DESCRIPTION
## Summary

- Replace `csrf(disable)` with `CookieCsrfTokenRepository.withHttpOnlyFalse()` + `CsrfTokenRequestAttributeHandler` in the main `filterChain` (Order 2) of `AzureEasyAuthSecurityConfiguration` (production/staging/localeasyauth); REST and static-resource chains remain disabled
- `LocalDevSecurityConfiguration` keeps `csrf(disable)` — Chrome does not reliably send cookies without an explicit `SameSite` attribute over plain HTTP on localhost, causing false 403s in local development; the local dev server is not internet-facing
- Add `htmx:configRequest` listener in `salat.js` to inject `X-XSRF-TOKEN` header on every HTMX request from the `XSRF-TOKEN` cookie
- Add `htmx:afterSettle` handler in `salat.js` to refresh stale `_csrf` hidden inputs from the current cookie after HTMX responses
- Add ADR-0018 documenting the token store, `CsrfTokenRequestAttributeHandler` over XOR variant (+ BREACH trade-off), HTMX header approach, stateless rationale, and local-dev exception

## Test plan

- [x] Build passes: `jenv exec ./mvnw verify` ✅ (255 tests, 0 failures)
- [x] Regular form POSTs (Thymeleaf `th:action`) work without template changes
- [x] HTMX-triggered POSTs send `X-XSRF-TOKEN` header and are accepted
- [x] After an HTMX response, `_csrf` hidden fields are refreshed from the current cookie
- [x] No `HttpSession` required for CSRF (stateless policy preserved)
- [x] No explicit `_csrf` hidden input appears in any template
- [x] POST without `_csrf` token returns 403 on production profile ✅ (verified via curl)

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #745