### PR TITLE
Default-Flag Fortbildung des Unterauftrags wieder auswerten (#836)

### DIFF
--- a/src/main/java/org/tb/dailyreport/controller/SuborderOption.java
+++ b/src/main/java/org/tb/dailyreport/controller/SuborderOption.java
@@ -1,3 +1,4 @@
 package org.tb.dailyreport.controller;
 
-record SuborderOption(Long id, String label, String subtext, boolean commentNecessary) {}
+record SuborderOption(Long id, String label, String subtext, boolean commentNecessary,
+                      boolean trainingFlag) {}

--- a/src/main/java/org/tb/dailyreport/controller/TimereportController.java
+++ b/src/main/java/org/tb/dailyreport/controller/TimereportController.java
@@ -101,9 +101,9 @@ public class TimereportController {
         if (comment != null && !comment.isBlank()) {
             form.setComment(comment);
         }
-        if (training != null) {
-            form.setTraining(training);
-        }
+        // #836: a suborder can carry a default flag for project based training. The explicit request
+        // parameter comes from the share-with-colleagues deeplink and has to win over that default.
+        form.setTraining(training != null ? training : trainingDefaultOf(suborders, defaultSuborderId));
 
         populateModel(employeeContractId, model, form, suborders, ecId, effectiveDate, false, returnUrl);
         return "dailyreport/timereport-form";
@@ -515,9 +515,21 @@ public class TimereportController {
                         : s.completeOrderSign();
                     var subtext = order.getSign() + " · " + order.getShortdescription()
                         + " · " + order.getCustomer().getShortname();
-                    return new SuborderOption(s.id(), label, subtext, s.commentNecessary());
+                    return new SuborderOption(s.id(), label, subtext, s.commentNecessary(), s.trainingFlag());
                 }))
             .toList();
+    }
+
+    /** Default state of the training switch for a suborder; false when nothing is preselected. */
+    static boolean trainingDefaultOf(List<SuborderOption> suborders, Long suborderId) {
+        if (suborderId == null) {
+            return false;
+        }
+        return suborders.stream()
+            .filter(s -> suborderId.equals(s.id()))
+            .findFirst()
+            .map(SuborderOption::trainingFlag)
+            .orElse(false);
     }
 
     private long effectiveContractId(Long employeeContractId) {

--- a/src/main/java/org/tb/order/service/SuborderService.java
+++ b/src/main/java/org/tb/order/service/SuborderService.java
@@ -59,7 +59,8 @@ public class SuborderService {
             s.getId(),
             s.getCompleteOrderSign(),
             s.getShortdescription(),
-            Boolean.TRUE.equals(s.getCommentnecessary())))
+            Boolean.TRUE.equals(s.getCommentnecessary()),
+            Boolean.TRUE.equals(s.getTrainingFlag())))
         .toList();
   }
 

--- a/src/main/java/org/tb/order/service/SuborderSummary.java
+++ b/src/main/java/org/tb/order/service/SuborderSummary.java
@@ -1,4 +1,5 @@
 package org.tb.order.service;
 
 public record SuborderSummary(Long id, String completeOrderSign,
-                               String shortdescription, boolean commentNecessary) {}
+                               String shortdescription, boolean commentNecessary,
+                               boolean trainingFlag) {}

--- a/src/main/resources/templates/dailyreport/timereport-form.html
+++ b/src/main/resources/templates/dailyreport/timereport-form.html
@@ -147,7 +147,7 @@
                 <option th:each="s : ${suborders}"
                         th:value="${s.id}"
                         th:text="${s.label}"
-                        th:attr="data-subtext=${s.subtext},data-cnr=${s.commentNecessary}"
+                        th:attr="data-subtext=${s.subtext},data-cnr=${s.commentNecessary},data-training=${s.trainingFlag}"
                         th:selected="${timereportForm.suborderId != null and timereportForm.suborderId == s.id}"></option>
               </select>
               <small id="suborderId-subtext" class="form-text text-muted mt-1"></small>
@@ -166,7 +166,9 @@
             <!-- Training -->
             <div class="mb-3">
               <label class="form-check form-switch">
-                <input class="form-check-input" type="checkbox" th:field="*{training}"/>
+                <!-- explicit id: Thymeleaf numbers the generated ids of checkboxes (training1, ...),
+                     but applySuborderTrainingDefault() needs a stable one -->
+                <input class="form-check-input" type="checkbox" id="trainingSwitch" th:field="*{training}"/>
                 <span class="form-check-label" th:text="#{main.timereport.form.training.label}">Fortbildung</span>
               </label>
             </div>
@@ -348,14 +350,31 @@
         ta.removeAttribute('required');
       }
     }
+    // #836: a suborder can carry a default flag for project based training. Picking such a
+    // suborder switches "Fortbildung" on - and only ever on, never off again, so that neither a
+    // manual choice nor the stored value of an edited booking is silently discarded. Called from
+    // the change event only: the state the server rendered is authoritative for the first paint.
+    function applySuborderTrainingDefault() {
+      var sel = document.getElementById('suborderId');
+      var box = document.getElementById('trainingSwitch');
+      if (!sel || !box) return;
+      var opt = sel.options[sel.selectedIndex];
+      if (opt && opt.dataset.training === 'true') box.checked = true;
+    }
     document.addEventListener('DOMContentLoaded', function() {
       var sel = document.getElementById('suborderId');
-      if (sel) sel.addEventListener('change', updateCommentRequired);
+      if (sel) {
+        sel.addEventListener('change', updateCommentRequired);
+        sel.addEventListener('change', applySuborderTrainingDefault);
+      }
       updateCommentRequired();
     });
     document.addEventListener('htmx:afterSettle', function() {
       var sel = document.getElementById('suborderId');
-      if (sel) sel.addEventListener('change', updateCommentRequired);
+      if (sel) {
+        sel.addEventListener('change', updateCommentRequired);
+        sel.addEventListener('change', applySuborderTrainingDefault);
+      }
       updateCommentRequired();
     });
     function updateDurationBadge() {

--- a/src/test/java/org/tb/dailyreport/controller/TimereportControllerTest.java
+++ b/src/test/java/org/tb/dailyreport/controller/TimereportControllerTest.java
@@ -1,0 +1,40 @@
+package org.tb.dailyreport.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.tb.dailyreport.controller.TimereportController.trainingDefaultOf;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The default state of the training switch derived from the preselected suborder (#836).
+ */
+class TimereportControllerTest {
+
+  private static final SuborderOption TRAINING =
+      new SuborderOption(1L, "FORTBILDUNG", "HBT", false, true);
+  private static final SuborderOption PROJECT =
+      new SuborderOption(2L, "ALPHA-DEV", "Contoso", false, false);
+
+  @Test
+  void suborder_with_the_training_flag_preselects_the_switch() {
+    assertThat(trainingDefaultOf(List.of(PROJECT, TRAINING), 1L)).isTrue();
+  }
+
+  @Test
+  void suborder_without_the_training_flag_leaves_the_switch_off() {
+    assertThat(trainingDefaultOf(List.of(PROJECT, TRAINING), 2L)).isFalse();
+  }
+
+  @Test
+  void nothing_preselected_leaves_the_switch_off() {
+    assertThat(trainingDefaultOf(List.of(PROJECT, TRAINING), null)).isFalse();
+  }
+
+  @Test
+  void a_suborder_outside_the_offered_options_leaves_the_switch_off() {
+    // the deeplink parameter suborderId is not validated against the employee's orders here
+    assertThat(trainingDefaultOf(List.of(PROJECT, TRAINING), 99L)).isFalse();
+  }
+
+}

--- a/src/test/java/org/tb/e2e/dailyreport/SuborderTrainingDefaultE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/SuborderTrainingDefaultE2ETest.java
@@ -1,0 +1,81 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.tb.common.GlobalConstants.SUBRORDER_SIGN_TRAINING;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * A suborder can carry a default flag for project based training ({@code Suborder.trainingFlag}).
+ * Choosing such a suborder in the booking form must switch "Fortbildung" on - the evaluation was
+ * lost with the Struts module and is back in the Thymeleaf flow (#836).
+ */
+class SuborderTrainingDefaultE2ETest extends PlaywrightE2ETestBase {
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void choosing_a_suborder_with_the_training_flag_switches_fortbildung_on(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN, newBookingPath(), page -> {
+      // start from a suborder without the flag, so the switch is off no matter which suborder
+      // the form would preselect on its own
+      openBookingFormFor(page, suborderIdOf(page, E2ETestData.SUBORDER_ALPHA_DEV_SIGN));
+      assertThat(trainingSwitch(page)).not().isChecked();
+
+      selectTomSelectOption(page, "suborderId", SUBRORDER_SIGN_TRAINING);
+
+      assertThat(trainingSwitch(page)).isChecked();
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void a_preselected_suborder_with_the_training_flag_renders_the_switch_on(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN, newBookingPath(), page -> {
+      openBookingFormFor(page, suborderIdOf(page, SUBRORDER_SIGN_TRAINING));
+
+      assertThat(trainingSwitch(page)).isChecked();
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void an_explicit_training_parameter_wins_over_the_suborder_default(E2EBrowser browser) {
+    runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN, newBookingPath(), page -> {
+      // the share-with-colleagues deeplink carries the training state of the shared booking and
+      // must not be overruled by the default flag of its suborder
+      String trainingSuborderId = suborderIdOf(page, SUBRORDER_SIGN_TRAINING);
+      page.navigate(urlWithLogin(newBookingPath() + "?suborderId=" + trainingSuborderId
+          + "&training=false", E2ETestData.EMPLOYEE_MA_SIGN));
+
+      assertThat(trainingSwitch(page)).not().isChecked();
+    });
+  }
+
+  private String newBookingPath() {
+    return "/dailyreport/timereports/new";
+  }
+
+  private Locator trainingSwitch(Page page) {
+    return page.locator("#trainingSwitch");
+  }
+
+  /** Reads the option value of a suborder from the rendered dropdown, keyed by its sign. */
+  private String suborderIdOf(Page page, String sign) {
+    Object value = page.evaluate(
+        "sign => Array.from(document.querySelectorAll('#suborderId option'))"
+            + ".find(o => o.textContent.includes(sign)).value", sign);
+    return String.valueOf(value);
+  }
+
+  private void openBookingFormFor(Page page, String suborderId) {
+    page.navigate(urlWithLogin(newBookingPath() + "?suborderId=" + suborderId,
+        E2ETestData.EMPLOYEE_MA_SIGN));
+  }
+
+}


### PR DESCRIPTION
## Summary

`Suborder.trainingFlag` ("Default-Flag Fortbildung") war seit dem Entfernen des Struts-Moduls (`9022c6de`) reines Write-only-Datum: Manager konnten das Flag setzen und bekamen ein Badge, das Buchungsformular hat es nicht mehr gelesen. Damit wurden projektbezogene Fortbildungszeiten nur noch als solche gebucht, wenn der Mitarbeiter den Schalter selbst gesetzt hat — die Fortbildungsauswertung auf `Timereport.training` war entsprechend unvollständig.

Das Flag erreicht jetzt wieder die View und schaltet "Fortbildung" ein:

- `SuborderSummary` und `SuborderOption` transportieren `trainingFlag`, `TimereportController.suborderOptions()` reicht es durch
- `timereport-form.html` gibt es als `data-training` am `<option>` aus; der Change-Handler des Unterauftrags-Selects schaltet den Schalter darauf ein
- `createForm()` leitet den Initialwert aus dem vorbelegten Unterauftrag ab, damit schon der erste Render stimmt. Der explizite `training`-Request-Parameter (Teilen-Deeplink) hat weiterhin Vorrang
- im Bearbeiten-Modus bleibt der gespeicherte Wert maßgeblich

Der Schalter wird bewusst nur ein-, nie ausgeschaltet — das entspricht der früheren Struts-Logik und verhindert, dass ein Wechsel des Unterauftrags eine manuelle Entscheidung oder den gespeicherten Wert einer bearbeiteten Buchung stillschweigend verwirft.

Der Training-Schalter hat eine explizite `id` bekommen: Thymeleaf nummeriert die generierten Ids von Checkboxen (`training1`, …), der Handler braucht eine stabile.

Kein Schema-Change (die Spalte stammt aus der Zeit vor dem Changelog), keine neuen i18n-Keys.

## Test plan

- [x] `jenv exec ./mvnw verify` — 331 Tests, grün
- [x] `jenv exec ./mvnw test -Pe2e -De2e.browsers=chrome` — neue `SuborderTrainingDefaultE2ETest` grün
- [x] `TimereportControllerTest` deckt die serverseitige Ableitung des Initialwerts ab (Flag gesetzt / nicht gesetzt / keine Vorauswahl / unbekannte Id)
- [x] `SuborderTrainingDefaultE2ETest` deckt end-to-end ab: Auswahl eines Unterauftrags mit Flag schaltet den Schalter ein, ein vorbelegter Unterauftrag mit Flag rendert ihn bereits eingeschaltet, `training=false` aus dem Deeplink gewinnt

Anmerkung: `DailyProgressUnitE2ETest.the_progress_line_looks_the_same_after_an_out_of_band_refresh` schlägt fehl, wenn die E2E-Suite lokal über **beide** Browser läuft — die zweite Browser-Runde sieht die Buchung der ersten in der geteilten H2-Datenbank (#846). Das ist auf `main` identisch reproduzierbar und unabhängig von diesem Branch; die CI-Matrix läuft je Leg mit einem Browser und ist davon nicht betroffen.

## Nicht in diesem PR

`DailyController.applyFavourite` bucht Favoriten fest mit `training=false` — ein Favorit auf einem Fortbildungs-Unterauftrag landet also weiterhin als normale Zeit. Das ist ein eigener Einstiegspunkt neben dem Buchungsformular und damit außerhalb des Tickets; sinnvoll als Folge-Issue.

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #836