### PR TITLE
Effektiven Arbeitsbeginn aus einer Quelle bestimmen (#851)

### DIFF
--- a/src/main/java/org/tb/dailyreport/controller/TimereportController.java
+++ b/src/main/java/org/tb/dailyreport/controller/TimereportController.java
@@ -30,7 +30,9 @@ import org.tb.dailyreport.preferences.DailyPreferenceService;
 import org.tb.dailyreport.preferences.TimereportPreferenceService;
 import org.tb.common.exception.ErrorCodeException;
 import org.tb.common.exception.InvalidDataException;
+import org.tb.common.util.DateTimeUtils;
 import org.tb.common.viewhelper.ErrorCodeViewHelper;
+import org.tb.dailyreport.domain.Workingday;
 import org.tb.dailyreport.service.TimereportService;
 import org.tb.dailyreport.service.WorkingdayService;
 import org.tb.employee.domain.AuthorizedEmployee;
@@ -444,14 +446,27 @@ public class TimereportController {
         model.addAttribute("recentComments", loadRecentComments(employeeContractId, form));
         if (!isEdit && date != null && date.equals(today())) {
             var workingday = workingdayService.getWorkingday(ecId, date);
-            if (workingday != null && (workingday.getStarttimehour() > 0 || workingday.getStarttimeminute() > 0)) {
+            // A day marked as not worked has no starting point. The suppression hangs on the type,
+            // not on "start is 00:00" as before — that also treated a deliberately stored 00:00 as
+            // unset, and it would have swallowed the fallback below (#851).
+            boolean notWorked = workingday != null
+                && workingday.getType() == Workingday.WorkingDayType.NOT_WORKED;
+            if (!notWorked) {
+                // same source as the daily view, which is showing this start time to the user
+                var effectiveStart = workingdayService.getEffectiveStart(workingday, ecId);
+                long breakMinutes = workingday != null
+                    ? workingday.getBreakhours() * 60L + workingday.getBreakminutes()
+                    : 0;
                 long bookedMinutes = todaysBookings.stream()
                     .mapToLong(tr -> tr.getDuration().toMinutes())
                     .sum();
-                long startMinutes = workingday.getStarttimehour() * 60L + workingday.getStarttimeminute()
-                    + workingday.getBreakhours() * 60L + workingday.getBreakminutes()
-                    + bookedMinutes;
-                model.addAttribute("liveBookingStartMinutes", startMinutes);
+                long startMinutes = effectiveStart.getHour() * 60L + effectiveStart.getMinute()
+                    + breakMinutes + bookedMinutes;
+                // Only offer the live booking once that starting point is in the past. Otherwise the
+                // form would open with an end time before its begin time, which cannot be saved.
+                if (startMinutes < nowInMinutes()) {
+                    model.addAttribute("liveBookingStartMinutes", startMinutes);
+                }
             }
         }
         if (ecId > 0) {
@@ -516,6 +531,11 @@ public class TimereportController {
     }
 
     /** Tolerant towards the input formats of the time widget (#830), see DailyController.parseTime. */
+    private static long nowInMinutes() {
+        var now = DateTimeUtils.now().toLocalTime();
+        return now.getHour() * 60L + now.getMinute();
+    }
+
     private static int[] parseTime(String hhmm) {
         return parseFlexibleTimeOfDay(hhmm)
             .map(time -> new int[]{time.getHour(), time.getMinute()})

--- a/src/main/java/org/tb/dailyreport/service/DailyService.java
+++ b/src/main/java/org/tb/dailyreport/service/DailyService.java
@@ -32,7 +32,6 @@ import org.tb.dailyreport.domain.TimereportDTO;
 import org.tb.dailyreport.domain.Workingday;
 import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.service.EmployeecontractService;
-import org.tb.dailyreport.preferences.DailyPreferenceService;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +45,6 @@ public class DailyService {
     private final OvertimeService overtimeService;
     private final EmployeecontractService employeecontractService;
     private final AuthorizedUser authorizedUser;
-    private final DailyPreferenceService dailyPreferenceService;
 
     @Transactional(readOnly = true)
     public DailyViewData buildDailyView(LocalDate date, long employeeContractId) {
@@ -67,10 +65,8 @@ public class DailyService {
         List<WeekStripDay> weekStrip = buildWeekStrip(date, employeeContractId);
 
         boolean notWorked = workingday != null && workingday.getType() == Workingday.WorkingDayType.NOT_WORKED;
-        var preferredStart = workingday == null ? dailyPreferenceService.getForEmployeeContractId(employeeContractId).workDayStart() : null;
-        String startTime = workingday != null
-            ? String.format("%02d:%02d", workingday.getStarttimehour(), workingday.getStarttimeminute())
-            : String.format("%02d:%02d", preferredStart.getHour(), preferredStart.getMinute());
+        var effectiveStart = workingdayService.getEffectiveStart(workingday, employeeContractId);
+        String startTime = String.format("%02d:%02d", effectiveStart.getHour(), effectiveStart.getMinute());
         String breakTime = workingday != null
             ? String.format("%02d:%02d", workingday.getBreakhours(), workingday.getBreakminutes())
             : "00:00";

--- a/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
+++ b/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
@@ -32,6 +32,7 @@ import org.tb.dailyreport.persistence.PublicholidayRepository;
 import org.tb.dailyreport.persistence.TimereportDAO;
 import org.tb.dailyreport.persistence.WorkingdayDAO;
 import org.tb.dailyreport.persistence.WorkingdayRepository;
+import org.tb.dailyreport.preferences.DailyPreferenceService;
 import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.event.EmployeecontractConflictResolutionEvent;
 import org.tb.employee.event.EmployeecontractDeleteEvent;
@@ -52,6 +53,26 @@ public class WorkingdayService {
   private final WorkingdayDAO workingdayDAO;
   private final AuthService authService;
   private final EmployeecontractService employeecontractService;
+  private final DailyPreferenceService dailyPreferenceService;
+
+  /**
+   * The time the working day started: the stored value when there is one, otherwise the configured
+   * work day start.
+   *
+   * <p>Callers must not derive this themselves. The display in the daily view and the prefill in the
+   * booking form each had their own version, and only one of them knew about the fallback — so the
+   * first booking of a day did not pick up the start time the same page was showing (#851).
+   *
+   * <p>Takes the already loaded working day (may be {@code null}) so that callers which have it do
+   * not query twice. A working day marked as not worked carries {@code 00:00} here; whether that is
+   * a sensible starting point is the caller's decision.
+   */
+  public LocalTime getEffectiveStart(Workingday workingday, long employeecontractId) {
+    if (workingday != null) {
+      return LocalTime.of(workingday.getStarttimehour(), workingday.getStarttimeminute());
+    }
+    return dailyPreferenceService.getForEmployeeContractId(employeecontractId).workDayStart();
+  }
 
   private boolean isSupervisedByCurrentUser(Employeecontract ec) {
     return ec.getSupervisors().stream()

--- a/src/test/java/org/tb/e2e/dailyreport/LiveBookingStartE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/LiveBookingStartE2ETest.java
@@ -1,0 +1,92 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Page;
+import java.time.LocalDate;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.tb.common.test.FixedClock;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * The booking form prefills begin/end from the start of the working day (#851).
+ *
+ * <p>Walks the whole lifecycle of one day in one test on purpose: the interesting case is the state
+ * <em>before</em> a working day row exists, and a second test could not rely on that state still
+ * being there — the E2E tests share one database (#846).
+ *
+ * <p>Uses the backoffice employee because the other dailyreport tests book as {@code ema} on the
+ * fixed clock's today, which would create the very row this test needs to be absent.
+ */
+@FixedClock(LiveBookingStartE2ETest.NOW)
+class LiveBookingStartE2ETest extends PlaywrightE2ETestBase {
+
+  /**
+   * Set explicitly rather than relying on the base class: {@code @FixedClock} is not
+   * {@code @Inherited}, so a subclass without its own annotation silently gets the extension's
+   * default instead of the base class's value.
+   */
+  static final String NOW = "2026-06-25T10:15:30";
+
+  private static final String EMPLOYEE = E2ETestData.EMPLOYEE_BO_SIGN;
+  /** What {@link #NOW} makes "today"; no other E2E test books on this date. */
+  private static final LocalDate TODAY = LocalDate.parse("2026-06-25");
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void the_form_prefills_begin_from_the_start_of_the_working_day(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, "/settings", page -> {
+
+      // the default work day start is 09:00, which equals the fixed clock's "now" — no elapsed time
+      // to book, so move it earlier to get a meaningful live booking
+      page.fill("#workDayStart", "08:00");
+      page.click("button[type=submit]");
+      page.waitForLoadState();
+
+      // (1) first booking of the day: no working day row yet, so the configured start applies.
+      // The daily view has always shown it; the form used to ignore it and stay in duration mode.
+      page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + TODAY, EMPLOYEE));
+      assertThat(page.locator("#startTime")).hasValue("08:00");
+
+      openBookingForm(page, TODAY);
+      assertThat(page.locator("#durationModeField")).hasValue("beginEnd");
+      assertThat(page.locator("#beginEndSection")).isVisible();
+      assertThat(page.locator("#beginTimeInput")).hasValue("08:00");
+
+      // (2) a stored start wins over the setting
+      page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + TODAY, EMPLOYEE));
+      page.fill("#startTime", "07:00");
+      page.locator("h3").first().click();
+      page.waitForTimeout(1200);
+
+      openBookingForm(page, TODAY);
+      assertThat(page.locator("#beginTimeInput")).hasValue("07:00");
+
+      // (3) a day marked as not worked has no starting point
+      page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + TODAY, EMPLOYEE));
+      page.locator("#notWorked").check();
+      page.waitForTimeout(1200);
+
+      openBookingForm(page, TODAY);
+      assertThat(page.locator("#durationModeField")).hasValue("duration");
+      assertThat(page.locator("#beginEndSection")).isHidden();
+
+      // (4) the prefill is for today only — a past day stays in duration mode
+      page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + TODAY, EMPLOYEE));
+      page.locator("#notWorked").uncheck();
+      page.waitForTimeout(1200);
+
+      openBookingForm(page, TODAY.minusDays(3));
+      assertThat(page.locator("#durationModeField")).hasValue("duration");
+      assertThat(page.locator("#beginEndSection")).isHidden();
+    });
+  }
+
+  private void openBookingForm(Page page, LocalDate date) {
+    page.navigate(urlWithLogin("/dailyreport/timereports/new?date=" + date, EMPLOYEE));
+  }
+
+}


### PR DESCRIPTION
## Ursache

Zwei Stellen beantworteten dieselbe Frage — „wann hat der Arbeitstag begonnen?" — unterschiedlich:

- `DailyService.buildDailyView` hatte einen **Fallback** auf den konfigurierten Arbeitsbeginn, wenn für den Tag noch keine `workingday`-Zeile existiert. Deshalb *zeigte* die Einzelübersicht `08:00`.
- `TimereportController.populateModel` hatte ihn **nicht** und setzte `liveBookingStartMinutes` gar nicht erst — also kein Umschalten auf Von-Bis, keine Vorbelegung.

Die Zeile entsteht erst beim Speichern einer Buchung (`seedWorkingday`); `buildDailyView` schreibt nichts. Wer Start und Pause nicht anfasst, hat vor der ersten Buchung also keine Zeile. Genau der gemeldete Fall — ab der zweiten Buchung lief es.

## Änderungen

**Eine gemeinsame Quelle.** Neu `WorkingdayService.getEffectiveStart(workingday, employeecontractId)`: gespeicherter Wert wenn vorhanden, sonst der konfigurierte Arbeitsbeginn. Beide Aufrufstellen benutzen sie. Die Methode nimmt die bereits geladene `workingday` entgegen, damit keine zweite Abfrage entsteht. Die Ableitung in `DailyService` entfällt samt der dort nun toten `DailyPreferenceService`-Abhängigkeit.

**Unterdrückung am Typ statt am Wert.** Die alte Bedingung `getStarttimehour() > 0 || getStarttimeminute() > 0` tat zwei Dinge in einem: sie verhinderte das Umschalten an „nicht gearbeitet"-Tagen (dort werden Start und Pause auf 0 gesetzt) und behandelte gleichzeitig ein bewusst gespeichertes `00:00` als nicht gesetzt. Mit dem Fallback hätte sie ihn außerdem mitverschluckt. Jetzt hängt die Unterdrückung explizit an `WorkingDayType.NOT_WORKED`.

**Über die Akzeptanzkriterien hinaus, bewusst:** die Live-Buchung wird nur angeboten, wenn der Startpunkt in der Vergangenheit liegt. Sonst öffnet das Formular mit einer Endzeit **vor** der Startzeit — ein Zustand, der sich nicht speichern lässt. Bisher konnte das nur passieren, wenn eine Zeile gespeichert war und man früh buchte; mit dem Fallback träfe es jede Buchung vor Arbeitsbeginn, und das ist nicht exotisch. Wenn ihr das anders wollt, nehme ich es raus.

## Test

`LiveBookingStartE2ETest` läuft den Lebenszyklus eines Tages in einem Test durch, weil der interessante Zustand der ist, in dem noch **keine** Zeile existiert — ein zweiter Test könnte sich darauf nicht verlassen, die E2E-Tests teilen eine Datenbank (#846):

1. keine Zeile → Vorbelegung aus der Einstellung, und die Einzelübersicht zeigt denselben Wert
2. gespeicherter Start → gewinnt über die Einstellung
3. „nicht gearbeitet" → kein Umschalten
4. vergangener Tag → Dauer-Modus, die Vorbelegung gilt nur für heute

Der Test bucht als Backoffice-Mitarbeiter, weil die anderen dailyreport-Tests als `ema` auf dem Heute der Testuhr buchen — und damit genau die Zeile erzeugen würden, deren Abwesenheit hier geprüft wird.

**Gegengeprüft:** mit zurückgenommenem Controller-Fix schlägt der Test fehl, das Formular bleibt im Dauer-Modus.

- [x] Neuer E2E-Test grün (Chrome)
- [x] Volle Nicht-E2E-Suite grün: 315 Tests
- [x] E2E-Suite grün bis auf den vorbestehenden `MatrixE2ETest`-Fehlschlag (#846)

## Nebenbefund in der Test-Infrastruktur

Beim Schreiben des Tests gestolpert und erwähnenswert, weil es still falsch läuft: **`@FixedClock` ist nicht `@Inherited`.** `FixedClockExtension.resolveFixture` benutzt `clazz.getAnnotation(...)`, findet an einer Unterklasse ohne eigene Annotation also nichts und fällt auf den Extension-Default `2026-06-25T10:15:30` zurück.

Folge: `PlaywrightE2ETestBase` deklariert `FIXED_NOW = "2026-06-15T09:00:00"` und seedet damit, **jede Unterklasse läuft aber auf 2026-06-25T10:15:30**. Den bisherigen Tests fällt das nicht auf, weil keiner von ihnen von „heute" abhängt. Mein Test tut es, deshalb setzt er die Uhr explizit.

Das gehört als eigenes Ticket aufgenommen — entweder `@Inherited` an die Annotation oder Suche über die Klassenhierarchie in der Extension. Ich habe es hier nicht angefasst, weil es die Uhr für alle E2E-Tests verschiebt und das eine eigene Prüfung braucht.

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #851