### PR TITLE
Fix CSV-Export/Import-Rundtrip: Tagestyp im Export setzen (#820)

### DIFF
--- a/src/main/java/org/tb/dailyreport/controller/DailyReportCsvController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DailyReportCsvController.java
@@ -10,6 +10,7 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpOutputMessage;
@@ -36,6 +37,7 @@ import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeecontractService;
 import org.tb.employee.service.EmployeeService;
 
+@Slf4j
 @Controller
 @RequestMapping("/dailyreport/csv")
 @RequiredArgsConstructor
@@ -101,6 +103,7 @@ public class DailyReportCsvController {
                     .map(Object::toString).findFirst()
                     .orElse(messages.getMessage("main.dailyreport.csv.import.error.parse.text")));
         } catch (IOException ex) {
+            log.error("Could not import CSV.", ex);
             redirectAttributes.addFlashAttribute("toastError",
                 messages.getMessage("main.dailyreport.csv.import.error.parse.text"));
         }

--- a/src/main/java/org/tb/dailyreport/service/DailyWorkingReportService.java
+++ b/src/main/java/org/tb/dailyreport/service/DailyWorkingReportService.java
@@ -60,7 +60,7 @@ public class DailyWorkingReportService {
         var timeReports = timereportService.getTimereportsByDateAndEmployeeContractId(contractId, date)
             .stream().map(DailyReportData::valueOf).toList();
         if (workingDay == null && timeReports.isEmpty()) return null;
-        var builder = DailyWorkingReportData.builder().date(date).dailyReports(timeReports);
+        var builder = DailyWorkingReportData.builder().date(date).dailyReports(timeReports).type(WorkingDayType.WORKED);
         if (workingDay != null) {
             builder.type(workingDay.getType());
             if (workingDay.getType() != WorkingDayType.NOT_WORKED) {


### PR DESCRIPTION
## Beschreibung

Fixes #820.

Beim CSV-Export wurde für Tage, die Buchungen (Timereports), aber **keinen** `Workingday`-Datensatz haben, keine Tagesart (`type`) geschrieben — die Spalte blieb leer. Beim Re-Import gelten solche Zeilen in `DailyWorkingReportCsvConverter#isEmptyWorkingDayRow` als „leere" Arbeitstagszeile; `getUniqueWorkingDayRow` wirft dann `IOException("no working day data found for ...")`, was im Controller auf die generische Meldung `main.dailyreport.csv.import.error.parse.text` abgebildet wird.

Änderungen:
- `DailyWorkingReportService#buildReportForDay`: Der Builder wird mit `type(WorkingDayType.WORKED)` vorbelegt. Existiert ein `Workingday`, überschreibt dessen Typ den Default wie bisher.
- `DailyReportCsvController#importCsv`: Die `IOException` wird jetzt geloggt (`log.error`), damit die Ursache eines fehlgeschlagenen Imports nicht mehr nur als generischer Text beim Nutzer landet, sondern im Log nachvollziehbar ist.

## Akzeptanzkriterien / Testplan

- [x] Tagesbericht mit Buchungen an einem Tag ohne `Workingday`-Datensatz als CSV exportieren → Spalte für die Tagesart ist mit `WORKED` gefüllt.
- [x] Unveränderte Export-Datei im Modus „Überschreiben" (`replace`) wieder importieren → Import läuft ohne Fehlermeldung durch.
- [x] Gleicher Rundtrip im Modus „Anfügen" (`append`) funktioniert weiterhin.
- [x] Tage mit `Workingday` (inkl. `NOT_WORKED`) exportieren/importieren weiterhin unverändert.
- [x] Bei einem fehlschlagenden Import steht die Ursache im Anwendungslog.

## Operations / Deployment Notes

Keine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)