### PR TITLE
Dauern in der Fortschrittsanzeige mit Einheit, immer sichtbar (#831)

### DIFF
--- a/src/main/java/org/tb/dailyreport/service/DailyService.java
+++ b/src/main/java/org/tb/dailyreport/service/DailyService.java
@@ -55,11 +55,11 @@ public class DailyService {
         Duration totalBooked = timereports.stream().map(TimereportDTO::getDuration).reduce(Duration.ZERO, Duration::plus);
         Workingday workingday = workingdayService.getWorkingday(employeeContractId, date);
 
-        String quittingTime = workingdayService.calculateQuittingTime(workingday);
-        String targetEndTime = hasTarget ? workingdayService.calculateWorkingDayEnds(workingday) : null;
+        String quittingTime = workingdayService.calculateQuittingTime(employeeContractId, date);
+        String targetEndTime = hasTarget ? workingdayService.calculateWorkingDayEnds(employeeContractId, date) : null;
         boolean overMaxHours = workingdayService.checkLaborTimeMaximum(timereports);
 
-        long targetMinutes = hasTarget && workingday != null ? workingday.getEmployeecontract().getDailyWorkingTime().toMinutes() : 0;
+        long targetMinutes = hasTarget ? contract.getDailyWorkingTime().toMinutes() : 0;
         int progressPercent = targetMinutes > 0 ? (int) Math.min(100, totalBooked.toMinutes() * 100 / targetMinutes) : 0;
 
         List<WeekStripDay> weekStrip = buildWeekStrip(date, employeeContractId);
@@ -70,8 +70,8 @@ public class DailyService {
         String breakTime = workingday != null
             ? String.format("%02d:%02d", workingday.getBreakhours(), workingday.getBreakminutes())
             : "00:00";
-        String dailyWorkingTimeFormatted = workingday != null
-            ? DurationUtils.format(workingday.getEmployeecontract().getDailyWorkingTime())
+        String dailyWorkingTimeFormatted = hasTarget
+            ? DurationUtils.format(contract.getDailyWorkingTime())
             : null;
 
         boolean isOwner = contract.getEmployee().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());

--- a/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
+++ b/src/main/java/org/tb/dailyreport/service/WorkingdayService.java
@@ -183,28 +183,35 @@ public class WorkingdayService {
     return LocalTime.MIDNIGHT.plus(elapsed);
   }
 
-  public String calculateQuittingTime(Workingday workingday) {
-    if (workingday == null) return "n/a";
+  /**
+   * When the day is done based on what has been booked so far.
+   *
+   * <p>Works without a stored working day: the start then comes from {@link #getEffectiveStart}, so
+   * the daily view shows a quitting time from the first visit on instead of only after the first
+   * booking (#831).
+   */
+  public String calculateQuittingTime(long employeecontractId, LocalDate date) {
     Duration laborTime = timereportDAO
-        .getTimereportsByDateAndEmployeeContractId(workingday.getEmployeecontract().getId(), workingday.getRefday())
+        .getTimereportsByDateAndEmployeeContractId(employeecontractId, date)
         .stream().map(TimereportDTO::getDuration).reduce(Duration.ZERO, Duration::plus);
-    LocalTime end = LocalTime.MIDNIGHT
-        .plusHours(workingday.getStarttimehour())
-        .plusMinutes(workingday.getStarttimeminute())
-        .plusHours(workingday.getBreakhours())
-        .plusMinutes(workingday.getBreakminutes())
-        .plus(laborTime);
-    return "%02d:%02d".formatted(end.getHour(), end.getMinute());
+    return endOfDay(getWorkingday(employeecontractId, date), employeecontractId, laborTime);
   }
 
-  public String calculateWorkingDayEnds(Workingday workingday) {
-    if (workingday == null) return "n/a";
+  /** When the day would be done if the full daily working time were booked. */
+  public String calculateWorkingDayEnds(long employeecontractId, LocalDate date) {
+    var dailyWorkingTime = employeecontractService.getEmployeecontractById(employeecontractId)
+        .getDailyWorkingTime();
+    return endOfDay(getWorkingday(employeecontractId, date), employeecontractId, dailyWorkingTime);
+  }
+
+  private String endOfDay(Workingday workingday, long employeecontractId, Duration worked) {
+    var start = getEffectiveStart(workingday, employeecontractId);
     LocalTime end = LocalTime.MIDNIGHT
-        .plusHours(workingday.getStarttimehour())
-        .plusMinutes(workingday.getStarttimeminute())
-        .plusHours(workingday.getBreakhours())
-        .plusMinutes(workingday.getBreakminutes())
-        .plus(workingday.getEmployeecontract().getDailyWorkingTime());
+        .plusHours(start.getHour())
+        .plusMinutes(start.getMinute())
+        .plusHours(workingday != null ? workingday.getBreakhours() : 0)
+        .plusMinutes(workingday != null ? workingday.getBreakminutes() : 0)
+        .plus(worked);
     return "%02d:%02d".formatted(end.getHour(), end.getMinute());
   }
 

--- a/src/main/resources/org/tb/web/MessageResources.properties
+++ b/src/main/resources/org/tb/web/MessageResources.properties
@@ -430,6 +430,7 @@ main.daily.column.order=Auftrag / Unterauftrag
 main.daily.column.total=Gesamt
 main.daily.delete.modal.confirm=Löschen
 main.daily.delete.modal.title=Buchung löschen?
+main.daily.duration.unit=h
 main.daily.favourites.apply.button=Favorit anwenden
 main.daily.favourites.delete.confirm=Diesen Favoriten löschen?
 main.daily.favourites.delete.title=Favorit löschen

--- a/src/main/resources/org/tb/web/MessageResources_en.properties
+++ b/src/main/resources/org/tb/web/MessageResources_en.properties
@@ -432,6 +432,7 @@ main.daily.column.order=Order / Suborder
 main.daily.column.total=Total
 main.daily.delete.modal.confirm=Delete
 main.daily.delete.modal.title=Delete booking?
+main.daily.duration.unit=h
 main.daily.favourites.apply.button=Apply favourite
 main.daily.favourites.delete.confirm=Delete this favourite?
 main.daily.favourites.delete.title=Delete favourite

--- a/src/main/resources/templates/dailyreport/daily.html
+++ b/src/main/resources/templates/dailyreport/daily.html
@@ -198,23 +198,36 @@
           <!-- Progress / quitting time -->
           <div th:if="${dailyData != null and dailyData.hasTarget}" id="daily-progress"
                th:classappend="${workingdayForm.notWorked} ? 'd-none' : ''" class="mt-3">
-            <div class="d-flex justify-content-between align-items-center mb-1">
-              <span class="text-muted small">
-                <span th:text="#{main.daily.booked.label}">Gebucht:</span>
-                <strong th:text="${@durationUtils.format(dailyData.totalBooked)}"></strong>
-                <span th:text="#{main.daily.of.label}">von</span>
-                <strong th:text="${dailyData.dailyWorkingTimeFormatted ?: '—'}"></strong>
-              </span>
-              <span class="text-muted small" th:if="${dailyData.workingday != null}">
-                <span th:text="#{main.daily.quitting.label}">Feierabend ~</span>
-                <strong th:text="${dailyData.quittingTime}"></strong>
-              </span>
-            </div>
-            <div class="progress" style="height: 8px" th:if="${dailyData.progressPercent > 0 or dailyData.hasTarget}">
-              <div class="progress-bar"
-                   th:classappend="${dailyData.overMaxHours} ? 'bg-danger' : 'bg-primary'"
-                   role="progressbar"
-                   th:style="'width:' + ${dailyData.progressPercent} + '%'">
+            <!-- The content is a fragment because the OOB refresh below renders the same block. It
+                 used to be copied, and a change in one place silently drifted from the other. -->
+            <div th:fragment="dailyProgressContent">
+              <!-- flex-wrap: the booked duration and the quitting time must not squeeze each other
+                   on a narrow window -->
+              <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-1">
+                <span class="text-muted small">
+                  <span th:text="#{main.daily.booked.label}">Gebucht:</span>
+                  <!-- both values are durations; without the unit they read like a time of day,
+                       especially next to the quitting time in the same h:mm format (#831) -->
+                  <strong th:text="${@durationUtils.format(dailyData.totalBooked)}"></strong>
+                  <span th:text="#{main.daily.duration.unit}">h</span>
+                  <span th:text="#{main.daily.of.label}">von</span>
+                  <strong th:text="${dailyData.dailyWorkingTimeFormatted ?: '—'}"></strong>
+                  <span th:if="${dailyData.dailyWorkingTimeFormatted != null}"
+                        th:text="#{main.daily.duration.unit}">h</span>
+                </span>
+                <!-- no longer bound to a stored working day: the quitting time is computed from the
+                     effective start, so it is there before the first booking too (#831) -->
+                <span class="text-muted small">
+                  <span th:text="#{main.daily.quitting.label}">Feierabend ~</span>
+                  <strong th:text="${dailyData.quittingTime}"></strong>
+                </span>
+              </div>
+              <div class="progress" style="height: 8px" th:if="${dailyData.progressPercent > 0 or dailyData.hasTarget}">
+                <div class="progress-bar"
+                     th:classappend="${dailyData.overMaxHours} ? 'bg-danger' : 'bg-primary'"
+                     role="progressbar"
+                     th:style="'width:' + ${dailyData.progressPercent} + '%'">
+                </div>
               </div>
             </div>
           </div>
@@ -386,25 +399,8 @@
       <div th:if="${isHtmxRequest == true and isDailyMode == true and dailyData != null and dailyData.hasTarget}" id="daily-progress"
            th:classappend="${workingdayForm.notWorked} ? 'd-none' : ''"
            hx-swap-oob="outerHTML:#daily-progress" class="mt-3">
-        <div class="d-flex justify-content-between align-items-center mb-1">
-          <span class="text-muted small">
-            <span th:text="#{main.daily.booked.label}">Gebucht:</span>
-            <strong th:text="${@durationUtils.format(dailyData.totalBooked)}"></strong>
-            <span th:text="#{main.daily.of.label}">von</span>
-            <strong th:text="${dailyData.dailyWorkingTimeFormatted ?: '—'}"></strong>
-          </span>
-          <span class="text-muted small" th:if="${dailyData.workingday != null}">
-            <span th:text="#{main.daily.quitting.label}">Feierabend ~</span>
-            <strong th:text="${dailyData.quittingTime}"></strong>
-          </span>
-        </div>
-        <div class="progress" style="height: 8px" th:if="${dailyData.progressPercent > 0 or dailyData.hasTarget}">
-          <div class="progress-bar"
-               th:classappend="${dailyData.overMaxHours} ? 'bg-danger' : 'bg-primary'"
-               role="progressbar"
-               th:style="'width:' + ${dailyData.progressPercent} + '%'">
-          </div>
-        </div>
+        <!-- same content as the initial render, see dailyProgressContent -->
+        <div th:replace="~{:: dailyProgressContent}"></div>
       </div>
 
       <!-- OOB: week strip refresh -->

--- a/src/test/java/org/tb/e2e/dailyreport/DailyProgressUnitE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/DailyProgressUnitE2ETest.java
@@ -1,0 +1,79 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.microsoft.playwright.Page;
+import java.time.LocalDate;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.tb.common.test.FixedClock;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * The progress line in the daily view: durations carry their unit, and the line is there from the
+ * first visit on rather than only once something has been stored (#831).
+ */
+@FixedClock(DailyProgressUnitE2ETest.NOW)
+class DailyProgressUnitE2ETest extends PlaywrightE2ETestBase {
+
+  /** Explicit because {@code @FixedClock} is not inherited from the base class. */
+  static final String NOW = "2026-07-15T14:00:00";
+
+  private static final String EMPLOYEE = E2ETestData.EMPLOYEE_MA_SIGN;
+  /** Untouched by the other E2E tests, and in the past so the live booking prefill stays out. */
+  private static final LocalDate UNTOUCHED_DAY = LocalDate.parse("2026-07-13");
+  private static final LocalDate BOOKED_DAY = LocalDate.parse("2026-07-14");
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void a_day_without_anything_stored_still_shows_target_progress_and_quitting_time(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, "/dailyreport/daily?mode=daily&date=" + UNTOUCHED_DAY, page -> {
+
+      // no working day row, no booking — the target used to be read through that row, so the line
+      // showed "von —" with an empty bar and no quitting time at all
+      var progress = page.locator("#daily-progress");
+      assertThat(progress).isVisible();
+      assertThat(progress).containsText("0:00 h");
+      assertThat(progress).containsText("8:00 h");
+      assertThat(progress).containsText("Feierabend");
+      assertThat(progress.locator(".progress-bar")).hasCount(1);
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void the_progress_line_looks_the_same_after_an_out_of_band_refresh(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, "/dailyreport/timereports/new?date=" + BOOKED_DAY, page -> {
+
+      page.fill("#durationTime", "02:00");
+      selectTomSelectOption(page, "suborderId", E2ETestData.SUBORDER_ALPHA_DEV_SIGN);
+      page.click("#timereportMainForm button[type=submit]");
+      page.waitForLoadState();
+
+      page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + BOOKED_DAY, EMPLOYEE));
+      assertThat(page.locator("#daily-progress")).containsText("2:00 h");
+      var initial = structureOf(page);
+
+      // an inline duration edit answers with an out-of-band refresh of this very block, which used
+      // to be a copy of the markup above and could drift from it unnoticed
+      var wrap = page.locator("#daily-bookings-area .inline-edit-wrap:has(input[name='duration'])").first();
+      wrap.locator(".inline-edit-display").click();
+      wrap.locator(".inline-edit-input").fill("03:00");
+      page.locator("h3").first().click();
+      page.waitForTimeout(1500);
+
+      assertThat(page.locator("#daily-progress")).containsText("3:00 h");
+      assertEquals(initial, structureOf(page),
+          "labels and units must be identical after the refresh; only the values may move");
+    });
+  }
+
+  /** The rendered line with all clock and duration values masked out, so only the wording remains. */
+  private String structureOf(Page page) {
+    return page.locator("#daily-progress").innerText().replaceAll("\\d{1,2}:\\d{2}", "#");
+  }
+
+}


### PR DESCRIPTION
## Die gemeldete Verwechslungsgefahr

`Gebucht: 7:30 von 8:00` las sich wie eine Uhrzeit — verstärkt dadurch, dass rechts daneben mit `Feierabend ~ 17:15` tatsächlich eine Uhrzeit im gleichen `h:mm`-Format steht. Beide Dauerwerte tragen jetzt ein `h` aus einem eigenen i18n-Key (`main.daily.duration.unit`, beide Bundles, sortiert):

```
Gebucht: 7:30 h von 8:00 h          Feierabend ~ 17:15
```

Ohne Tagessoll bleibt es bei `Gebucht: 7:30 h von —` — die Einheit hängt am Wert, nicht am Gedankenstrich.

**Die im Ticket erbetene Prüfung, ob dieselbe Darstellung woanders auftritt: nein.** `quittingTime` kommt in genau diesen zwei Blöcken vor — das ist die einzige Stelle in der Anwendung, an der eine Dauer und eine Uhrzeit nebeneinander im selben Format stehen. Die übrigen 56 `durationUtils.format`-Stellen (Auftragslisten, Matrix, Wochenstreifen, Meine Konten) stehen in Spalten mit Kopfzeile oder als Badge ohne Uhrzeit in der Nähe. Dort Einheiten nachzurüsten wäre eine breite optische Änderung ohne den Anlass, der dieses Ticket ausgelöst hat.

## Duplizierung strukturell entfernt

Das Ticket warnt: „Die Markup-Blöcke sind dupliziert. Eine Korrektur muss an **beiden** Stellen erfolgen." Statt sie beide zu pflegen ist der Inhalt jetzt ein Fragment (`dailyProgressContent`), das der OOB-Refresh wiederverwendet. Die Anzeige kann nach einem HTMX-Update also nicht mehr strukturell von der initialen abweichen — vorher war das eine Frage der Disziplin.

Die beiden Wrapper-`div`s bleiben getrennt, weil sie sich legitim unterscheiden: der eine trägt `hx-swap-oob`, der andere nicht, und die `th:if`-Bedingungen sind verschieden.

## Zusätzlich behoben: ohne gespeicherte Startzeit fehlte alles

Aus der Diskussion am Ticket: ohne gespeicherte Startzeit und ohne Buchung gab es weder Tagessoll noch Feierabend, und der Fortschrittsbalken blieb leer. Ursache war, dass beide Werte über die `workingday`-Zeile gelesen wurden — die erst beim ersten Speichern entsteht:

| | vorher | jetzt |
|---|---|---|
| Tagessoll / Fortschritt | `hasTarget && workingday != null` → sonst `—` und 0 % | aus dem Vertrag, wo die Arbeitszeit hingehört |
| `calculateQuittingTime` | `workingday == null` → `"n/a"` | rechnet ab `getEffectiveStart` |
| `calculateWorkingDayEnds` | `workingday == null` → `"n/a"` | dito |
| Feierabend-Anzeige | `th:if="${dailyData.workingday != null}"` | immer |

`getEffectiveStart` ist die gemeinsame Quelle aus #851 — dieselbe, die schon die Startzeit in der Zeile darüber und die Vorbelegung im Buchungsformular speist. Die Signaturen der beiden Rechenmethoden nehmen jetzt `(employeecontractId, date)` statt der Entität; `DailyService` war der einzige Aufrufer, deshalb umgestellt statt überladen.

**Eine Beobachtung, die ich nicht eigenmächtig geändert habe:** `calculateQuittingTime` rechnet `Start + Pause + gebuchte Zeit`. Bei null gebuchten Stunden steht dort also die Startzeit selbst — „Feierabend ~ 09:00" um neun Uhr morgens. Der Wert beantwortet „wann wäre ich fertig, wenn ich jetzt aufhöre", nicht „wann darf ich gehen". Letzteres wäre `calculateWorkingDayEnds`, das berechnet, aber nirgends angezeigt wird. Ob das Label die andere Zahl meinen sollte, ist eine fachliche Entscheidung — sagt Bescheid, dann drehe ich es.

## Test plan

- [x] `DailyProgressUnitE2ETest`, 2 Tests: ein Tag ohne gespeicherte Zeile und ohne Buchung zeigt Tagessoll, Balken und Feierabend; nach dem OOB-Refresh sind Beschriftungen und Einheiten identisch zur initialen Darstellung
- [x] Der Vergleich maskiert alle `h:mm`-Werte, prüft also die Struktur — die Feierabend-Zeit wandert beim Nachbuchen korrekt mit und darf sich unterscheiden
- [x] **Gegengeprüft:** mit zurückgenommenem Java-Fix schlägt der Fall „nichts gespeichert" fehl
- [x] Volle Nicht-E2E-Suite grün: 315 Tests
- [x] E2E-Suite grün bis auf den vorbestehenden `MatrixE2ETest`-Fehlschlag (#846)
- [x] Schmales Fenster: die Zeile hat `flex-wrap` und `gap-2` bekommen, damit die beiden Angaben umbrechen statt sich zu quetschen

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #831