### PR TITLE
Matrix-Popover: Buchungsdetails nicht mehr abschneiden (#818)

### DIFF
--- a/src/main/resources/templates/dailyreport/matrix.html
+++ b/src/main/resources/templates/dailyreport/matrix.html
@@ -165,12 +165,12 @@
               class="text-center px-1"
               th:classappend="${matrixData.dayHeaders[cs.index].today ? 'matrix-today ' : ''} + ${cell.weekend ? 'bg-azure-lt' : (cell.publicHoliday ? 'bg-warning-lt' : '')}">
             <span th:if="${not cell.empty}" th:text="${cell.durationString}">7:30</span>
-            <div th:if="${not cell.empty and not #lists.isEmpty(cell.details)}" class="matrix-cell-detail p-10 d-none">
-              <pre th:each="d : ${cell.details}"
-                   class="text-start p-1 m-1"
+            <div th:if="${not cell.empty and not #lists.isEmpty(cell.details)}" class="matrix-cell-detail d-none">
+              <div th:each="d : ${cell.details}"
+                   class="text-start py-1"
                    th:text="${d.durationString + (d.taskDescription ne '' ? ': ' + d.taskDescription : '')}">
                 MOS-16345 did something
-              </pre>
+              </div>
             </div>
           </td>
           <td class="matrix-last-col text-center px-1 fw-medium" th:text="${row.totalString}">0:00</td>

--- a/src/test/java/org/tb/e2e/dailyreport/MatrixE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/MatrixE2ETest.java
@@ -1,7 +1,9 @@
 package org.tb.e2e.dailyreport;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.microsoft.playwright.Locator;
 import java.time.LocalDate;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -15,6 +17,9 @@ import org.tb.e2e.PlaywrightE2ETestBase;
 class MatrixE2ETest extends PlaywrightE2ETestBase {
 
   private static final LocalDate BOOKING_DATE = LocalDate.parse("2026-06-17");
+  private static final String LONG_COMMENT =
+      "Sehr ausfuehrliche Beschreibung der Taetigkeit, die deutlich breiter ist als das Popover "
+          + "und daher umgebrochen werden muss, damit nichts abgeschnitten wird.";
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
@@ -34,6 +39,39 @@ class MatrixE2ETest extends PlaywrightE2ETestBase {
 
       assertThat(page.locator("#matrix")).isVisible();
       assertThat(page.locator("#matrix")).containsText(E2ETestData.SUBORDER_GLOBEX_CONSULT_SIGN);
+    });
+  }
+
+  /**
+   * The detail lines used to be {@code <pre>} blocks, which Tabler styles with
+   * {@code overflow: auto} and no line wrapping, so long task descriptions were cut off behind a
+   * scrollbar that cannot be reached without dismissing the hover popover (#818).
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void cell_detail_popover_shows_the_complete_task_description(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN,
+        "/dailyreport/timereports/new?date=" + BOOKING_DATE, page -> {
+
+      page.fill("#durationTime", "03:00");
+      selectTomSelectOption(page, "suborderId", E2ETestData.SUBORDER_GLOBEX_CONSULT_SIGN);
+      page.fill("#commentField", LONG_COMMENT);
+      page.click("button[type=submit]");
+      page.waitForLoadState();
+
+      page.navigate(urlWithLogin(
+          "/dailyreport/matrix?month=" + BOOKING_DATE.getMonthValue() + "&year=" + BOOKING_DATE.getYear(),
+          E2ETestData.EMPLOYEE_MA_SIGN));
+
+      page.locator("#matrix tbody td:has(.matrix-cell-detail)").first().hover();
+
+      Locator popover = page.locator(".matrix-detail-popover");
+      assertThat(popover).isVisible();
+      assertThat(popover).containsText(LONG_COMMENT);
+
+      // the description has to wrap inside the popover instead of overflowing it sideways
+      assertEquals(true, popover.locator(".popover-body > *").first()
+          .evaluate("el => el.scrollWidth <= el.clientWidth + 1"));
     });
   }
 


### PR DESCRIPTION
## Beschreibung

Fixes #818.

Die Detailzeilen im Hover-Popover der Matrix waren `<pre>`-Elemente. Tabler stylt `pre` global mit `overflow: auto`, `white-space: pre` (Browser-Default, kein Umbruch) und einer 1rem breiten Custom-Scrollbar. Lange Tätigkeitsbeschreibungen wurden dadurch am rechten Popover-Rand abgeschnitten, und die eingeblendete Scrollbar ließ sich nicht bedienen, weil das Hover-Popover beim Verlassen der Zelle verschwindet.

Änderung: Die Detailzeilen sind jetzt einfache `<div>`s. Sie erben die Popover-Typografie und brechen normal um — der komplette Text ist lesbar, es entsteht keine Scrollbar mehr.

Der technische Hinweis im Issue (Clipping durch `.table-responsive`) trifft nicht zu: Bootstrap 5 normalisiert `container: false` zu `document.body`, das Popover hing also nie im Overflow-Container. Daher bleibt die Popover-Initialisierung unverändert.

Nebenbei entfernt: die wirkungslose Klasse `p-10` am ausgeblendeten Wrapper.

## Akzeptanzkriterien / Testplan

- [x] Neuer E2E-Test `MatrixE2ETest#cell_detail_popover_shows_the_complete_task_description` (Chrome + Firefox): bucht eine lange Beschreibung, hovert die Zelle und prüft, dass die Detailzeile nicht seitlich überläuft (`scrollWidth <= clientWidth`). Der Test schlägt auf dem alten Template fehl und ist mit dem Fix grün.
- [x] Manuell: `/dailyreport/matrix` öffnen, Zelle mit langer Buchungsbeschreibung hovern → vollständiger Text lesbar, keine Scrollbar.
- [x] Dark Mode gegenprüfen (Text erscheint jetzt in Popover-Textfarbe statt im dunklen `pre`-Block).

## Operations / Deployment Notes

Keine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)