### PR TITLE
Pause als Dauer eingeben, nicht als Uhrzeit (#833)

### DIFF
--- a/src/main/java/org/tb/dailyreport/controller/DailyController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DailyController.java
@@ -169,7 +169,8 @@ public class DailyController {
             } else {
                 var beginTime = dailyPreferenceService.getForEmployeeContractId(effEmployeeContractId).workDayStart();
                 int[] start = parseTime(form.getStartTime(), beginTime.getHour(), beginTime.getMinute());
-                int[] brk   = parseTime(form.getBreakTime(), 0, 0);
+                // the break is a duration, not a time of day — "30" means half an hour, not 30 o'clock
+                int[] brk   = parseBreak(form.getBreakTime());
                 workingday.setType(Workingday.WorkingDayType.WORKED);
                 workingday.setStarttimehour(start[0]);
                 workingday.setStarttimeminute(start[1]);
@@ -387,6 +388,16 @@ public class DailyController {
      * point when the field is submitted with Enter, before the client had a chance to normalise on
      * blur. Without that tolerance the value would silently fall back to the default.
      */
+    /**
+     * The break length. Read as a duration, so two digits are minutes: "30" is half an hour, whereas
+     * the same input in a time-of-day field would be an invalid hour and silently fall back to zero
+     * (#833). Anything unparseable means no break.
+     */
+    private static int[] parseBreak(String value) {
+        long minutes = parseFlexibleMinutes(value).orElse(0L);
+        return new int[]{(int) (minutes / MINUTES_PER_HOUR), (int) (minutes % MINUTES_PER_HOUR)};
+    }
+
     private static int[] parseTime(String hhmm, int defaultHour, int defaultMinute) {
         return parseFlexibleTimeOfDay(hhmm)
             .map(time -> new int[]{time.getHour(), time.getMinute()})

--- a/src/main/resources/static/js/salat.js
+++ b/src/main/resources/static/js/salat.js
@@ -269,6 +269,8 @@ function timeBlur(event) {
  */
 function durationMask(event) {
   const input = event.target;
+  // a native time input rejects intermediate values, so leave it to the browser (classic break field)
+  if (input.type === 'time') return;
   const raw = input.value;
   if (/[.,hm]/i.test(raw)) {
     const cleaned = raw.replace(/[^\d:.,hm ]/gi, '');
@@ -282,6 +284,7 @@ function durationMask(event) {
 }
 
 function durationBlur(event) {
+  if (event.target.type === 'time') return;
   const minutes = parseDurationValue(event.target.value);
   if (minutes !== null) {
     event.target.value = timeInputFormat(minutes);

--- a/src/main/resources/templates/dailyreport/daily.html
+++ b/src/main/resources/templates/dailyreport/daily.html
@@ -182,11 +182,11 @@
                        th:text="#{main.daily.workingday.break.label}">Pause</label>
                 <input type="time" class="form-control form-control-sm" th:field="*{breakTime}"
                        th:disabled="${!dailyData.workingdayEditable}"
-                       style="width:auto" size="5" oninput="timeMask(event)"
-                       onblur="timeBlur(event); saveTime(event)"
-                       inputmode="numeric" maxlength="5" placeholder="HH:MM"
+                       style="width:auto" size="5" oninput="durationMask(event)"
+                       onblur="durationBlur(event); saveTime(event)"
+                       inputmode="decimal" maxlength="8" placeholder="HH:MM"
                        th:attr="type=${betaTimeInput} ? 'text' : 'time',
-                                data-time-mode=${betaTimeInput} ? 'time' : null,
+                                data-time-mode=${betaTimeInput} ? 'duration' : null,
                                 data-time-step=${betaTimeInput} ? '15' : null,
                                 data-time-label-decrease=#{main.timeinput.decrease.tooltip},
                                 data-time-label-increase=#{main.timeinput.increase.tooltip}">
@@ -505,11 +505,11 @@
                      th:text="#{main.daily.workingday.break.label}">Pause</label>
               <input type="time" class="form-control form-control-sm" th:field="*{breakTime}"
                      th:disabled="${!dailyData.workingdayEditable}"
-                     style="width:auto" size="5" oninput="timeMask(event)"
-                     onblur="timeBlur(event); saveTime(event)"
-                     inputmode="numeric" maxlength="5" placeholder="HH:MM"
+                     style="width:auto" size="5" oninput="durationMask(event)"
+                     onblur="durationBlur(event); saveTime(event)"
+                     inputmode="decimal" maxlength="8" placeholder="HH:MM"
                      th:attr="type=${betaTimeInput} ? 'text' : 'time',
-                              data-time-mode=${betaTimeInput} ? 'time' : null,
+                              data-time-mode=${betaTimeInput} ? 'duration' : null,
                               data-time-step=${betaTimeInput} ? '15' : null,
                               data-time-label-decrease=#{main.timeinput.decrease.tooltip},
                               data-time-label-increase=#{main.timeinput.increase.tooltip}">

--- a/src/test/java/org/tb/e2e/dailyreport/BreakAsDurationE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/BreakAsDurationE2ETest.java
@@ -1,0 +1,94 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Page;
+import java.time.LocalDate;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.tb.common.test.FixedClock;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * The break is a duration, not a time of day (#833).
+ *
+ * <p>It used to be read with time-of-day rules, where two digits are an hour: typing {@code 30} for
+ * half an hour meant "30 o'clock", which is invalid, so the server silently stored no break at all.
+ *
+ * <p>Uses the backoffice employee and a day no other test touches, because the assertions depend on
+ * the stored working day of that day.
+ */
+@FixedClock(BreakAsDurationE2ETest.NOW)
+class BreakAsDurationE2ETest extends PlaywrightE2ETestBase {
+
+  /** Explicit because {@code @FixedClock} is not inherited from the base class. */
+  static final String NOW = "2026-08-10T14:00:00";
+
+  private static final String EMPLOYEE = E2ETestData.EMPLOYEE_BO_SIGN;
+  private static final LocalDate DAY = LocalDate.parse("2026-08-10");
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void the_break_accepts_duration_input(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, "/settings", page -> {
+
+      setBeta(page, true);
+
+      // two digits are minutes, as in every other duration field
+      assertBreakInputStores(page, "30", "00:30");
+      // and the other duration formats work too
+      assertBreakInputStores(page, "90m", "01:30");
+      assertBreakInputStores(page, "1,5", "01:30");
+      assertBreakInputStores(page, "0:45", "00:45");
+      // clearing the field means no break
+      assertBreakInputStores(page, "", "00:00");
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void the_classic_break_field_keeps_the_native_picker(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, "/settings", page -> {
+
+      setBeta(page, false);
+      page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + DAY, EMPLOYEE));
+
+      // without the beta the browser control stays, and the duration mask must not interfere with it
+      assertThat(page.locator("#breakTime")).hasAttribute("type", "time");
+      page.fill("#breakTime", "00:45");
+      page.locator("h3").first().click();
+      page.waitForTimeout(1200);
+      page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + DAY, EMPLOYEE));
+      assertThat(page.locator("#breakTime")).hasValue("00:45");
+    });
+  }
+
+  private void assertBreakInputStores(Page page, String typed, String stored) {
+    page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + DAY, EMPLOYEE));
+    page.fill("#breakTime", "");
+    if (!typed.isEmpty()) {
+      page.locator("#breakTime").click();
+      page.locator("#breakTime").pressSequentially(typed);
+    }
+    page.locator("h3").first().click();
+    page.waitForTimeout(1200);
+
+    page.navigate(urlWithLogin("/dailyreport/daily?mode=daily&date=" + DAY, EMPLOYEE));
+    assertThat(page.locator("#breakTime")).hasValue(stored);
+  }
+
+  private void setBeta(Page page, boolean enabled) {
+    page.navigate(urlWithLogin("/settings", EMPLOYEE));
+    var checkbox = page.locator("input[name='betaFeatures'][value='timeinput']");
+    if (enabled) {
+      checkbox.check();
+    } else {
+      checkbox.uncheck();
+    }
+    page.click("button[type=submit]");
+    page.waitForLoadState();
+  }
+
+}


### PR DESCRIPTION
## Der Fehler

Die Pause ist im Modell längst eine Dauer (`Workingday.breakhours` / `breakminutes`), das Eingabefeld hat sie aber als Tageszeit gelesen. Im Beta, wo das Feld ein Textfeld ist, hatte das eine stille Folge — gemessen in Chrome:

```
Feld leer, "30" getippt  →  Feld zeigt "30"
Feld verlassen           →  gespeichert wird 00:00
```

`30` ist die naheliegendste Eingabe für eine halbe Stunde Pause. Als Tageszeit gelesen sind zwei Ziffern eine **Stunde**, „30 Uhr" ist ungültig, der Parser liefert nichts und der Server fällt auf den Default `0:00` zurück — ohne Meldung.

**Das ist eine Verschlechterung aus #830.** Als `type="time"` hat der Browser ungültige Eingaben selbst abgefangen. Das Umstellen auf ein Textfeld ohne gleichzeitigen Wechsel der Semantik hat die Lücke geöffnet.

## Änderungen

- `data-time-mode="duration"` statt `"time"`, dazu `durationMask`/`durationBlur` statt der Tageszeit-Varianten und `inputmode="decimal"` samt `maxlength="8"`, damit `2h30` hineinpasst
- serverseitig neu `parseBreak` über `DurationUtils.parseFlexibleMinutes` statt `parseFlexibleTimeOfDay`
- `durationMask`/`durationBlur` lassen native Zeitfelder unangetastet (`input.type === 'time'` → return). Ohne diese Sperre hätte die Maske im klassischen Pfad in das Browser-Control geschrieben, das Zwischenwerte ablehnt
- beide Kopien des Felds in `daily.html` geändert, initiale Darstellung und OOB-Refresh

Damit gilt:

| Eingabe | gespeichert |
|---|---|
| `30` | 0:30 |
| `90m` | 1:30 |
| `1,5` | 1:30 |
| `0:45` | 0:45 |
| leer | 0:00 |

Die künstliche Obergrenze `23:59` einer Tageszeit entfällt. `breakhours`/`breakminutes` und das Übertragungsformat `HH:MM` bleiben unverändert, ebenso die Pausenvalidierung in `TimereportService`.

Start und Beginn/Ende sind bewusst **nicht** angefasst — das sind Zeitpunkte, dort ist die Tageszeit-Semantik richtig.

## Test plan

- [x] `BreakAsDurationE2ETest`, 2 Tests: die fünf Eingabeformen oben werden korrekt gespeichert; ohne Beta bleibt das native Feld erhalten und die Dauer-Maske greift nicht hinein
- [x] **Gegengeprüft:** mit zurückgenommenem Fix schlägt der Test mit `00:00` fehl, also genau mit dem gemeldeten Verhalten
- [x] Grün in Chrome und Firefox
- [x] Volle Nicht-E2E-Suite grün: 315 Tests
- [x] E2E-Suite grün bis auf den vorbestehenden `MatrixE2ETest`-Fehlschlag (#846)

## Damit ist #833 abgeschlossen

Zwei Punkte des Tickets werden nach Abstimmung **nicht** mehr angegangen und sind dort als solche vermerkt:

1. **Arbeitsbeginn in den Einstellungen** bleibt ein natives Zeitfeld und kann AM/PM zeigen. Das Feld wird einmal gesetzt, der Wert bleibt eindeutig lesbar.
2. **`lang` am `<html>`-Element** wird nicht nachgetragen. Für den Anlass ist es nicht mehr nötig, weil das Beta ohne Browser-Picker arbeitet. Es bleibt ein eigenständiger Accessibility-Punkt (WCAG 3.1.1), unabhängig von diesem Ticket.

Punkt 3 des Tickets (Auswählen statt Tippen) ist mit #830 erledigt, Punkt 2 (AM/PM bei Start und Beginn/Ende) ebenfalls.

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #833
