### PR TITLE
Jira-Replikation: Baseline nur noch aus dem Config-Wasserzeichen (#840)

### DIFF
--- a/src/main/java/org/tb/jira/persistence/JiraTicketRepository.java
+++ b/src/main/java/org/tb/jira/persistence/JiraTicketRepository.java
@@ -1,11 +1,9 @@
 package org.tb.jira.persistence;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.tb.jira.domain.JiraTicket;
 
@@ -13,9 +11,6 @@ import org.tb.jira.domain.JiraTicket;
 public interface JiraTicketRepository extends JpaRepository<JiraTicket, Long> {
 
   Optional<JiraTicket> findByCustomerorderSignAndJiraId(String customerorderSign, long jiraId);
-
-  @Query("select max(t.updatedTs) from JiraTicket t where t.customerorderSign = :customerorderSign")
-  LocalDateTime findMaxUpdatedTs(String customerorderSign);
 
   List<JiraTicket> findByCustomerorderSignAndKeyIn(String customerorderSign, Collection<String> keys);
 

--- a/src/main/java/org/tb/jira/service/JiraReplicationService.java
+++ b/src/main/java/org/tb/jira/service/JiraReplicationService.java
@@ -51,8 +51,12 @@ public class JiraReplicationService {
         cfg.getId(), cfg.getName(), cfg.getCustomerorderSign(), pageSize);
 
     // Note: We do not modify JQL per requirement. We filter during upsert by updated timestamp.
-    var baseline = ticketRepo.findMaxUpdatedTs(cfg.getCustomerorderSign());
-    if (baseline == null) baseline = cfg.getLastMaxUpdated();
+    // The baseline comes solely from the config watermark, which is only written after a run has
+    // completed (see below). Deriving it from the stored tickets would let a single ticket saved by
+    // an aborted run raise the bar for all other tickets of that customer order, permanently
+    // skipping the ones that were never fetched. Re-fetching is harmless — upsertIfChanged is
+    // idempotent — so the failure mode has to be "fetch again", never "skip".
+    var baseline = cfg.getLastMaxUpdated();
     int startAt = 0;
     int processed = 0;
     LocalDateTime newMax = baseline;

--- a/src/test/java/org/tb/jira/service/JiraReplicationServiceTest.java
+++ b/src/test/java/org/tb/jira/service/JiraReplicationServiceTest.java
@@ -1,9 +1,11 @@
 package org.tb.jira.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -17,9 +19,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.RestClientException;
 import org.tb.common.domain.AuditedEntity;
 import org.tb.common.test.FixedClock;
 import org.tb.common.util.DateTimeUtils;
@@ -50,7 +54,6 @@ class JiraReplicationServiceTest {
   void testRunReplicationWithValidConfig() {
     JiraReplicationConfig config = createMockReplicationConfig();
     when(configRepo.findById(config.getId())).thenReturn(Optional.of(config));
-    when(ticketRepo.findMaxUpdatedTs(config.getCustomerorderSign())).thenReturn(null);
     when(jiraClient.searchIssues(any(), any(), any(), any(), anyInt(), anyInt(), any()))
         .thenReturn(createMockJiraSearchResult());
 
@@ -66,7 +69,6 @@ class JiraReplicationServiceTest {
   void testRunReplicationWithNoIssues() {
     JiraReplicationConfig config = createMockReplicationConfig();
     when(configRepo.findById(config.getId())).thenReturn(Optional.of(config));
-    when(ticketRepo.findMaxUpdatedTs(config.getCustomerorderSign())).thenReturn(null);
     when(jiraClient.searchIssues(any(), any(), any(), any(), anyInt(), anyInt(), any()))
         .thenReturn(emptyResult());
 
@@ -81,7 +83,6 @@ class JiraReplicationServiceTest {
     LocalDateTime mockUpdated = LocalDateTime.of(2026, 6, 25, 11, 20, 25);
     JiraReplicationConfig config = createMockReplicationConfig();
     when(configRepo.findById(config.getId())).thenReturn(Optional.of(config));
-    when(ticketRepo.findMaxUpdatedTs(config.getCustomerorderSign())).thenReturn(null);
     when(jiraClient.searchIssues(any(), any(), any(), any(), anyInt(), anyInt(), any()))
         .thenReturn(createMockJiraSearchResult(mockUpdated));
 
@@ -89,6 +90,56 @@ class JiraReplicationServiceTest {
 
     verify(configRepo, times(1)).save(config);
     assertEquals(mockUpdated, config.getLastMaxUpdated());
+  }
+
+  @Test
+  void testAbortedRunDoesNotAdvanceLastMaxUpdated() {
+    LocalDateTime watermark = LocalDateTime.of(2026, 6, 1, 8, 0, 0);
+    JiraReplicationConfig config = createMockReplicationConfig();
+    config.setLastMaxUpdated(watermark);
+    when(configRepo.findById(config.getId())).thenReturn(Optional.of(config));
+    // first page succeeds and stores a ticket with a far newer timestamp, second page fails
+    when(jiraClient.searchIssues(any(), any(), any(), any(), anyInt(), anyInt(), any()))
+        .thenReturn(pagedResult(mockIssue(LocalDateTime.of(2026, 8, 19, 10, 0, 0)), 2))
+        .thenThrow(new RestClientException("connection reset"));
+
+    assertThrows(RestClientException.class, () -> jiraReplicationService.runReplication(config.getId()));
+
+    verify(ticketRepo, times(1)).save(any(JiraTicket.class));
+    verify(configRepo, never()).save(any(JiraReplicationConfig.class));
+    assertEquals(watermark, config.getLastMaxUpdated());
+  }
+
+  @Test
+  void testBaselineIsTakenFromConfigWatermark() {
+    JiraReplicationConfig config = createMockReplicationConfig();
+    config.setLastMaxUpdated(LocalDateTime.of(2026, 6, 1, 8, 0, 0));
+    when(configRepo.findById(config.getId())).thenReturn(Optional.of(config));
+    when(jiraClient.searchIssues(any(), any(), any(), any(), anyInt(), anyInt(), any()))
+        .thenReturn(emptyResult());
+
+    jiraReplicationService.runReplication(config.getId());
+
+    assertEquals("(project = MOCK) AND updated >= '2026-06-01'", capturedJql());
+  }
+
+  @Test
+  void testMissingWatermarkFetchesEverything() {
+    JiraReplicationConfig config = createMockReplicationConfig();
+    config.setLastMaxUpdated(null);
+    when(configRepo.findById(config.getId())).thenReturn(Optional.of(config));
+    when(jiraClient.searchIssues(any(), any(), any(), any(), anyInt(), anyInt(), any()))
+        .thenReturn(emptyResult());
+
+    jiraReplicationService.runReplication(config.getId());
+
+    assertEquals("project = MOCK", capturedJql());
+  }
+
+  private String capturedJql() {
+    var jql = ArgumentCaptor.forClass(String.class);
+    verify(jiraClient).searchIssues(any(), any(), any(), jql.capture(), anyInt(), anyInt(), any());
+    return jql.getValue();
   }
 
   private JiraReplicationConfig createMockReplicationConfig() {
@@ -110,6 +161,10 @@ class JiraReplicationServiceTest {
   }
 
   private JiraSearchResult createMockJiraSearchResult(LocalDateTime updated) {
+    return result(mockIssue(updated));
+  }
+
+  private static JiraIssue mockIssue(LocalDateTime updated) {
     JiraIssue issue = new JiraIssue();
     issue.setId("1001");
     issue.setKey("MOCK-1");
@@ -119,7 +174,7 @@ class JiraReplicationServiceTest {
         "created", DateTimeUtils.now().toString(),
         "issuetype", Map.of("name", "Task")
     ));
-    return result(issue);
+    return issue;
   }
 
   private static JiraSearchResult result(JiraIssue issue) {
@@ -127,6 +182,13 @@ class JiraReplicationServiceTest {
     result.setIssues(List.of(issue));
     result.setMaxResults(1);
     result.setTotal(1);
+    return result;
+  }
+
+  /** One issue, but {@code total} claims more — forces the service to request a further page. */
+  private static JiraSearchResult pagedResult(JiraIssue issue, int total) {
+    var result = result(issue);
+    result.setTotal(total);
     return result;
   }
 


### PR DESCRIPTION
## Summary

- Die Baseline für den inkrementellen Abgleich kommt jetzt ausschließlich aus `JiraReplicationConfig.lastMaxUpdated` statt aus `JiraTicketRepository.findMaxUpdatedTs`.
- Bisher hob jedes gespeicherte Ticket die JQL-Schwelle für alle anderen Tickets desselben Kundenauftrags an. Da `lastMaxUpdated` erst nach der vollständigen Paginierungsschleife geschrieben wird, lief der Commit-on-Success-Schutz damit ins Leere: ein abgebrochener Lauf konnte Tickets mit älterem `updated`-Zeitstempel dauerhaft und unbemerkt überspringen.
- Der Fehlerfall führt nun zum erneuten Holen statt zum Überspringen — unschädlich, weil `upsertIfChanged` idempotent ist. Die Sortierung der Jira-Ergebnisse ist für die Korrektheit damit irrelevant (es wird nirgends ein `ORDER BY` gesetzt).
- `last_max_updated = NULL` erzwingt jetzt tatsächlich einen Vollabgleich; vorher wirkungslos, weil die Baseline aus `jira_ticket` neu abgeleitet wurde.
- `findMaxUpdatedTs` hat keine Aufrufer mehr und wurde entfernt.

Kein Schema-Änderung, keine neuen i18n-Keys, keine UI-Änderung.

**Hinweis zum Rollout:** Konfigurationen, deren `last_max_updated` aktuell `NULL` ist, machen beim ersten Lauf nach dem Deployment einen Vollabgleich. Idempotent, nur einmalig länger laufend.

Der zweite Weg, auf dem Tickets verloren gehen können — das Wasserzeichen rückt über dauerhaft fehlschlagende Einzeltickets hinaus — ist bewusst **nicht** Teil dieses PRs und separat als #841 erfasst.

## Test plan

- [x] `jenv exec ./mvnw verify` — BUILD SUCCESS, 299 Tests, 0 Failures
- [x] Neu: `testAbortedRunDoesNotAdvanceLastMaxUpdated` — erste Seite speichert ein Ticket mit weit neuerem Zeitstempel, zweite Seite wirft `RestClientException`; das Wasserzeichen bleibt unverändert und `configRepo.save` wird nicht aufgerufen
- [x] Neu: `testBaselineIsTakenFromConfigWatermark` — das abgesetzte JQL enthält `updated >= '2026-06-01'` aus dem Wasserzeichen
- [x] Neu: `testMissingWatermarkFetchesEverything` — ohne Wasserzeichen wird das JQL nicht eingeschränkt
- [x] Bestehende Tests unverändert grün (obsolete `findMaxUpdatedTs`-Stubs entfernt)

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #840