### PR TITLE
Replace single responsible_hbt with many-to-many (#757)

### DIFF
--- a/src/main/java/org/tb/common/thymeleaf/processor/SelectProcessor.java
+++ b/src/main/java/org/tb/common/thymeleaf/processor/SelectProcessor.java
@@ -22,6 +22,7 @@ public class SelectProcessor extends AbstractElementModelProcessor {
         var field = openTag.getAttributeValue("th:field");
         var label = openTag.getAttributeValue("th:label");
         var required = Boolean.parseBoolean(openTag.getAttributeValue("required"));
+        var multiple = openTag.getAttribute("multiple") != null;
         var fieldName = extractFieldName(field);
 
         var mf = context.getModelFactory();
@@ -37,9 +38,12 @@ public class SelectProcessor extends AbstractElementModelProcessor {
         newModel.add(mf.createCloseElementTag("label"));
 
         Map<String, String> selectAttrs = new LinkedHashMap<>();
-        selectAttrs.put("class", "form-select tomselect");
+        selectAttrs.put("class", multiple ? "form-select tomselect tomselect-multi" : "form-select tomselect");
         selectAttrs.put("th:field", field);
         selectAttrs.put("th:errorclass", "is-invalid");
+        if (multiple) {
+            selectAttrs.put("multiple", "multiple");
+        }
         newModel.add(mf.createOpenElementTag("select", selectAttrs, AttributeValueQuotes.DOUBLE, false));
 
         for (int i = 1; i < model.size() - 1; i++) {

--- a/src/main/java/org/tb/dailyreport/auth/TimereportAuthorization.java
+++ b/src/main/java/org/tb/dailyreport/auth/TimereportAuthorization.java
@@ -40,7 +40,9 @@ public class TimereportAuthorization {
 
     if(accessLevel == READ) {
       // every project manager may see the time reports of her project
-      if(authorizedUser.getEffectiveLoginSign().equals(timereport.getSuborder().getCustomerorder().getResponsible_hbt().getSalatUser().getLoginname())) {
+      var loginSign = authorizedUser.getEffectiveLoginSign();
+      if(timereport.getSuborder().getCustomerorder().getResponsibleHbt().stream()
+          .anyMatch(e -> loginSign.equals(e.getSalatUser().getLoginname()))) {
         return true;
       }
       if(authorizedUser.getEffectiveLoginSign().equals(timereport.getSuborder().getCustomerorder().getRespEmpHbtContract().getSalatUser().getLoginname())) {

--- a/src/main/java/org/tb/order/controller/CustomerorderController.java
+++ b/src/main/java/org/tb/order/controller/CustomerorderController.java
@@ -97,7 +97,7 @@ public class CustomerorderController {
     var form = new CustomerorderForm();
     form.setValidFrom(format(today()));
     form.setOrderType(OrderType.STANDARD);
-    form.setEmployeeId(authorizedEmployee.getEmployeeId());
+    form.setResponsibleHbtIds(new java.util.ArrayList<>(List.of(authorizedEmployee.getEmployeeId())));
     form.setRespContrEmployeeId(authorizedEmployee.getEmployeeId());
     form.setCustomerId(customerId);
     form.setHide(false);
@@ -133,7 +133,7 @@ public class CustomerorderController {
             form.getCustomerId(), fromDate, untilDate, form.getSign(),
             form.getDescription(), form.getShortdescription(), form.getOrderCustomer(),
             form.getResponsibleCustomerContractually(), form.getResponsibleCustomerTechnical(),
-            form.getEmployeeId(), form.getRespContrEmployeeId(),
+            form.getResponsibleHbtIds(), form.getRespContrEmployeeId(),
             form.getDebithours(), form.getDebithoursunit(), form.getHide(), form.getOrderType());
         if (form.getId() == null) {
           newId = customerorderService.create(dto).getId();
@@ -261,8 +261,8 @@ public class CustomerorderController {
           messages.getMessage("form.timereport.error.date.wrongformat", "Invalid date format"));
     }
 
-    if (form.getEmployeeId() == null) {
-      bindingResult.rejectValue("employeeId", "error.employeeId",
+    if (form.getResponsibleHbtIds() == null || form.getResponsibleHbtIds().isEmpty()) {
+      bindingResult.rejectValue("responsibleHbtIds", "error.responsibleHbtIds",
           messages.getMessage("form.customerorder.error.responsiblehbt.required", "Responsible HBT employee is required"));
     }
 
@@ -296,7 +296,9 @@ public class CustomerorderController {
     // In edit mode, ensure assigned employees appear even if hidden or their contracts have expired.
     // Fall back to stored IDs when the form fields are null (e.g. after validation failure with empty select).
     if (isEdit) {
-      addEmployeeIfAbsent(employees, form.getEmployeeId() != null ? form.getEmployeeId() : form.getStoredEmployeeId());
+      var effectiveHbtIds = (form.getResponsibleHbtIds() != null && !form.getResponsibleHbtIds().isEmpty())
+          ? form.getResponsibleHbtIds() : form.getStoredResponsibleHbtIds();
+      effectiveHbtIds.forEach(id -> addEmployeeIfAbsent(employees, id));
       addEmployeeIfAbsent(employees, form.getRespContrEmployeeId() != null ? form.getRespContrEmployeeId() : form.getStoredRespContrEmployeeId());
       employees.sort(Comparator.comparing(Employee::getName));
     }
@@ -330,10 +332,9 @@ public class CustomerorderController {
     form.setOrderCustomer(co.getOrder_customer());
     form.setResponsibleCustomerContractually(co.getResponsible_customer_contractually());
     form.setResponsibleCustomerTechnical(co.getResponsible_customer_technical());
-    if (co.getResponsible_hbt() != null) {
-      form.setEmployeeId(co.getResponsible_hbt().getId());
-      form.setStoredEmployeeId(co.getResponsible_hbt().getId());
-    }
+    var responsibleHbtIds = co.getResponsibleHbt().stream().map(Employee::getId).collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+    form.setResponsibleHbtIds(responsibleHbtIds);
+    form.setStoredResponsibleHbtIds(new java.util.ArrayList<>(responsibleHbtIds));
     if (co.getRespEmpHbtContract() != null) {
       form.setRespContrEmployeeId(co.getRespEmpHbtContract().getId());
       form.setStoredRespContrEmployeeId(co.getRespEmpHbtContract().getId());

--- a/src/main/java/org/tb/order/controller/CustomerorderForm.java
+++ b/src/main/java/org/tb/order/controller/CustomerorderForm.java
@@ -1,5 +1,7 @@
 package org.tb.order.controller;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.tb.order.domain.OrderType;
@@ -21,10 +23,10 @@ public class CustomerorderForm {
   private String debithours;
   private Byte debithoursunit;
   private Boolean hide;
-  private Long employeeId;
+  private List<Long> responsibleHbtIds = new ArrayList<>();
+  private List<Long> storedResponsibleHbtIds = new ArrayList<>();
   private Long respContrEmployeeId;
-  /** Employee IDs as stored in the DB when the edit form was opened; never mutated by the form lifecycle. */
-  private Long storedEmployeeId;
+  /** Employee ID as stored in the DB when the edit form was opened; never mutated by the form lifecycle. */
   private Long storedRespContrEmployeeId;
   private OrderType orderType;
 

--- a/src/main/java/org/tb/order/domain/Customerorder.java
+++ b/src/main/java/org/tb/order/domain/Customerorder.java
@@ -7,12 +7,16 @@ import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -61,12 +65,15 @@ public class Customerorder extends AuditedEntity implements Serializable {
     private String responsible_customer_contractually;
 
     /**
-     * Responsible employee of HBT
+     * Responsible employees of HBT
      */
-    @ManyToOne
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(name = "customerorder_responsible_hbt",
+        joinColumns = @JoinColumn(name = "CUSTOMERORDER_ID"),
+        inverseJoinColumns = @JoinColumn(name = "EMPLOYEE_ID"))
     @Fetch(FetchMode.SELECT)
-    @JoinColumn(name = "RESPONSIBLE_HBT_ID")
-    private Employee responsible_hbt;
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    private List<Employee> responsibleHbt = new ArrayList<>();
 
     /**
      * contractually responsible employee of HBT

--- a/src/main/java/org/tb/order/domain/CustomerorderDTO.java
+++ b/src/main/java/org/tb/order/domain/CustomerorderDTO.java
@@ -1,6 +1,7 @@
 package org.tb.order.domain;
 
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * Data transfer object carrying customer order field values for create/update operations.
@@ -15,7 +16,7 @@ public record CustomerorderDTO(
     String orderCustomer,
     String responsibleCustomerContractually,
     String responsibleCustomerTechnical,
-    Long responsibleHbtId,
+    List<Long> responsibleHbtIds,
     Long respEmpHbtContractId,
     String debithours,
     Byte debithoursunit,

--- a/src/main/java/org/tb/order/persistence/CustomerorderDAO.java
+++ b/src/main/java/org/tb/order/persistence/CustomerorderDAO.java
@@ -100,7 +100,7 @@ public class CustomerorderDAO {
             || containsIgnoreCase(customer.getName(), upper)
             || containsIgnoreCase(co.getSign(), upper)
             || containsIgnoreCase(co.getDescription(), upper)
-            || (co.getResponsible_hbt() != null && containsIgnoreCase(co.getResponsible_hbt().getName(), upper))
+            || co.getResponsibleHbt().stream().anyMatch(e -> containsIgnoreCase(e.getName(), upper))
             || (co.getRespEmpHbtContract() != null && containsIgnoreCase(co.getRespEmpHbtContract().getName(), upper));
     }
 

--- a/src/main/java/org/tb/order/persistence/CustomerorderRepository.java
+++ b/src/main/java/org/tb/order/persistence/CustomerorderRepository.java
@@ -14,7 +14,7 @@ import org.tb.order.domain.Customerorder;
 public interface CustomerorderRepository extends PagingAndSortingRepository<Customerorder, Long>,
     JpaSpecificationExecutor<Customerorder>, CrudRepository<Customerorder, Long> {
 
-  @Query("select c from Customerorder c where c.responsible_hbt.id = :responsibleHbtId")
+  @Query("select c from Customerorder c join c.responsibleHbt e where e.id = :responsibleHbtId")
   List<Customerorder> findAllByResponsibleHbt(long responsibleHbtId);
 
   List<Customerorder> findAllByCustomerId(long customerId);

--- a/src/main/java/org/tb/order/service/CustomerorderService.java
+++ b/src/main/java/org/tb/order/service/CustomerorderService.java
@@ -83,13 +83,13 @@ public class CustomerorderService {
     co.setResponsible_customer_contractually(dto.responsibleCustomerContractually());
     co.setResponsible_customer_technical(dto.responsibleCustomerTechnical());
 
-    if (dto.responsibleHbtId() == null) {
+    if (dto.responsibleHbtIds() == null || dto.responsibleHbtIds().isEmpty()) {
       throw new InvalidDataException(ErrorCode.CO_RESPONSIBLE_HBT_REQUIRED);
     }
     if (dto.respEmpHbtContractId() == null) {
       throw new InvalidDataException(ErrorCode.CO_RESP_CONTRACT_EMPLOYEE_REQUIRED);
     }
-    co.setResponsible_hbt(employeeDAO.getEmployeeById(dto.responsibleHbtId()));
+    co.setResponsibleHbt(dto.responsibleHbtIds().stream().map(employeeDAO::getEmployeeById).toList());
     co.setRespEmpHbtContract(employeeDAO.getEmployeeById(dto.respEmpHbtContractId()));
 
     if (dto.debithours() == null

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1930,5 +1930,51 @@ databaseChangeLog:
                   name: updatecounter
                   type: int
 
+  - changeSet:
+      id: 54
+      author: kr
+      comment: Create customerorder_responsible_hbt join table and migrate existing responsible_hbt data
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: customerorder_responsible_hbt
+      changes:
+        - createTable:
+            tableName: customerorder_responsible_hbt
+            columns:
+              - column:
+                  name: CUSTOMERORDER_ID
+                  type: bigint
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_corhbt_customerorder
+                    references: customerorder(id)
+              - column:
+                  name: EMPLOYEE_ID
+                  type: bigint
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_corhbt_employee
+                    references: employee(id)
+        - sql:
+            sql: "INSERT INTO customerorder_responsible_hbt (CUSTOMERORDER_ID, EMPLOYEE_ID) SELECT id, RESPONSIBLE_HBT_ID FROM customerorder WHERE RESPONSIBLE_HBT_ID IS NOT NULL"
+  - changeSet:
+      id: 55
+      author: kr
+      comment: Drop legacy RESPONSIBLE_HBT_ID column from customerorder after join table migration
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: customerorder
+            columnName: RESPONSIBLE_HBT_ID
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: customerorder
+            constraintName: FKB0BA7210F5620BCF
+        - dropColumn:
+            tableName: customerorder
+            columnName: RESPONSIBLE_HBT_ID
+
 #  - include:
 #      file: db/changelog/includes/addAllEmployees.sql

--- a/src/main/resources/static/css/salat.css
+++ b/src/main/resources/static/css/salat.css
@@ -22,6 +22,11 @@
   padding-bottom: .5625rem;
 }
 
+.ts-wrapper.form-select.multi .ts-control {
+  padding-top: calc(.5625rem - 2.5px);
+  padding-bottom: calc(.5625rem - 2.5px);
+}
+
 body {
   font-feature-settings: "cv03", "cv04", "cv11";
 }

--- a/src/main/resources/templates/order/customer-order-form.html
+++ b/src/main/resources/templates/order/customer-order-form.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:salat="http://hbt.de/salat/thymeleaf"
       layout:decorate="~{layout/base}"
       th:with="section='orders',subSection='customerorders',title=${pageTitle},sectionTitle=#{main.general.mainmenu.orders.text}">
 <main layout:fragment="content">
@@ -8,7 +9,9 @@
   <form th:action="@{/orders/customerorders/store}" th:object="${customerorderForm}" method="post" class="card">
     <div class="card-body">
       <input type="hidden" th:field="*{id}" />
-      <input type="hidden" th:field="*{storedEmployeeId}" />
+      <th:block th:each="sid : *{storedResponsibleHbtIds}">
+        <input type="hidden" name="storedResponsibleHbtIds" th:value="${sid}" />
+      </th:block>
       <input type="hidden" th:field="*{storedRespContrEmployeeId}" />
 
       <div class="row">
@@ -75,10 +78,9 @@
 
       <div class="row">
         <div class="col-md-6">
-          <div th:replace="~{fragments/form-fields :: selectInput(
-            field='employeeId', label=#{main.customerorder.responsiblehbt.text}, required=true,
-            placeholder=null, options=${employees}, optionValue='id', optionLabel='name'
-          )}"></div>
+          <salat:select th:field="*{responsibleHbtIds}" th:label="#{main.customerorder.responsiblehbt.text}" required multiple>
+            <option th:each="e : ${employees}" th:value="${e.id}" th:text="${e.name}"></option>
+          </salat:select>
         </div>
         <div class="col-md-6">
           <div th:replace="~{fragments/form-fields :: selectInput(

--- a/src/main/resources/templates/order/customer-order-list.html
+++ b/src/main/resources/templates/order/customer-order-list.html
@@ -121,7 +121,7 @@
           <td class="d-none d-md-table-cell">
             <div>
               <span class="badge bg-primary-lt me-1" th:title="#{main.customerorder.responsiblehbt.execution.text}"><i class="bi-diagram-3"></i></span>
-              <span th:text="${co.responsible_hbt != null ? co.responsible_hbt.name : ''}"></span>
+              <span th:text="${#strings.listJoin(co.responsibleHbt.![name], ', ')}"></span>
             </div>
             <div class="mt-1">
               <span class="badge bg-primary-lt me-1" th:title="#{main.customerorder.responsiblehbt.contract.text}"><i class="bi-shield-check"></i></span>


### PR DESCRIPTION
## Summary

- Replaced `@ManyToOne Employee responsible_hbt` on `Customerorder` with `@ManyToMany List<Employee> responsibleHbt` backed by a new `customerorder_responsible_hbt` join table — consistent with the `Employeecontract.supervisors` pattern
- Form (`CustomerorderForm`), DTO (`CustomerorderDTO`), service, repository, and controller all updated to work with `List<Long> responsibleHbtIds`
- `customer-order-form.html` now renders a multi-select using `salat:select` with `multiple` attribute; `SelectProcessor` extended to support multi-select (`tomselect-multi` class + `multiple` attribute)
- `customer-order-list.html` renders the full list of responsible employees, joined by `, `
- `TimereportAuthorization` updated: read access granted if the current user is *any* of the responsible HBT employees
- `CustomerorderDAO.filterMatchesInMemory` updated to match across all responsible employees
- Liquibase changesets 54 + 55: create join table → migrate existing rows → drop legacy `RESPONSIBLE_HBT_ID` column

## Test plan

- [x] Create a new customer order with two responsible HBT employees — both are saved
- [x] Edit an existing customer order — the responsible HBT multi-select pre-selects the migrated employees
- [x] Submit the form with zero responsible HBT employees — form rejects with validation error
- [x] Filter the customer order list — results match on any responsible employee name
- [x] `jenv exec ./mvnw verify` passes (287 tests, 0 failures)

Closes #757

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.