### PR TITLE
Fehleranzeige im Report-Ergebnis auf ErrorInfo umstellen (#848)

### DIFF
--- a/src/main/java/org/tb/reporting/service/ReportService.java
+++ b/src/main/java/org/tb/reporting/service/ReportService.java
@@ -164,6 +164,7 @@ public class ReportService {
           .columnHeaders(List.of())
           .error(true)
           .errorInfo(errorInfo)
+          .sql(resolvedSql) // the view offers "Show failing SQL", so the statement has to come along
           .build();
     }
   }

--- a/src/main/resources/templates/reporting/report-result.html
+++ b/src/main/resources/templates/reporting/report-result.html
@@ -31,15 +31,18 @@
     </div>
     <div class="card-body">
       <!-- Error Alert -->
-      <div th:if="${reportResult.error}" class="alert alert-danger" role="alert">
+      <!-- The details live on the nested ErrorInfo. Read through a local variable and tolerate it
+           being absent: a missing detail must not turn the error page itself into a 500. -->
+      <div th:if="${reportResult.error}" class="alert alert-danger" role="alert"
+           th:with="errorInfo=${reportResult.errorInfo}">
         <div class="d-flex">
           <div class="me-2"><i class="ti ti-alert-triangle"></i></div>
           <div>
-            <div><strong th:text="${reportResult.errorClass}">BadSqlGrammarException</strong>: <span th:text="${reportResult.errorMessage}">SQL error message</span></div>
-            <div class="small text-muted mt-1">
-              <span th:if="${reportResult.sqlState != null}">SQLState: <code th:text="${reportResult.sqlState}">42000</code></span>
-              <span th:if="${reportResult.sqlState != null && reportResult.errorCode != null}">&nbsp;|&nbsp;</span>
-              <span th:if="${reportResult.errorCode != null}">ErrorCode: <code th:text="${reportResult.errorCode}">1064</code></span>
+            <div><strong th:text="${errorInfo != null ? errorInfo.errorClass : 'Error'}">BadSqlGrammarException</strong>: <span th:text="${errorInfo?.errorMessage}">SQL error message</span></div>
+            <div class="small text-muted mt-1" th:if="${errorInfo != null}">
+              <span th:if="${errorInfo.sqlState != null}">SQLState: <code th:text="${errorInfo.sqlState}">42000</code></span>
+              <span th:if="${errorInfo.sqlState != null && errorInfo.errorCode != null}">&nbsp;|&nbsp;</span>
+              <span th:if="${errorInfo.errorCode != null}">ErrorCode: <code th:text="${errorInfo.errorCode}">1064</code></span>
             </div>
             <details class="mt-2">
               <summary>Show failing SQL</summary>

--- a/src/test/java/org/tb/e2e/reporting/ReportErrorDisplayE2ETest.java
+++ b/src/test/java/org/tb/e2e/reporting/ReportErrorDisplayE2ETest.java
@@ -1,0 +1,52 @@
+package org.tb.e2e.reporting;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+import org.tb.reporting.domain.ReportDefinition;
+import org.tb.reporting.persistence.ReportDefinitionRepository;
+
+/**
+ * A report whose SQL fails must show the database error, not a 500.
+ *
+ * <p>The error details moved onto the nested {@code ReportResult.ErrorInfo} in a refactoring that
+ * did not update the view, and because the block only renders for a failing report the mismatch
+ * stayed invisible for months (#848). This test walks that path so it cannot happen unnoticed
+ * again.
+ */
+class ReportErrorDisplayE2ETest extends PlaywrightE2ETestBase {
+
+  @Autowired
+  private ReportDefinitionRepository reportDefinitionRepository;
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void a_failing_report_shows_the_database_error_instead_of_a_500(E2EBrowser browser) {
+    var broken = new ReportDefinition();
+    broken.setName("E2E broken report");
+    // no placeholders, so execution is not deflected to the parameter form
+    broken.setSql("select * from a_table_that_does_not_exist");
+    var id = reportDefinitionRepository.save(broken).getId();
+
+    // the manager is authorized for every report, so no authorization rows are needed
+    runAsUser(browser, E2ETestData.EMPLOYEE_BL_SIGN, "/reporting/reports/execute?id=" + id, page -> {
+
+      var alert = page.locator(".alert-danger");
+      assertThat(alert).isVisible();
+      assertThat(alert).containsText("BadSqlGrammarException");
+      // the identifier travels in the driver message, which is localised — assert on the identifier
+      assertThat(alert).containsText("a_table_that_does_not_exist");
+      assertThat(alert).containsText("SQLState");
+
+      // the view offers "Show failing SQL", so the statement has to be carried into the result
+      assertThat(page.locator(".alert-danger pre code"))
+          .containsText("a_table_that_does_not_exist");
+    });
+  }
+
+}


### PR DESCRIPTION
## Ursache

`report-result.html` las die Fehlerdetails flach vom `ReportResult`:

```html
<strong th:text="${reportResult.errorClass}">…
<span th:if="${reportResult.sqlState != null}">…
```

Diese Felder sind in **6ec15fe7** („Propagate SQL errors through result type instead of throwing exception", Mai 2026) in ein verschachteltes `ReportResult.ErrorInfo` gewandert. Der Commit hat sechs Dateien angefasst — `ReportEmailService`, `ScheduledReportJobService`, `JobExecutionResult` und weitere — **das Template war nicht dabei**.

Ergebnis: `EL1008E: Property or field 'errorClass' cannot be found on object of type 'ReportResult'`, also ein 500 statt der Fehleranzeige.

Warum das drei Monate unbemerkt blieb: der Block steht unter `th:if="${reportResult.error}"` und wird nur für einen **fehlgeschlagenen** Report gerendert. Solange alle Reports liefen, war der Bruch unerreichbar. Die Suche nach weiteren veralteten Zugriffen in allen Templates ergab genau diese eine Stelle (Zeilen 38–42).

## Änderungen

1. **Zugriffe über `ErrorInfo`**, gelesen über eine lokale Variable statt vier Mal navigiert. Zusätzlich null-tolerant: `error == true` wird heute immer mit `errorInfo` gebaut, aber ein fehlendes Detail darf die Fehlerseite nicht selbst zum 500 machen — das ist der schlechteste Ort für einen NPE.

2. **`.sql(resolvedSql)` im `catch`-Zweig** von `ReportService.execute`. Zweiter Mangel derselben Stelle: die Ansicht bietet „Show failing SQL" an, im Fehlerfall wurde `sql` aber nie gesetzt, das Detail blieb also leer. `resolvedSql` steht bereits vor dem `try` und war nur nicht mitgegeben. Genau diese Information braucht man zur Diagnose eines kaputten Reports.

## Was dieser PR **nicht** tut

Die Reports „Healthcare PM Monat" (69) und „Healthcare PM total (new)" (71) laufen danach **nicht** wieder. Ihr SQL scheitert in der Datenbank — der Stacktrace im Ticket beweist, dass der Fehlerzweig erreicht wurde, es lag also eine `BadSqlGrammarException` vor. Dieser PR macht diesen Fehler lesbar, statt ihn hinter einem 500 zu verbergen.

Nach dem Deploy zeigt die Seite Exception-Klasse, Meldung, SQLState, ErrorCode und das fehlerhafte Statement. Damit lässt sich entscheiden, ob das SQL angepasst werden muss oder eine Schemaänderung die Reports gebrochen hat. Das SQL selbst liegt in `report_definition` und ist Daten, nicht Code.

Nicht angefasst habe ich außerdem, dass nur `BadSqlGrammarException` abgefangen wird — andere `DataAccessException`s laufen weiter in einen rohen 500. Das zu erweitern ist eine eigene Abwägung (es würde auch echte Fehler verschlucken) und gehört nicht in einen Blocker-Fix.

## Test plan

- [x] Neuer E2E-Test `ReportErrorDisplayE2ETest`: legt eine Report-Definition mit ungültigem SQL an und führt sie als Manager aus (der ist für jeden Report autorisiert, es braucht also keine Auth-Regeln). Geprüft werden Exception-Klasse, der Tabellen-Identifier aus der Treibermeldung, `SQLState` und das angezeigte fehlerhafte SQL
- [x] **Gegenprobe:** mit zurückgenommenem Template-Fix schlägt der Test mit exakt der Meldung aus dem Ticket fehl — `EL1008E` auf `errorClass`, `report-result` Zeile 38, Spalte 26
- [x] Grün in Chrome und Firefox
- [x] Volle Nicht-E2E-Suite grün: 299 Tests
- [x] Alle Templates auf weitere Zugriffe der alten flachen Felder durchsucht: keine weiteren

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #848