### PR TITLE
Restore EmployeecontractChangedEvent publication on login

### DIFF
--- a/src/main/java/org/tb/employee/listener/AuthorizedUserChangedListener.java
+++ b/src/main/java/org/tb/employee/listener/AuthorizedUserChangedListener.java
@@ -3,6 +3,7 @@ package org.tb.employee.listener;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,7 @@ import org.tb.auth.event.AuthorizedUserChangedEvent;
 import org.tb.common.GlobalConstants;
 import org.tb.employee.domain.Employee;
 import org.tb.employee.domain.Employeecontract;
+import org.tb.employee.event.EmployeecontractChangedEvent;
 import org.tb.employee.service.EmployeeService;
 import org.tb.employee.service.EmployeecontractService;
 
@@ -20,6 +22,7 @@ import org.tb.employee.service.EmployeecontractService;
 @RequiredArgsConstructor
 public class AuthorizedUserChangedListener {
 
+  private final ApplicationEventPublisher eventPublisher;
   private final AuthorizedUser authorizedUser;
   private final EmployeeService employeeService;
   private final EmployeecontractService employeecontractService;
@@ -39,6 +42,9 @@ public class AuthorizedUserChangedListener {
       log.error("No valid contract found for {}.", loginEmployee.getSign());
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No valid contract found for " + loginEmployee.getSign());
     }
+
+    employeecontract.ifPresent(contract ->
+        eventPublisher.publishEvent(new EmployeecontractChangedEvent(this, contract.getId())));
 
   }
 

--- a/src/test/java/org/tb/employee/listener/AuthorizedUserChangedListenerTest.java
+++ b/src/test/java/org/tb/employee/listener/AuthorizedUserChangedListenerTest.java
@@ -1,0 +1,73 @@
+package org.tb.employee.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.tb.auth.domain.AuthorizedUser;
+import org.tb.auth.event.AuthorizedUserChangedEvent;
+import org.tb.common.GlobalConstants;
+import org.tb.employee.domain.Employee;
+import org.tb.employee.domain.Employeecontract;
+import org.tb.employee.event.EmployeecontractChangedEvent;
+import org.tb.employee.service.EmployeeService;
+import org.tb.employee.service.EmployeecontractService;
+import org.tb.testutils.EmployeeTestUtils;
+import org.tb.testutils.EmployeecontractTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorizedUserChangedListenerTest {
+
+  @InjectMocks
+  private AuthorizedUserChangedListener classUnderTest;
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+  @Mock
+  private AuthorizedUser authorizedUser;
+  @Mock
+  private EmployeeService employeeService;
+  @Mock
+  private EmployeecontractService employeecontractService;
+
+  @Test
+  void publishes_employeecontract_changed_event_when_valid_contract_present() {
+    Employee loginEmployee = EmployeeTestUtils.createEmployee("testy");
+    setField(loginEmployee, "id", 42L);
+    Employeecontract employeecontract = EmployeecontractTestUtils.createEmployeecontract(loginEmployee, null);
+    setField(employeecontract, "id", 123L);
+
+    when(employeeService.getLoginEmployee()).thenReturn(loginEmployee);
+    when(employeecontractService.getCurrentContract(42L)).thenReturn(Optional.of(employeecontract));
+
+    classUnderTest.onAuthorizedUserChanged(new AuthorizedUserChangedEvent(this));
+
+    ArgumentCaptor<EmployeecontractChangedEvent> captor = ArgumentCaptor.forClass(EmployeecontractChangedEvent.class);
+    verify(eventPublisher).publishEvent(captor.capture());
+    org.assertj.core.api.Assertions.assertThat(captor.getValue().getEmployeecontractId()).isEqualTo(123L);
+  }
+
+  @Test
+  void does_not_publish_employeecontract_changed_event_when_no_contract_present() {
+    Employee loginEmployee = EmployeeTestUtils.createEmployee("adm");
+    setField(loginEmployee, "id", 1L);
+    loginEmployee.getSalatUser().setStatus(GlobalConstants.EMPLOYEE_STATUS_ADM);
+
+    when(employeeService.getLoginEmployee()).thenReturn(loginEmployee);
+    when(employeecontractService.getCurrentContract(1L)).thenReturn(Optional.empty());
+
+    classUnderTest.onAuthorizedUserChanged(new AuthorizedUserChangedEvent(this));
+
+    verify(eventPublisher, never()).publishEvent(any());
+  }
+
+}


### PR DESCRIPTION
## Summary
- Commit `b045a23d` removed the Struts-only session-population block from `AuthorizedUserChangedListener` but accidentally deleted the `eventPublisher.publishEvent(new EmployeecontractChangedEvent(...))` call along with it.
- Without this event, `EmployeeorderService.onEmployeecontractChanged` never fires, so employees stop getting automatic `Employeeorder` provisioning for `standard=true` suborders (e.g. Urlaub, Krankheit, Fortbildung) on login.
- Restores the event publication only — does not reintroduce the removed `HttpSession` usage (ADR-0013 still applies).

## Test plan
- [x] New unit test `AuthorizedUserChangedListenerTest`: event published with correct contract id when a valid contract exists; not published when no contract exists (e.g. admin).
- [x] `jenv exec ./mvnw verify` passes.

Closes #805

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.