### PR TITLE
Auftraggeber-Liste case-insensitiv nach Kurzname sortieren

### DIFF
--- a/src/main/java/org/tb/customer/persistence/CustomerDAO.java
+++ b/src/main/java/org/tb/customer/persistence/CustomerDAO.java
@@ -12,10 +12,10 @@ public class CustomerDAO {
     private final CustomerRepository customerRepository;
 
     /**
-     * Get a list of visible (non-hidden) Customers ordered by name.
+     * Get a list of visible (non-hidden) Customers ordered by short name, ignoring case.
      */
     public List<Customer> getCustomers() {
-        return customerRepository.findAllVisible();
+        return customerRepository.findAllVisibleOrderByShortnameIgnoreCase();
     }
 
     /**

--- a/src/main/java/org/tb/customer/persistence/CustomerRepository.java
+++ b/src/main/java/org/tb/customer/persistence/CustomerRepository.java
@@ -12,27 +12,13 @@ public interface CustomerRepository extends PagingAndSortingRepository<Customer,
     CrudRepository<Customer, Long> {
 
   @Query("""
-      select c from Customer c where cast(c.id as string) like upper(:filter) or upper(c.name) like upper(:filter)
-      or upper(c.address) like upper(:filter) or upper(c.shortname) like upper(:filter) order by c.name asc
+      select c from Customer c order by upper(c.shortname) asc
       """)
-  List<Customer> findAllByFilterIgnoringCase(String filter);
-
-  @Query("""
-      select c from Customer c where (c.hide is null or c.hide = false) order by c.name asc
-      """)
-  List<Customer> findAllVisible();
+  List<Customer> findAllOrderByShortnameIgnoreCase();
 
   @Query("""
       select c from Customer c where (c.hide is null or c.hide = false) order by upper(c.shortname) asc
       """)
   List<Customer> findAllVisibleOrderByShortnameIgnoreCase();
-
-  @Query("""
-      select c from Customer c where (c.hide is null or c.hide = false) and (
-        cast(c.id as string) like upper(:filter) or upper(c.name) like upper(:filter)
-        or upper(c.address) like upper(:filter) or upper(c.shortname) like upper(:filter)
-      ) order by c.name asc
-      """)
-  List<Customer> findVisibleByFilterIgnoringCase(String filter);
 
 }

--- a/src/main/java/org/tb/customer/service/CustomerService.java
+++ b/src/main/java/org/tb/customer/service/CustomerService.java
@@ -13,7 +13,6 @@ import java.util.function.Predicate;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tb.auth.domain.Authorized;
@@ -26,7 +25,6 @@ import org.tb.common.exception.ServiceFeedbackMessage;
 import org.tb.common.exception.VetoedException;
 import org.tb.customer.domain.Customer;
 import org.tb.customer.domain.CustomerDTO;
-import org.tb.customer.domain.Customer_;
 import org.tb.customer.event.CustomerDeleteEvent;
 import org.tb.customer.persistence.CustomerDAO;
 import org.tb.customer.persistence.CustomerRepository;
@@ -48,10 +46,10 @@ public class CustomerService {
   @Transactional(readOnly = true)
   public List<CustomerDTO> getAllCustomerDTOsByFilter(String filter, boolean showHidden) {
     boolean hasFilter = filter != null && !filter.isBlank();
-    var repo = showHidden
-        ? stream(customerRepository.findAll(Sort.by(Customer_.NAME)).spliterator(), false)
-        : customerRepository.findAllVisible().stream();
-    return repo
+    var customers = showHidden
+        ? customerRepository.findAllOrderByShortnameIgnoreCase()
+        : customerRepository.findAllVisibleOrderByShortnameIgnoreCase();
+    return customers.stream()
         .filter(c -> !hasFilter || filterMatchesInMemory(c, filter))
         .map(CustomerDTO::from)
         .toList();

--- a/src/test/java/org/tb/customer/service/CustomerServiceTest.java
+++ b/src/test/java/org/tb/customer/service/CustomerServiceTest.java
@@ -1,0 +1,104 @@
+package org.tb.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.tb.auth.domain.AuthorizedUser;
+import org.tb.auth.persistence.AuthorizedUserAuditorAware;
+import org.tb.customer.domain.Customer;
+import org.tb.customer.domain.CustomerDTO;
+import org.tb.customer.persistence.CustomerDAO;
+import org.tb.customer.persistence.CustomerRepository;
+
+/**
+ * Die Testdaten sind so gewählt, dass eine Sortierung nach {@code name} oder eine
+ * Sortierung mit Beachtung der Groß-/Kleinschreibung eine andere Reihenfolge ergibt
+ * als die erwartete Sortierung nach Kurzname ohne Beachtung der Groß-/Kleinschreibung.
+ */
+@DataJpaTest
+@Import({
+    AuthorizedUserAuditorAware.class,
+    CustomerDAO.class,
+    CustomerService.class
+})
+@DisplayNameGeneration(ReplaceUnderscores.class)
+public class CustomerServiceTest {
+
+  @Autowired
+  private CustomerService customerService;
+
+  @Autowired
+  private CustomerRepository customerRepository;
+
+  @MockitoBean
+  private AuthorizedUser authorizedUser;
+
+  @BeforeEach
+  public void initAuthorizedUser() {
+    when(authorizedUser.isAuthenticated()).thenReturn(true);
+    when(authorizedUser.isManager()).thenReturn(true);
+    when(authorizedUser.getLoginSign()).thenReturn("test");
+  }
+
+  @Test
+  public void customers_are_sorted_by_shortname_ignoring_case() {
+    createCustomer("charlie", "Xena GmbH", false);
+    createCustomer("Beta", "Yota GmbH", false);
+    createCustomer("alpha", "Zeta GmbH", false);
+
+    assertThat(shortNames(false)).containsExactly("alpha", "Beta", "charlie");
+  }
+
+  @Test
+  public void hidden_customers_are_sorted_by_shortname_ignoring_case_as_well() {
+    createCustomer("charlie", "Xena GmbH", false);
+    createCustomer("Beta", "Yota GmbH", true);
+    createCustomer("alpha", "Zeta GmbH", false);
+
+    assertThat(shortNames(true)).containsExactly("alpha", "Beta", "charlie");
+  }
+
+  @Test
+  public void hidden_customers_are_excluded_unless_requested() {
+    createCustomer("visible", "Visible GmbH", false);
+    createCustomer("Hidden", "Hidden GmbH", true);
+
+    assertThat(shortNames(false)).containsExactly("visible");
+  }
+
+  @Test
+  public void filtered_customers_are_sorted_by_shortname_ignoring_case() {
+    createCustomer("ACME-z", "Alpha GmbH", false);
+    createCustomer("acme-a", "Zeta GmbH", false);
+    createCustomer("other", "Other GmbH", false);
+
+    var shortNames = customerService.getAllCustomerDTOsByFilter("acme", false)
+        .stream().map(CustomerDTO::getShortName).toList();
+
+    assertThat(shortNames).containsExactly("acme-a", "ACME-z");
+  }
+
+  private List<String> shortNames(boolean showHidden) {
+    return customerService.getAllCustomerDTOsByFilter(null, showHidden)
+        .stream().map(CustomerDTO::getShortName).toList();
+  }
+
+  private void createCustomer(String shortname, String name, boolean hide) {
+    Customer customer = new Customer();
+    customer.setShortname(shortname);
+    customer.setName(name);
+    customer.setAddress(name + " Street 1");
+    customer.setHide(hide);
+    customerRepository.save(customer);
+  }
+
+}

--- a/src/test/java/org/tb/e2e/E2ETestData.java
+++ b/src/test/java/org/tb/e2e/E2ETestData.java
@@ -75,7 +75,7 @@ public class E2ETestData {
       SalatUserRepository salatUserRepository,
       VacationRepository vacationRepository) {
 
-    if (customerRepository.findAllVisible().stream()
+    if (customerRepository.findAllVisibleOrderByShortnameIgnoreCase().stream()
         .anyMatch(c -> CUSTOMER_HBT_SHORTNAME.equalsIgnoreCase(c.getShortname()))) {
       return;
     }


### PR DESCRIPTION
## Summary
- `/customers` sortiert jetzt nach `upper(c.shortname)` — passend zur führenden Spalte "Kurzname" und ohne Beachtung der Groß-/Kleinschreibung; das gilt für beide Pfade (mit und ohne "Versteckte anzeigen").
- Der `showHidden`-Pfad nutzt statt `findAll(Sort.by(Customer_.NAME))` die neue JPQL-Query `findAllOrderByShortnameIgnoreCase()`, da `Sort` nicht case-insensitiv sortieren kann.
- Aufräumen: `findAllVisible()` (war identisch zu `findAllVisibleOrderByShortnameIgnoreCase()` bis auf die falsche Sortierung) sowie die beiden ungenutzten Queries `findAllByFilterIgnoringCase()` / `findVisibleByFilterIgnoringCase()` entfernt — damit existiert nur noch eine Sortierreihenfolge für Auftraggeber.
- Neuer `CustomerServiceTest` (`@DataJpaTest`) mit Testdaten, deren Reihenfolge sich bei Sortierung nach `name` bzw. case-sensitiver Sortierung unterscheidet; gegen den alten Code fallen 3 der 4 Tests.

## Test plan
- [x] `jenv exec ./mvnw verify` — 323 Tests, keine Fehler
- [x] Regressionsnachweis: mit `order by c.name asc` schlagen die neuen Tests fehl
- [x] `/customers` im Browser prüfen: Kurznamen alphabetisch, Groß-/Kleinschreibung ignoriert, auch mit "Versteckte anzeigen"

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #824