### PR TITLE
Budget: Domain-Entität OrderPricing (Kundenstundensatz) (#770)

### DIFF
--- a/src/main/java/org/tb/budget/domain/OrderPricing.java
+++ b/src/main/java/org/tb/budget/domain/OrderPricing.java
@@ -1,0 +1,41 @@
+package org.tb.budget.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.tb.common.domain.AuditedEntity;
+
+@Entity
+@Table(name = "order_pricing")
+@Getter
+@Setter
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+public class OrderPricing extends AuditedEntity {
+
+    @Column(name = "customerorder_sign", nullable = false)
+    private String customerorderSign;
+
+    @Column(name = "suborder_sign")
+    private String suborderSign;
+
+    @Column(name = "employee_sign")
+    private String employeeSign;
+
+    @Column
+    private String description;
+
+    @Column(name = "price_cents_per_hour", nullable = false)
+    private Integer priceCentsPerHour;
+
+    @Column(name = "valid_from", nullable = false)
+    private LocalDate validFrom;
+
+    @Column(name = "valid_until", nullable = false)
+    private LocalDate validUntil;
+
+}

--- a/src/main/java/org/tb/budget/domain/OrderPricingData.java
+++ b/src/main/java/org/tb/budget/domain/OrderPricingData.java
@@ -1,0 +1,13 @@
+package org.tb.budget.domain;
+
+import java.time.LocalDate;
+
+public record OrderPricingData(
+    String customerorderSign,
+    String suborderSign,
+    String employeeSign,
+    String description,
+    Integer priceCentsPerHour,
+    LocalDate validFrom,
+    LocalDate validUntil
+) {}

--- a/src/main/java/org/tb/budget/persistence/OrderPricingRepository.java
+++ b/src/main/java/org/tb/budget/persistence/OrderPricingRepository.java
@@ -1,0 +1,42 @@
+package org.tb.budget.persistence;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.tb.budget.domain.OrderPricing;
+
+@Repository
+public interface OrderPricingRepository
+    extends CrudRepository<OrderPricing, Long>, PagingAndSortingRepository<OrderPricing, Long> {
+
+    List<OrderPricing> findByCustomerorderSign(String customerorderSign);
+
+    @Query("SELECT p FROM OrderPricing p WHERE p.customerorderSign = :co"
+        + " AND p.suborderSign = :so AND p.employeeSign = :emp"
+        + " AND p.validFrom <= :date AND p.validUntil >= :date")
+    List<OrderPricing> findEffectiveEmployeeSpecific(
+        @Param("co") String customerorderSign,
+        @Param("so") String suborderSign,
+        @Param("emp") String employeeSign,
+        @Param("date") LocalDate date);
+
+    @Query("SELECT p FROM OrderPricing p WHERE p.customerorderSign = :co"
+        + " AND p.suborderSign = :so AND p.employeeSign IS NULL"
+        + " AND p.validFrom <= :date AND p.validUntil >= :date")
+    List<OrderPricing> findEffectiveSuborderWide(
+        @Param("co") String customerorderSign,
+        @Param("so") String suborderSign,
+        @Param("date") LocalDate date);
+
+    @Query("SELECT p FROM OrderPricing p WHERE p.customerorderSign = :co"
+        + " AND p.suborderSign IS NULL AND p.employeeSign IS NULL"
+        + " AND p.validFrom <= :date AND p.validUntil >= :date")
+    List<OrderPricing> findEffectiveOrderWide(
+        @Param("co") String customerorderSign,
+        @Param("date") LocalDate date);
+
+}

--- a/src/main/java/org/tb/budget/service/OrderPricingService.java
+++ b/src/main/java/org/tb/budget/service/OrderPricingService.java
@@ -1,0 +1,82 @@
+package org.tb.budget.service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tb.auth.domain.Authorized;
+import org.tb.budget.domain.OrderPricing;
+import org.tb.budget.domain.OrderPricingData;
+import org.tb.budget.persistence.OrderPricingRepository;
+import org.tb.common.exception.ErrorCode;
+import org.tb.common.exception.InvalidDataException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Authorized
+public class OrderPricingService {
+
+    private final OrderPricingRepository orderPricingRepository;
+
+    @Transactional(readOnly = true)
+    public OrderPricing getById(long id) {
+        return orderPricingRepository.findById(id)
+            .orElseThrow(() -> new InvalidDataException(ErrorCode.BU_PRICING_NOT_FOUND, id));
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderPricing> getByCustomerorderSign(String customerorderSign) {
+        return orderPricingRepository.findByCustomerorderSign(customerorderSign);
+    }
+
+    /**
+     * Fallback hierarchy: employee-specific → suborder-wide → order-wide.
+     */
+    @Transactional(readOnly = true)
+    public Optional<OrderPricing> findEffectiveRate(String customerorderSign, String suborderSign, String employeeSign, LocalDate date) {
+        if (suborderSign != null && employeeSign != null) {
+            var rates = orderPricingRepository.findEffectiveEmployeeSpecific(customerorderSign, suborderSign, employeeSign, date);
+            if (!rates.isEmpty()) return Optional.of(rates.get(0));
+        }
+        if (suborderSign != null) {
+            var rates = orderPricingRepository.findEffectiveSuborderWide(customerorderSign, suborderSign, date);
+            if (!rates.isEmpty()) return Optional.of(rates.get(0));
+        }
+        var rates = orderPricingRepository.findEffectiveOrderWide(customerorderSign, date);
+        if (!rates.isEmpty()) return Optional.of(rates.get(0));
+        return Optional.empty();
+    }
+
+    @Authorized(requiresManager = true)
+    public void save(OrderPricingData data) {
+        var pricing = new OrderPricing();
+        apply(pricing, data);
+        orderPricingRepository.save(pricing);
+    }
+
+    @Authorized(requiresManager = true)
+    public void update(long id, OrderPricingData data) {
+        var pricing = getById(id);
+        apply(pricing, data);
+        orderPricingRepository.save(pricing);
+    }
+
+    @Authorized(requiresManager = true)
+    public void delete(long id) {
+        orderPricingRepository.deleteById(id);
+    }
+
+    private void apply(OrderPricing pricing, OrderPricingData data) {
+        pricing.setCustomerorderSign(data.customerorderSign());
+        pricing.setSuborderSign(data.suborderSign());
+        pricing.setEmployeeSign(data.employeeSign());
+        pricing.setDescription(data.description());
+        pricing.setPriceCentsPerHour(data.priceCentsPerHour());
+        pricing.setValidFrom(data.validFrom());
+        pricing.setValidUntil(data.validUntil() != null ? data.validUntil() : LocalDate.of(2999, 12, 31));
+    }
+
+}

--- a/src/main/java/org/tb/common/exception/ErrorCode.java
+++ b/src/main/java/org/tb/common/exception/ErrorCode.java
@@ -100,6 +100,7 @@ public enum ErrorCode {
 
   BU_BUDGET_NOT_FOUND("BU-0001", "order budget not found"),
   BU_ADJUSTMENT_NOT_FOUND("BU-0002", "order budget adjustment not found"),
+  BU_PRICING_NOT_FOUND("BU-0003", "order pricing not found"),
 
   XX_UNHANDLED_SERVLET_EXCEPTION("XX-0001", "Unhandled servlet exception"),
   XX_DATA_MISSING("XX-0002", "Required data missing"),

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2280,5 +2280,37 @@ databaseChangeLog:
                   name: updatecounter
                   type: int
 
+  - changeSet:
+      id: 61
+      author: kr
+      comment: Add surrogate PK and audit columns to order_pricing (AuditedEntity)
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: order_pricing
+                columnName: id
+      changes:
+        - sql:
+            sql: "ALTER TABLE order_pricing ADD COLUMN id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST"
+        - addColumn:
+            tableName: order_pricing
+            columns:
+              - column:
+                  name: created
+                  type: datetime
+              - column:
+                  name: lastupdate
+                  type: datetime
+              - column:
+                  name: createdby
+                  type: varchar(255)
+              - column:
+                  name: lastupdatedby
+                  type: varchar(255)
+              - column:
+                  name: updatecounter
+                  type: int
+
 #  - include:
 #      file: db/changelog/includes/addAllEmployees.sql

--- a/src/main/resources/org/tb/web/MessageResources.properties
+++ b/src/main/resources/org/tb/web/MessageResources.properties
@@ -58,6 +58,7 @@ errorcode.aa.0006=Erfordert People-Lead-Berechtigung.
 errorcode.aa.9999=Fehlende Berechtigung.
 errorcode.bu.0001=Budgetplan nicht gefunden.
 errorcode.bu.0002=Budgetanpassung nicht gefunden.
+errorcode.bu.0003=Preissatz nicht gefunden.
 errorcode.co.0001=Auftrag {0} kann aufgrund eines Vetos nicht geändert werden.
 errorcode.co.0002=Auftrag {0} kann aufgrund eines Vetos nicht gelöscht werden.
 errorcode.co.0003=Auftragsverantwortlicher fehlt.

--- a/src/main/resources/org/tb/web/MessageResources_en.properties
+++ b/src/main/resources/org/tb/web/MessageResources_en.properties
@@ -59,6 +59,7 @@ errorcode.aa.0006=Requires people lead privileges
 errorcode.aa.9999=Missing privileges
 errorcode.bu.0001=Order budget not found.
 errorcode.bu.0002=Order budget adjustment not found.
+errorcode.bu.0003=Order pricing not found.
 errorcode.co.0001=Customer order {0} cannot be changed due to veto
 errorcode.co.0002=Customer order {0} cannot be deleted due to veto
 errorcode.co.0003=Responsible HBT employee is required.


### PR DESCRIPTION
## Summary

- `OrderPricing` extends `AuditedEntity` (surrogate `bigint` PK + audit columns)
- Changeset 61: adds `id BIGINT AUTO_INCREMENT PRIMARY KEY` and five audit columns to `order_pricing`; nullable `suborder_sign`/`employee_sign` remain nullable in DB
- `OrderPricingRepository`: JPQL queries for the three effective-rate levels (employee-specific, suborder-wide, order-wide) using `IS NULL` for the nullable columns
- `OrderPricingService`: CRUD by `long id` + `findEffectiveRate` with fallback hierarchy (employee-specific → suborder-wide → order-wide)
- Error code `BU-0003` + i18n entries (de/en)

## Test plan

- [x] `jenv exec ./mvnw verify` grün ✅
- [x] Manueller Test nach Deployment: Preissatz-Lookup für alle drei Fallback-Stufen

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)