### PR TITLE
Add Playwright E2E test suite for the dailyreport module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /tb/target/
 /.java-version
 /.jpb/
+/.mcp.json

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <opencsv.version>5.12.0</opencsv.version>
     <org.mapstruct.version>1.6.3</org.mapstruct.version>
     <p6spy.version>3.9.1</p6spy.version>
+    <playwright.version>1.61.0</playwright.version>
     <poi.version>5.5.1</poi.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <salat.image.name>ghcr.io/hbtgmbh/salat</salat.image.name>
@@ -133,6 +134,12 @@
       <groupId>com.tngtech.archunit</groupId>
       <artifactId>archunit-junit5</artifactId>
       <version>${archunit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>playwright</artifactId>
+      <version>${playwright.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- other stuff -->
@@ -354,10 +361,62 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>-Dspring.profiles.active=unittest -XX:+EnableDynamicAgentLoading</argLine>
+          <excludes>
+            <exclude>**/*E2ETest.java</exclude>
+          </excludes>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!--
+      Runs the Playwright E2E test suite (Chrome + Firefox) against the dailyreport module.
+      Requires a one-time local browser install: jenv exec ./mvnw -Pe2e test-compile exec:java@install-playwright-browsers
+      Usage: jenv exec ./mvnw test -Pe2e
+    -->
+    <profile>
+      <id>e2e</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>-Dspring.profiles.active=unittest -XX:+EnableDynamicAgentLoading</argLine>
+              <excludes combine.self="override">
+                <exclude>none</exclude>
+              </excludes>
+              <includes>
+                <include>**/*E2ETest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install-playwright-browsers</id>
+                <phase>none</phase>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+                <configuration>
+                  <mainClass>com.microsoft.playwright.CLI</mainClass>
+                  <classpathScope>test</classpathScope>
+                  <arguments>
+                    <argument>install</argument>
+                    <argument>chromium</argument>
+                    <argument>firefox</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <reporting>
     <plugins>

--- a/src/test/java/org/tb/e2e/E2EBrowser.java
+++ b/src/test/java/org/tb/e2e/E2EBrowser.java
@@ -1,0 +1,29 @@
+package org.tb.e2e;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserType.LaunchOptions;
+import com.microsoft.playwright.Playwright;
+
+/**
+ * The two real browsers the dailyreport E2E suite must cover: an actually installed local
+ * Google Chrome (via Playwright's {@code channel} option) and Playwright's managed Firefox
+ * build.
+ */
+public enum E2EBrowser {
+
+  CHROME {
+    @Override
+    public Browser launch(Playwright playwright) {
+      return playwright.chromium().launch(new LaunchOptions().setChannel("chrome").setHeadless(true));
+    }
+  },
+  FIREFOX {
+    @Override
+    public Browser launch(Playwright playwright) {
+      return playwright.firefox().launch(new LaunchOptions().setHeadless(true));
+    }
+  };
+
+  public abstract Browser launch(Playwright playwright);
+
+}

--- a/src/test/java/org/tb/e2e/E2ETestData.java
+++ b/src/test/java/org/tb/e2e/E2ETestData.java
@@ -1,0 +1,223 @@
+package org.tb.e2e;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.Year;
+import lombok.experimental.UtilityClass;
+import org.tb.auth.domain.SalatUser;
+import org.tb.auth.persistence.SalatUserRepository;
+import org.tb.common.GlobalConstants;
+import org.tb.common.util.ClockProvider;
+import org.tb.customer.domain.Customer;
+import org.tb.customer.persistence.CustomerRepository;
+import org.tb.employee.domain.Employee;
+import org.tb.employee.domain.Employeecontract;
+import org.tb.employee.domain.Vacation;
+import org.tb.employee.persistence.EmployeeRepository;
+import org.tb.employee.persistence.EmployeecontractRepository;
+import org.tb.employee.persistence.VacationRepository;
+import org.tb.order.domain.Customerorder;
+import org.tb.order.domain.Employeeorder;
+import org.tb.order.domain.OrderType;
+import org.tb.order.domain.Suborder;
+import org.tb.order.persistence.CustomerorderRepository;
+import org.tb.order.persistence.EmployeeorderRepository;
+import org.tb.order.persistence.SuborderRepository;
+
+/**
+ * Seeds a fixed, realistic set of master/reference data for the dailyreport E2E suite:
+ * Customer, Customerorder, Suborder, Employee, Employeecontract and Employeeorder.
+ *
+ * <p>The three "standard" suborders (Urlaub, Krankheit, Fortbildung) are deliberately left
+ * without an Employeeorder here: they are marked {@code standard=true} so that logging in as
+ * a seeded employee (via {@link org.tb.auth.configuration.LocalDevSecurityConfiguration})
+ * provisions them automatically, exercising the same production mechanism end-to-end.
+ */
+@UtilityClass
+public class E2ETestData {
+
+  public static final String CUSTOMER_HBT_SHORTNAME = "HBT";
+
+  public static final String SUBORDER_KRANKHEIT_SIGN = "Krankheit";
+  public static final String CUSTOMERORDER_KRANK_SIGN = "KRANK";
+
+  public static final String EMPLOYEE_MA_SIGN = "ema";
+  public static final String EMPLOYEE_PV_SIGN = "epv";
+  public static final String EMPLOYEE_BL_SIGN = "ebl";
+  public static final String EMPLOYEE_BO_SIGN = "ebo";
+  public static final String EMPLOYEE_RESTRICTED_SIGN = "ers";
+
+  public static final String CUSTOMERORDER_CONTOSO_SIGN = "CONTOSO-01";
+  public static final String SUBORDER_ALPHA_DEV_SIGN = "ALPHA-DEV";
+  public static final String CUSTOMERORDER_GLOBEX_SIGN = "GLOBEX-01";
+  public static final String SUBORDER_GLOBEX_CONSULT_SIGN = "GLOBEX-CONSULT";
+  public static final String CUSTOMERORDER_INITECH_SIGN = "INITECH-01";
+  public static final String SUBORDER_INITECH_SUPPORT_SIGN = "INITECH-SUPPORT";
+  public static final String SUBORDER_INITECH_MIGRATION_SIGN = "INITECH-MIGRATION";
+
+  private static final LocalDate PAST = LocalDate.of(2020, 1, 1);
+
+  /**
+   * Already-released-through date for {@link #EMPLOYEE_MA_SIGN}'s contract, aligned to
+   * {@code PlaywrightE2ETestBase.FIXED_NOW} (2026-06-15): only the following weekend
+   * (2026-05-30/31) remains unreleased, so the self-release E2E test doesn't hit the
+   * "all working days must be booked" business rule for the ~6 years since {@link #PAST}.
+   */
+  private static final LocalDate ALREADY_RELEASED_UNTIL = LocalDate.of(2026, 5, 29);
+
+  public static void seedIfNeeded(
+      CustomerRepository customerRepository,
+      CustomerorderRepository customerorderRepository,
+      SuborderRepository suborderRepository,
+      EmployeeRepository employeeRepository,
+      EmployeecontractRepository employeecontractRepository,
+      EmployeeorderRepository employeeorderRepository,
+      SalatUserRepository salatUserRepository,
+      VacationRepository vacationRepository) {
+
+    if (customerRepository.findAllVisible().stream()
+        .anyMatch(c -> CUSTOMER_HBT_SHORTNAME.equalsIgnoreCase(c.getShortname()))) {
+      return;
+    }
+
+    Customer hbt = customer(customerRepository, "HBT GmbH", CUSTOMER_HBT_SHORTNAME);
+
+    // --- Standard/absence orders (all customer HBT, all suborders standard=true) ---
+    Customerorder vacationOrder = customerorder(customerorderRepository, hbt,
+        GlobalConstants.CUSTOMERORDER_SIGN_VACATION, "Urlaub", OrderType.KRANK_URLAUB_ABWESEND);
+    String currentYear = String.valueOf(Year.now(ClockProvider.getClock()).getValue());
+    suborder(suborderRepository, vacationOrder, currentYear, "Urlaub " + currentYear,
+        LocalDate.of(Integer.parseInt(currentYear), 1, 1), true, false);
+
+    Customerorder sickOrder = customerorder(customerorderRepository, hbt,
+        CUSTOMERORDER_KRANK_SIGN, "Krankheit", OrderType.KRANK_URLAUB_ABWESEND);
+    suborder(suborderRepository, sickOrder, SUBORDER_KRANKHEIT_SIGN, "Krankheit", PAST, true, false);
+
+    Customerorder trainingOrder = customerorder(customerorderRepository, hbt,
+        GlobalConstants.CUSTOMERORDER_SIGN_TRAINING, "Fortbildung", OrderType.STANDARD);
+    suborder(suborderRepository, trainingOrder, GlobalConstants.SUBRORDER_SIGN_TRAINING, "Fortbildung",
+        PAST, true, true);
+
+    // --- Project master data (richer scenario) ---
+    Customer contoso = customer(customerRepository, "Contoso AG", "CONTOSO");
+    Customerorder contosoOrder = customerorder(customerorderRepository, contoso,
+        CUSTOMERORDER_CONTOSO_SIGN, "Projekt Alpha", OrderType.STANDARD);
+    Suborder alphaDev = suborder(suborderRepository, contosoOrder, SUBORDER_ALPHA_DEV_SIGN, "Entwicklung",
+        PAST, false, false);
+
+    Customer globex = customer(customerRepository, "Globex GmbH", "GLOBEX");
+    Customerorder globexOrder = customerorder(customerorderRepository, globex,
+        CUSTOMERORDER_GLOBEX_SIGN, "Beratung", OrderType.STANDARD);
+    Suborder globexConsult = suborder(suborderRepository, globexOrder, SUBORDER_GLOBEX_CONSULT_SIGN, "Consulting",
+        PAST, false, false);
+
+    Customer initech = customer(customerRepository, "Initech KG", "INITECH");
+    Customerorder initechOrder = customerorder(customerorderRepository, initech,
+        CUSTOMERORDER_INITECH_SIGN, "Support & Migration", OrderType.STANDARD);
+    suborder(suborderRepository, initechOrder, SUBORDER_INITECH_SUPPORT_SIGN, "Support", PAST, false, false);
+    suborder(suborderRepository, initechOrder, SUBORDER_INITECH_MIGRATION_SIGN, "Migration", PAST, false, false);
+
+    // --- Employees across roles ---
+    Employee peopleLead = employee(employeeRepository, salatUserRepository, EMPLOYEE_PV_SIGN,
+        "Petra", "Vorgesetzte", GlobalConstants.EMPLOYEE_STATUS_PV);
+    Employee manager = employee(employeeRepository, salatUserRepository, EMPLOYEE_BL_SIGN,
+        "Bernd", "Leitmann", GlobalConstants.EMPLOYEE_STATUS_BL);
+    Employee backoffice = employee(employeeRepository, salatUserRepository, EMPLOYEE_BO_SIGN,
+        "Beate", "Officeva", GlobalConstants.EMPLOYEE_STATUS_BO);
+    Employee restricted = employee(employeeRepository, salatUserRepository, EMPLOYEE_RESTRICTED_SIGN,
+        "Rita", "Strictedt", GlobalConstants.EMPLOYEE_STATUS_RESTRICTED);
+    Employee regular = employee(employeeRepository, salatUserRepository, EMPLOYEE_MA_SIGN,
+        "Manuela", "Angestellt", GlobalConstants.EMPLOYEE_STATUS_MA);
+
+    employeecontract(employeecontractRepository, peopleLead, null);
+    employeecontract(employeecontractRepository, manager, null);
+    employeecontract(employeecontractRepository, backoffice, null);
+    employeecontract(employeecontractRepository, restricted, null);
+    Employeecontract regularContract = employeecontract(employeecontractRepository, regular, peopleLead);
+    regularContract.setReportReleaseDate(ALREADY_RELEASED_UNTIL);
+    regularContract = employeecontractRepository.save(regularContract);
+
+    employeeorder(employeeorderRepository, regularContract, alphaDev);
+    employeeorder(employeeorderRepository, regularContract, globexConsult);
+
+    Vacation vacation = new Vacation();
+    vacation.setEmployeecontract(regularContract);
+    vacation.setYear(Year.now(ClockProvider.getClock()).getValue());
+    vacation.setEntitlement(GlobalConstants.DEFAULT_VACATION_PER_YEAR);
+    vacation.setUsed(0);
+    vacationRepository.save(vacation);
+  }
+
+  private static Customer customer(CustomerRepository repository, String name, String shortname) {
+    Customer customer = new Customer();
+    customer.setName(name);
+    customer.setShortname(shortname);
+    customer.setAddress("Musterstraße 1, 12345 Musterstadt");
+    return repository.save(customer);
+  }
+
+  private static Customerorder customerorder(CustomerorderRepository repository, Customer customer,
+      String sign, String description, OrderType orderType) {
+    Customerorder customerorder = new Customerorder();
+    customerorder.setCustomer(customer);
+    customerorder.setSign(sign);
+    customerorder.setDescription(description);
+    customerorder.setFromDate(PAST);
+    customerorder.setOrderType(orderType);
+    customerorder.setDebithours(Duration.ZERO);
+    return repository.save(customerorder);
+  }
+
+  private static Suborder suborder(SuborderRepository repository, Customerorder customerorder,
+      String sign, String description, LocalDate fromDate, boolean standard, boolean training) {
+    Suborder suborder = new Suborder();
+    suborder.setCustomerorder(customerorder);
+    suborder.setSign(sign);
+    suborder.setDescription(description);
+    suborder.setFromDate(fromDate);
+    suborder.setStandard(standard);
+    suborder.setTrainingFlag(training);
+    suborder.setDebithours(Duration.ZERO);
+    return repository.save(suborder);
+  }
+
+  private static Employee employee(EmployeeRepository employeeRepository, SalatUserRepository salatUserRepository,
+      String sign, String firstname, String lastname, String status) {
+    SalatUser salatUser = new SalatUser();
+    salatUser.setLoginname(sign);
+    salatUser.setStatus(status);
+    salatUser = salatUserRepository.save(salatUser);
+
+    Employee employee = new Employee();
+    employee.setSign(sign);
+    employee.setFirstname(firstname);
+    employee.setLastname(lastname);
+    employee.setGender(GlobalConstants.GENDER_FEMALE);
+    employee.setSalatUser(salatUser);
+    return employeeRepository.save(employee);
+  }
+
+  private static Employeecontract employeecontract(EmployeecontractRepository repository, Employee employee,
+      Employee supervisor) {
+    Employeecontract contract = new Employeecontract();
+    contract.setEmployee(employee);
+    contract.setValidFrom(PAST);
+    contract.setDailyWorkingTime(Duration.ofHours(8));
+    if (supervisor != null) {
+      contract.setSupervisors(java.util.List.of(supervisor));
+    }
+    return repository.save(contract);
+  }
+
+  private static Employeeorder employeeorder(EmployeeorderRepository repository, Employeecontract contract,
+      Suborder suborder) {
+    Employeeorder employeeorder = new Employeeorder();
+    employeeorder.setEmployeecontract(contract);
+    employeeorder.setSuborder(suborder);
+    employeeorder.setSign(" ");
+    employeeorder.setFromDate(PAST);
+    employeeorder.setDebithours(Duration.ZERO);
+    return repository.save(employeeorder);
+  }
+
+}

--- a/src/test/java/org/tb/e2e/PlaywrightE2ETestBase.java
+++ b/src/test/java/org/tb/e2e/PlaywrightE2ETestBase.java
@@ -1,0 +1,142 @@
+package org.tb.e2e;
+
+import static org.mockito.Mockito.when;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import java.time.LocalDateTime;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockReset;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.tb.auth.persistence.SalatUserRepository;
+import org.tb.common.test.FixedClock;
+import org.tb.common.util.ClockProvider;
+import org.tb.customer.persistence.CustomerRepository;
+import org.tb.employee.persistence.EmployeeRepository;
+import org.tb.employee.persistence.EmployeecontractRepository;
+import org.tb.employee.persistence.VacationRepository;
+import org.tb.order.persistence.CustomerorderRepository;
+import org.tb.order.persistence.EmployeeorderRepository;
+import org.tb.order.persistence.SuborderRepository;
+
+/**
+ * Base class for Playwright-driven E2E tests against the {@code dailyreport} module.
+ *
+ * <p>Starts the real Spring Boot application ({@code webEnvironment = RANDOM_PORT}) with the
+ * H2 test datasource ({@code unittest} profile) and the pre-authenticated dev login
+ * ({@code local} profile, see {@link org.tb.auth.configuration.LocalDevSecurityConfiguration}).
+ * Master data (customers, orders, employees, ...) is seeded once per test run via
+ * {@link E2ETestData}.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "management.health.mail.enabled=false")
+@ActiveProfiles({"unittest", "local"})
+@FixedClock(PlaywrightE2ETestBase.FIXED_NOW)
+@TestInstance(Lifecycle.PER_CLASS)
+public abstract class PlaywrightE2ETestBase {
+
+  static final String FIXED_NOW = "2026-06-15T09:00:00";
+
+  @LocalServerPort
+  private int port;
+
+  @Autowired
+  private CustomerRepository customerRepository;
+  @Autowired
+  private CustomerorderRepository customerorderRepository;
+  @Autowired
+  private SuborderRepository suborderRepository;
+  @Autowired
+  private EmployeeRepository employeeRepository;
+  @Autowired
+  private EmployeecontractRepository employeecontractRepository;
+  @Autowired
+  private EmployeeorderRepository employeeorderRepository;
+  @Autowired
+  private SalatUserRepository salatUserRepository;
+  @Autowired
+  private VacationRepository vacationRepository;
+
+  // no SMTP server is available in the E2E environment; release/acceptance/sharing flows send
+  // mail as a side effect, so the sender is stubbed out rather than left to fail with a raw
+  // RuntimeException (see MailService.sendEmail)
+  @MockitoBean(reset = MockReset.NONE)
+  private JavaMailSender mailSender;
+
+  private Playwright playwright;
+
+  @BeforeAll
+  void startPlaywrightAndSeedData() {
+    when(mailSender.createMimeMessage()).thenReturn(new JavaMailSenderImpl().createMimeMessage());
+
+    playwright = Playwright.create();
+    // the seed computes the Urlaub-suborder sign from "today", so it must run under the same
+    // fixed clock the per-test @FixedClock extension applies for assertions
+    ClockProvider.useFixedClock(LocalDateTime.parse(FIXED_NOW));
+    E2ETestData.seedIfNeeded(customerRepository, customerorderRepository, suborderRepository,
+        employeeRepository, employeecontractRepository, employeeorderRepository, salatUserRepository,
+        vacationRepository);
+  }
+
+  @AfterAll
+  void stopPlaywright() {
+    playwright.close();
+  }
+
+  private String urlFor(String path, String employeeSign) {
+    String separator = path.contains("?") ? "&" : "?";
+    return "http://localhost:" + port + path + separator + "login-name=" + employeeSign;
+  }
+
+  /**
+   * Launches the given browser, logs in as {@code employeeSign} by navigating to
+   * {@code startPath} with {@code ?login-name=...}, and runs {@code testBody} against the
+   * resulting page. Every subsequent {@code page.navigate(...)} call in the test body should
+   * keep appending {@code login-name} (see {@link #urlFor}) rather than relying solely on the
+   * {@code salat_dev_login} cookie, since it is marked {@code Secure} and cookie persistence
+   * over plain {@code http://localhost} is browser-dependent.
+   */
+  protected void runAsUser(E2EBrowser browser, String employeeSign, String startPath, Consumer<Page> testBody) {
+    try (Browser b = browser.launch(playwright)) {
+      // pin the locale so assertions on rendered (German) text are deterministic regardless of
+      // the browser's own default Accept-Language
+      BrowserContext context = b.newContext(new Browser.NewContextOptions().setLocale("de-DE"));
+      Page page = context.newPage();
+      page.navigate(urlFor(startPath, employeeSign));
+      testBody.accept(page);
+    }
+  }
+
+  protected String urlWithLogin(String path, String employeeSign) {
+    return urlFor(path, employeeSign);
+  }
+
+  /**
+   * Opens a TomSelect-enhanced {@code <select>} (see AGENTS.md "TomSelect Dropdowns") by
+   * clicking its rendered control and picking the option whose visible text contains
+   * {@code optionText}, mirroring real user interaction rather than setting the hidden native
+   * {@code <select>} value directly.
+   */
+  protected void selectTomSelectOption(Page page, String selectId, String optionText) {
+    Locator control = page.locator("#" + selectId + " ~ .ts-wrapper .ts-control");
+    control.click();
+    page.locator("#" + selectId + " ~ .ts-wrapper .ts-dropdown .option")
+        .filter(new Locator.FilterOptions().setHasText(optionText))
+        .first()
+        .click();
+  }
+
+}

--- a/src/test/java/org/tb/e2e/dailyreport/DailyBookingE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/DailyBookingE2ETest.java
@@ -1,0 +1,57 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * Books a working day and a timereport entry as a regular employee, then verifies both show up
+ * in the daily view, exercising the core dailyreport booking flow through the real UI.
+ */
+class DailyBookingE2ETest extends PlaywrightE2ETestBase {
+
+  private static final LocalDate BOOKING_DATE = LocalDate.parse("2026-06-15");
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(E2EBrowser.class)
+  void booking_a_project_timereport_shows_up_in_the_daily_view(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN,
+        "/dailyreport/timereports/new?date=" + BOOKING_DATE, page -> {
+
+      page.fill("#durationTime", "02:00");
+      selectTomSelectOption(page, "suborderId", E2ETestData.SUBORDER_ALPHA_DEV_SIGN);
+      page.fill("#commentField", "E2E-Testbuchung");
+      page.click("button[type=submit]");
+      page.waitForLoadState();
+
+      page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + BOOKING_DATE, E2ETestData.EMPLOYEE_MA_SIGN));
+
+      assertThat(page.locator("#daily-bookings-area")).containsText(E2ETestData.SUBORDER_ALPHA_DEV_SIGN);
+      assertThat(page.locator("#daily-bookings-area")).containsText("2:00");
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(E2EBrowser.class)
+  void booking_on_the_vacation_suborder_shows_up_as_urlaub(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN,
+        "/dailyreport/timereports/new?date=" + BOOKING_DATE.plusDays(1), page -> {
+
+      page.fill("#durationTime", "08:00");
+      selectTomSelectOption(page, "suborderId", "URLAUB");
+      page.click("button[type=submit]");
+      page.waitForLoadState();
+
+      page.navigate(urlWithLogin(
+          "/dailyreport/daily?mode=daily&date=" + BOOKING_DATE.plusDays(1), E2ETestData.EMPLOYEE_MA_SIGN));
+
+      assertThat(page.locator("#daily-bookings-area")).containsText("URLAUB");
+    });
+  }
+
+}

--- a/src/test/java/org/tb/e2e/dailyreport/DashboardE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/DashboardE2ETest.java
@@ -1,0 +1,35 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * Verifies the dailyreport dashboard (the post-login landing page, see the
+ * {@code /welcome -> /dailyreport/dashboard} legacy redirect in AGENTS.md) renders its core
+ * widgets for a logged-in employee.
+ */
+class DashboardE2ETest extends PlaywrightE2ETestBase {
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(E2EBrowser.class)
+  void dashboard_renders_kpi_widgets_after_login(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN, "/dailyreport/dashboard", page -> {
+      assertThat(page).hasURL(java.util.regex.Pattern.compile(".*/dailyreport/dashboard.*"));
+      assertThat(page.locator("body")).containsText("Diese Woche");
+      assertThat(page.locator("body")).containsText("Manuela Angestellt");
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(E2EBrowser.class)
+  void root_redirects_to_dashboard(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN, "/welcome", page ->
+        assertThat(page).hasURL(java.util.regex.Pattern.compile(".*/dailyreport/dashboard.*")));
+  }
+
+}

--- a/src/test/java/org/tb/e2e/dailyreport/LoginProvisionsStandardOrdersE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/LoginProvisionsStandardOrdersE2ETest.java
@@ -1,0 +1,39 @@
+package org.tb.e2e.dailyreport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.microsoft.playwright.Locator;
+import java.time.Year;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.tb.common.util.ClockProvider;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * Verifies the standard-suborder provisioning flow end-to-end: logging in as an employee must
+ * make the Urlaub/Krankheit/Fortbildung suborders (all seeded with {@code standard=true})
+ * available in the "new timereport" suborder dropdown, because the login mechanism
+ * (see {@code AuthorizedUserChangedListener} / {@code EmployeeorderService.generateMissingStandardOrders})
+ * silently creates the missing Employeeorders.
+ */
+class LoginProvisionsStandardOrdersE2ETest extends PlaywrightE2ETestBase {
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(E2EBrowser.class)
+  void standard_suborders_are_offered_after_login(E2EBrowser browser) {
+    String currentYear = String.valueOf(Year.now(ClockProvider.getClock()).getValue());
+
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN, "/dailyreport/timereports/new", page -> {
+      Locator suborderOptions = page.locator("#suborderId option");
+      String allOptionsText = String.join("|", suborderOptions.allTextContents());
+
+      assertThat(allOptionsText).contains(currentYear);
+      assertThat(allOptionsText).contains(E2ETestData.SUBORDER_KRANKHEIT_SIGN);
+      assertThat(allOptionsText).contains("FORTBILDUNG");
+      assertThat(allOptionsText).contains(E2ETestData.SUBORDER_ALPHA_DEV_SIGN);
+    });
+  }
+
+}

--- a/src/test/java/org/tb/e2e/dailyreport/MatrixE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/MatrixE2ETest.java
@@ -1,0 +1,47 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * Verifies the matrix overview renders for an employee and reflects their own bookings.
+ */
+class MatrixE2ETest extends PlaywrightE2ETestBase {
+
+  private static final LocalDate BOOKING_DATE = LocalDate.parse("2026-06-17");
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(E2EBrowser.class)
+  void matrix_shows_a_booking_made_by_the_employee(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN,
+        "/dailyreport/timereports/new?date=" + BOOKING_DATE, page -> {
+
+      page.fill("#durationTime", "03:00");
+      selectTomSelectOption(page, "suborderId", E2ETestData.SUBORDER_GLOBEX_CONSULT_SIGN);
+      page.fill("#commentField", "E2E-Matrix-Testbuchung");
+      page.click("button[type=submit]");
+      page.waitForLoadState();
+
+      page.navigate(urlWithLogin(
+          "/dailyreport/matrix?month=" + BOOKING_DATE.getMonthValue() + "&year=" + BOOKING_DATE.getYear(),
+          E2ETestData.EMPLOYEE_MA_SIGN));
+
+      assertThat(page.locator("#matrix")).isVisible();
+      assertThat(page.locator("#matrix")).containsText(E2ETestData.SUBORDER_GLOBEX_CONSULT_SIGN);
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(E2EBrowser.class)
+  void people_lead_can_open_the_matrix(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_PV_SIGN, "/dailyreport/matrix", page ->
+        assertThat(page.locator("#matrix")).isVisible());
+  }
+
+}

--- a/src/test/java/org/tb/e2e/dailyreport/ReleaseAcceptanceE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/ReleaseAcceptanceE2ETest.java
@@ -1,0 +1,38 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * Exercises the self-release flow at {@code /release} and the People Lead acceptance flow at
+ * {@code /acceptance}.
+ */
+class ReleaseAcceptanceE2ETest extends PlaywrightE2ETestBase {
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(E2EBrowser.class)
+  void employee_can_self_release_bookings(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN, "/release", page -> {
+      page.onDialog(dialog -> dialog.accept());
+      page.fill("input[name=selfReleaseDate]", "2026-05");
+      page.click("button[type=submit]");
+      page.waitForLoadState();
+
+      assertThat(page.locator("body")).containsText("2026-05-31");
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(E2EBrowser.class)
+  void people_lead_can_accept_team_bookings(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_PV_SIGN, "/acceptance", page -> {
+      assertThat(page.locator("body")).containsText(E2ETestData.EMPLOYEE_MA_SIGN);
+    });
+  }
+
+}


### PR DESCRIPTION
## Summary
- Adds a Playwright-based E2E test suite (`org.tb.e2e`) that starts the real Spring Boot app (`RANDOM_PORT`, `unittest` + `local` profiles) against H2 and drives it with real Chrome (`channel=chrome`) and Playwright-managed Firefox.
- `E2ETestData` seeds a realistic, idempotent master-data scenario: `HBT` customer with `URLAUB`/`KRANK`/`i976`-`FORTBILDUNG` standard orders (`standard=true`), 3 project customers/orders/suborders, and 5 employees across roles (`ma`, `pv`, `bl`, `bo`, `restricted`) with contracts, a vacation entitlement, and employee orders.
- Standard-order `Employeeorder`s are deliberately **not** seeded directly — they're provisioned by the real login mechanism (fixed by #805), and `LoginProvisionsStandardOrdersE2ETest` verifies that end-to-end.
- Covers: login-triggered standard-order provisioning, daily booking (project + vacation), matrix overview, self-release + People Lead acceptance, and the dashboard.
- `pom.xml`: adds `com.microsoft.playwright:playwright` (test scope), excludes `**/*E2ETest.java` from the default Surefire run, and adds an `e2e` Maven profile (`-Pe2e`) that runs only the E2E suite plus a one-time browser-install execution.
- Test-only mail sender mocking (`@MockitoBean(reset = MockReset.NONE) JavaMailSender`) since no SMTP server exists in the E2E environment; `management.health.mail.enabled=false` avoids an unrelated actuator health-indicator wiring issue this exposed.
- No CI wiring in this PR (per discussion, local-only for now): run via `jenv exec ./mvnw test -Pe2e` (one-time browser install: `jenv exec ./mvnw -Pe2e test-compile org.codehaus.mojo:exec-maven-plugin:3.1.0:java@install-playwright-browsers`).

## Test plan
- [x] `jenv exec ./mvnw test -Pe2e` — all 18 E2E tests (9 scenarios × Chrome + Firefox) pass locally.
- [x] `jenv exec ./mvnw verify` — unchanged, still excludes the E2E suite and stays green.

Closes #807

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.