### PR TITLE
MatrixE2ETest: Popover-Test adressiert die eigene Buchung (#846)

### DIFF
--- a/src/test/java/org/tb/e2e/PlaywrightE2ETestBase.java
+++ b/src/test/java/org/tb/e2e/PlaywrightE2ETestBase.java
@@ -43,6 +43,18 @@ import org.tb.order.persistence.SuborderRepository;
  * ({@code local} profile, see {@link org.tb.auth.configuration.LocalDevSecurityConfiguration}).
  * Master data (customers, orders, employees, ...) is seeded once per test run via
  * {@link E2ETestData}.
+ *
+ * <p><b>Shared database state:</b> all E2E test classes run against the same H2 database, and
+ * the bookings a test creates are never cleaned up — they stay visible to every test class that
+ * runs afterwards, and a {@code @ParameterizedTest} over {@link #browsers()} creates them once
+ * per browser. Tests must therefore assert on the data they created themselves instead of on
+ * "the first row/cell" of a view (#846). Two conventions keep that manageable:
+ * <ul>
+ *   <li>address elements by something unique to the test (its suborder, its comment text)
+ *       rather than by position,</li>
+ *   <li>prefer a dedicated day or month per test class, so month-spanning views such as the
+ *       matrix overview do not mix bookings of different classes in the first place.</li>
+ * </ul>
  */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "management.health.mail.enabled=false")
 @ActiveProfiles({"unittest", "local"})

--- a/src/test/java/org/tb/e2e/dailyreport/MatrixE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/MatrixE2ETest.java
@@ -63,15 +63,22 @@ class MatrixE2ETest extends PlaywrightE2ETestBase {
           "/dailyreport/matrix?month=" + BOOKING_DATE.getMonthValue() + "&year=" + BOOKING_DATE.getYear(),
           E2ETestData.EMPLOYEE_MA_SIGN));
 
-      page.locator("#matrix tbody td:has(.matrix-cell-detail)").first().hover();
+      // address the cell this test booked itself: the E2E suite shares one database, so other
+      // test classes leave bookings of their own in the same month (see PlaywrightE2ETestBase)
+      page.locator("#matrix tbody td:has(.matrix-cell-detail)")
+          .filter(new Locator.FilterOptions().setHasText(LONG_COMMENT))
+          .first()
+          .hover();
 
       Locator popover = page.locator(".matrix-detail-popover");
       assertThat(popover).isVisible();
       assertThat(popover).containsText(LONG_COMMENT);
 
       // the description has to wrap inside the popover instead of overflowing it sideways
-      assertEquals(true, popover.locator(".popover-body > *").first()
-          .evaluate("el => el.scrollWidth <= el.clientWidth + 1"));
+      Locator longDetailLine = popover.locator(".popover-body > *")
+          .filter(new Locator.FilterOptions().setHasText(LONG_COMMENT))
+          .first();
+      assertEquals(true, longDetailLine.evaluate("el => el.scrollWidth <= el.clientWidth + 1"));
     });
   }
 


### PR DESCRIPTION
## Summary
- `MatrixE2ETest.cell_detail_popover_shows_the_complete_task_description` adressiert die Detailzelle nicht mehr über `.first()`, sondern über den langen Kommentartext, den der Test selbst gebucht hat. Damit ist er unabhängig von Buchungen anderer Testklassen im selben Monat.
- Die Umbruchprüfung aus #818 greift jetzt gezielt die Popover-Detailzeile mit dem langen Text statt der ersten Zeile — vorher hätte eine fremde (kurze) erste Zeile die Prüfung stillschweigend entwertet.
- `PlaywrightE2ETestBase` dokumentiert die Ursache (geteilte H2-Datenbank, Buchungen bleiben über Testklassen und Browser-Parameter hinweg stehen) und die Konvention: eigene Daten adressieren statt Position, möglichst eigene Zeitscheibe pro Testklasse.

Nur Testcode, keine Produktivänderung.

## Test plan
- [x] Reproduktion aus dem Issue schlägt ohne den Fix fehl (per `git stash` verifiziert) und ist mit dem Fix grün: `jenv exec ./mvnw -o test -Dtest='DailyBookingE2ETest,MatrixE2ETest' -De2e.browsers=chrome`
- [x] Vollständige E2E-Suite grün in Chrome: `jenv exec ./mvnw -o test -Dtest='org.tb.e2e.**' -De2e.browsers=chrome` (25 Tests)
- [x] Vollständige E2E-Suite grün in Firefox: `jenv exec ./mvnw -o test -Dtest='org.tb.e2e.**' -De2e.browsers=firefox` (25 Tests)
- [x] `MatrixE2ETest` einzeln grün in beiden Browsern: `jenv exec ./mvnw -o test -Dtest='MatrixE2ETest'` (6 Tests)
- [x] `jenv exec ./mvnw verify` ohne Fehler (315 Tests)

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #846