### PR TITLE
Support a visible, slowed-down browser for local E2E debugging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,8 @@
       Runs the Playwright E2E test suite (Chrome + Firefox) against the dailyreport module.
       Requires a one-time local browser install: jenv exec ./mvnw -Pe2e test-compile exec:java@install-playwright-browsers
       Usage: jenv exec ./mvnw test -Pe2e
+      Watch it run in a visible, slowed-down browser: jenv exec ./mvnw test -Pe2e -De2e.headless=false -De2e.slowmo=500
+      Run only one browser (used by the CI matrix): -De2e.browsers=chrome (or firefox)
     -->
     <profile>
       <id>e2e</id>

--- a/src/test/java/org/tb/e2e/E2EBrowser.java
+++ b/src/test/java/org/tb/e2e/E2EBrowser.java
@@ -8,22 +8,34 @@ import com.microsoft.playwright.Playwright;
  * The two real browsers the dailyreport E2E suite must cover: an actually installed local
  * Google Chrome (via Playwright's {@code channel} option) and Playwright's managed Firefox
  * build.
+ *
+ * <p>Runs headless by default. For local, visible debugging, set
+ * {@code -De2e.headless=false} (optionally with {@code -De2e.slowmo=500}, milliseconds of
+ * delay Playwright inserts between actions) so you can watch the browser step through each
+ * test, e.g.:
+ * {@code jenv exec ./mvnw test -Pe2e -De2e.headless=false -De2e.slowmo=500}
  */
 public enum E2EBrowser {
 
   CHROME {
     @Override
     public Browser launch(Playwright playwright) {
-      return playwright.chromium().launch(new LaunchOptions().setChannel("chrome").setHeadless(true));
+      return playwright.chromium().launch(launchOptions().setChannel("chrome"));
     }
   },
   FIREFOX {
     @Override
     public Browser launch(Playwright playwright) {
-      return playwright.firefox().launch(new LaunchOptions().setHeadless(true));
+      return playwright.firefox().launch(launchOptions());
     }
   };
 
   public abstract Browser launch(Playwright playwright);
+
+  private static LaunchOptions launchOptions() {
+    boolean headless = !"false".equalsIgnoreCase(System.getProperty("e2e.headless", "true"));
+    double slowMo = Double.parseDouble(System.getProperty("e2e.slowmo", "0"));
+    return new LaunchOptions().setHeadless(headless).setSlowMo(slowMo);
+  }
 
 }


### PR DESCRIPTION
## Summary
- `E2EBrowser` now reads `-De2e.headless=false` (default: headless, unchanged) and `-De2e.slowmo=<ms>` (default: 0) to let you watch the Playwright-driven Chrome/Firefox step through a test locally.
- Documented in the `e2e` Maven profile comment in `pom.xml`.
- No change to CI or default local behavior — both stay headless with no slow-motion.

Example:
```
jenv exec ./mvnw test -Pe2e -De2e.browsers=chrome -De2e.headless=false -De2e.slowmo=500
```

## Test plan
- [x] `jenv exec ./mvnw test -Pe2e -De2e.browsers=chrome -De2e.headless=false -De2e.slowmo=300 -Dtest=DashboardE2ETest` — verified a real, visible Chrome window opens and steps through the test.
- [x] `jenv exec ./mvnw verify` — unaffected.

Closes #811

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.