### PR TITLE
Kein Tagessoll an Wochenenden und Feiertagen (#857)

### DIFF
--- a/src/main/java/org/tb/dailyreport/domain/DailyViewData.java
+++ b/src/main/java/org/tb/dailyreport/domain/DailyViewData.java
@@ -11,7 +11,11 @@ public record DailyViewData(
     Workingday workingday,
     String quittingTime,
     String targetEndTime,
+    // the contract does target accounting at all, i.e. it has a daily working time
     boolean hasTarget,
+    // this particular day has a target - false on weekends, public holidays and outside the
+    // validity of the contract (#857)
+    boolean hasDayTarget,
     boolean overMaxHours,
     int progressPercent,
     List<WeekStripDay> weekStrip,

--- a/src/main/java/org/tb/dailyreport/service/DailyService.java
+++ b/src/main/java/org/tb/dailyreport/service/DailyService.java
@@ -62,8 +62,9 @@ public class DailyService {
         Duration totalBooked = timereports.stream().map(TimereportDTO::getDuration).reduce(Duration.ZERO, Duration::plus);
         Workingday workingday = workingdayService.getWorkingday(employeeContractId, date);
 
-        // without a target there is no point in time the day is done at
-        String quittingTime = hasDayTarget ? workingdayService.calculateQuittingTime(employeeContractId, date) : null;
+        // the quitting time follows from what has been booked, not from a target - it is useful on a
+        // day without one too, so it stays (#857)
+        String quittingTime = workingdayService.calculateQuittingTime(employeeContractId, date);
         String targetEndTime = hasDayTarget ? workingdayService.calculateWorkingDayEnds(employeeContractId, date) : null;
         boolean overMaxHours = workingdayService.checkLaborTimeMaximum(timereports);
 

--- a/src/main/java/org/tb/dailyreport/service/DailyService.java
+++ b/src/main/java/org/tb/dailyreport/service/DailyService.java
@@ -51,15 +51,23 @@ public class DailyService {
         var contract = employeecontractService.getEmployeecontractById(employeeContractId);
         boolean hasTarget = !contract.getDailyWorkingTime().isZero();
 
+        // #857: the target of a single day is not simply the contract's daily working time -
+        // weekends, public holidays falling on a weekday and days outside the contract's validity
+        // carry no target at all. This is the same calculation the month sum in buildListView
+        // uses, called for a single day.
+        Duration dayTarget = overtimeService.calculateWorkingTimeTarget(employeeContractId, date, date);
+        boolean hasDayTarget = !dayTarget.isZero();
+
         List<TimereportDTO> timereports = timereportService.getTimereportsByDateAndEmployeeContractId(employeeContractId, date);
         Duration totalBooked = timereports.stream().map(TimereportDTO::getDuration).reduce(Duration.ZERO, Duration::plus);
         Workingday workingday = workingdayService.getWorkingday(employeeContractId, date);
 
-        String quittingTime = workingdayService.calculateQuittingTime(employeeContractId, date);
-        String targetEndTime = hasTarget ? workingdayService.calculateWorkingDayEnds(employeeContractId, date) : null;
+        // without a target there is no point in time the day is done at
+        String quittingTime = hasDayTarget ? workingdayService.calculateQuittingTime(employeeContractId, date) : null;
+        String targetEndTime = hasDayTarget ? workingdayService.calculateWorkingDayEnds(employeeContractId, date) : null;
         boolean overMaxHours = workingdayService.checkLaborTimeMaximum(timereports);
 
-        long targetMinutes = hasTarget ? contract.getDailyWorkingTime().toMinutes() : 0;
+        long targetMinutes = dayTarget.toMinutes();
         int progressPercent = targetMinutes > 0 ? (int) Math.min(100, totalBooked.toMinutes() * 100 / targetMinutes) : 0;
 
         List<WeekStripDay> weekStrip = buildWeekStrip(date, employeeContractId);
@@ -70,8 +78,8 @@ public class DailyService {
         String breakTime = workingday != null
             ? String.format("%02d:%02d", workingday.getBreakhours(), workingday.getBreakminutes())
             : "00:00";
-        String dailyWorkingTimeFormatted = hasTarget
-            ? DurationUtils.format(contract.getDailyWorkingTime())
+        String dailyWorkingTimeFormatted = hasDayTarget
+            ? DurationUtils.format(dayTarget)
             : null;
 
         boolean isOwner = contract.getEmployee().getSalatUser().getLoginname().equals(authorizedUser.getEffectiveLoginSign());
@@ -87,7 +95,7 @@ public class DailyService {
         boolean canCreate = (!monthReleased && isOwner) || authorizedUser.isManager();
 
         return new DailyViewData(timereports, totalBooked, workingday, quittingTime, targetEndTime,
-            hasTarget, overMaxHours, progressPercent, weekStrip,
+            hasTarget, hasDayTarget, overMaxHours, progressPercent, weekStrip,
             notWorked, startTime, breakTime, dailyWorkingTimeFormatted,
             editableIds, workingdayEditable, canCreate);
     }

--- a/src/main/resources/templates/dailyreport/daily.html
+++ b/src/main/resources/templates/dailyreport/daily.html
@@ -220,7 +220,7 @@
                 </span>
                 <!-- no longer bound to a stored working day: the quitting time is computed from the
                      effective start, so it is there before the first booking too (#831) -->
-                <span class="text-muted small" th:if="${dailyData.hasDayTarget}">
+                <span class="text-muted small">
                   <span th:text="#{main.daily.quitting.label}">Feierabend ~</span>
                   <strong th:text="${dailyData.quittingTime}"></strong>
                 </span>

--- a/src/main/resources/templates/dailyreport/daily.html
+++ b/src/main/resources/templates/dailyreport/daily.html
@@ -210,19 +210,22 @@
                        especially next to the quitting time in the same h:mm format (#831) -->
                   <strong th:text="${@durationUtils.format(dailyData.totalBooked)}"></strong>
                   <span th:text="#{main.daily.duration.unit}">h</span>
-                  <span th:text="#{main.daily.of.label}">von</span>
-                  <strong th:text="${dailyData.dailyWorkingTimeFormatted ?: '—'}"></strong>
-                  <span th:if="${dailyData.dailyWorkingTimeFormatted != null}"
-                        th:text="#{main.daily.duration.unit}">h</span>
+                  <!-- the booked value stays visible on a day without a target - whoever works on a
+                       Saturday wants to see what they booked. Only the target itself goes (#857). -->
+                  <th:block th:if="${dailyData.hasDayTarget}">
+                    <span th:text="#{main.daily.of.label}">von</span>
+                    <strong th:text="${dailyData.dailyWorkingTimeFormatted}"></strong>
+                    <span th:text="#{main.daily.duration.unit}">h</span>
+                  </th:block>
                 </span>
                 <!-- no longer bound to a stored working day: the quitting time is computed from the
                      effective start, so it is there before the first booking too (#831) -->
-                <span class="text-muted small">
+                <span class="text-muted small" th:if="${dailyData.hasDayTarget}">
                   <span th:text="#{main.daily.quitting.label}">Feierabend ~</span>
                   <strong th:text="${dailyData.quittingTime}"></strong>
                 </span>
               </div>
-              <div class="progress" style="height: 8px" th:if="${dailyData.progressPercent > 0 or dailyData.hasTarget}">
+              <div class="progress" style="height: 8px" th:if="${dailyData.hasDayTarget}">
                 <div class="progress-bar"
                      th:classappend="${dailyData.overMaxHours} ? 'bg-danger' : 'bg-primary'"
                      role="progressbar"

--- a/src/main/resources/templates/dailyreport/daily.html
+++ b/src/main/resources/templates/dailyreport/daily.html
@@ -225,8 +225,12 @@
                   <strong th:text="${dailyData.quittingTime}"></strong>
                 </span>
               </div>
-              <div class="progress" style="height: 8px" th:if="${dailyData.hasDayTarget}">
-                <div class="progress-bar"
+              <!-- On a day without a target the empty track stays as a hint: it keeps the block at
+                   the same height as on a working day, and without a target there is nothing the
+                   bar could be filled against (#857). -->
+              <div class="progress" style="height: 8px"
+                   th:classappend="${dailyData.hasDayTarget} ? '' : 'opacity-50'">
+                <div class="progress-bar" th:if="${dailyData.hasDayTarget}"
                      th:classappend="${dailyData.overMaxHours} ? 'bg-danger' : 'bg-primary'"
                      role="progressbar"
                      th:style="'width:' + ${dailyData.progressPercent} + '%'">

--- a/src/test/java/org/tb/dailyreport/service/OvertimeServiceWorkingTimeTargetTest.java
+++ b/src/test/java/org/tb/dailyreport/service/OvertimeServiceWorkingTimeTargetTest.java
@@ -1,0 +1,135 @@
+package org.tb.dailyreport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tb.dailyreport.domain.Publicholiday;
+import org.tb.dailyreport.persistence.PublicholidayDAO;
+import org.tb.dailyreport.persistence.TimereportDAO;
+import org.tb.employee.domain.Employeecontract;
+import org.tb.employee.persistence.EmployeecontractDAO;
+import org.tb.employee.service.EmployeecontractService;
+import org.tb.order.service.EmployeeorderService;
+
+/**
+ * The working time target of a <em>single</em> day. The daily view derives its target from this
+ * calculation instead of reading the contract's daily working time directly, so that weekends,
+ * public holidays and days outside the contract carry no target (#857).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OvertimeServiceWorkingTimeTargetTest {
+
+  private static final long EMPLOYEE_CONTRACT_ID = 1L;
+  private static final Duration DAILY_WORKING_TIME = Duration.ofHours(8);
+  private static final LocalDate CONTRACT_VALID_FROM = LocalDate.parse("2020-01-01");
+
+  private static final LocalDate MONDAY = LocalDate.parse("2026-07-13");
+  private static final LocalDate SATURDAY = LocalDate.parse("2026-07-18");
+  private static final LocalDate SUNDAY = LocalDate.parse("2026-07-19");
+
+  @InjectMocks
+  private OvertimeService overtimeService;
+
+  @Mock
+  private EmployeecontractDAO employeecontractDAO;
+  @Mock
+  private PublicholidayDAO publicholidayDAO;
+  @Mock
+  private TimereportDAO timereportDAO;
+  @Mock
+  private EmployeecontractService employeecontractService;
+  @Mock
+  private TimereportService timereportService;
+  @Mock
+  private EmployeeorderService employeeorderService;
+
+  @Test
+  void a_normal_weekday_carries_the_contract_daily_working_time() {
+    givenContract(null);
+    givenNoHolidays();
+
+    assertThat(targetOf(MONDAY)).isEqualTo(DAILY_WORKING_TIME);
+  }
+
+  @Test
+  void a_saturday_carries_no_target() {
+    givenContract(null);
+    givenNoHolidays();
+
+    assertThat(targetOf(SATURDAY)).isZero();
+  }
+
+  @Test
+  void a_sunday_carries_no_target() {
+    givenContract(null);
+    givenNoHolidays();
+
+    assertThat(targetOf(SUNDAY)).isZero();
+  }
+
+  @Test
+  void a_public_holiday_on_a_weekday_carries_no_target() {
+    givenContract(null);
+    givenHoliday(MONDAY, "Testfeiertag");
+
+    assertThat(targetOf(MONDAY)).isZero();
+  }
+
+  @Test
+  void a_public_holiday_on_a_weekend_is_not_subtracted_twice() {
+    givenContract(null);
+    givenHoliday(SATURDAY, "Testfeiertag");
+
+    // the weekend already brings the target to zero; subtracting the holiday on top would make it
+    // negative and hand out an hour of overtime for doing nothing
+    assertThat(targetOf(SATURDAY)).isZero();
+  }
+
+  @Test
+  void a_weekday_before_the_contract_starts_carries_no_target() {
+    givenContract(null);
+
+    assertThat(targetOf(CONTRACT_VALID_FROM.minusDays(7))).isZero();
+  }
+
+  @Test
+  void a_weekday_after_the_contract_ended_carries_no_target() {
+    givenContract(MONDAY.minusDays(7));
+
+    assertThat(targetOf(MONDAY)).isZero();
+  }
+
+  private Duration targetOf(LocalDate day) {
+    return overtimeService.calculateWorkingTimeTarget(EMPLOYEE_CONTRACT_ID, day, day);
+  }
+
+  private void givenContract(LocalDate validUntil) {
+    Employeecontract contract = new Employeecontract();
+    contract.setValidFrom(CONTRACT_VALID_FROM);
+    contract.setValidUntil(validUntil);
+    contract.setDailyWorkingTime(DAILY_WORKING_TIME);
+    when(employeecontractDAO.getEmployeecontractById(EMPLOYEE_CONTRACT_ID)).thenReturn(contract);
+  }
+
+  private void givenNoHolidays() {
+    when(publicholidayDAO.getPublicHolidaysBetween(any(), any())).thenReturn(List.of());
+  }
+
+  private void givenHoliday(LocalDate date, String name) {
+    when(publicholidayDAO.getPublicHolidaysBetween(any(), any()))
+        .thenReturn(List.of(new Publicholiday(date, name)));
+  }
+
+}

--- a/src/test/java/org/tb/e2e/E2ETestData.java
+++ b/src/test/java/org/tb/e2e/E2ETestData.java
@@ -10,6 +10,8 @@ import org.tb.common.GlobalConstants;
 import org.tb.common.util.ClockProvider;
 import org.tb.customer.domain.Customer;
 import org.tb.customer.persistence.CustomerRepository;
+import org.tb.dailyreport.domain.Publicholiday;
+import org.tb.dailyreport.persistence.PublicholidayRepository;
 import org.tb.employee.domain.Employee;
 import org.tb.employee.domain.Employeecontract;
 import org.tb.employee.domain.Vacation;
@@ -26,7 +28,8 @@ import org.tb.order.persistence.SuborderRepository;
 
 /**
  * Seeds a fixed, realistic set of master/reference data for the dailyreport E2E suite:
- * Customer, Customerorder, Suborder, Employee, Employeecontract and Employeeorder.
+ * Customer, Customerorder, Suborder, Employee, Employeecontract, Employeeorder and a pair of
+ * public holidays.
  *
  * <p>The three "standard" suborders (Urlaub, Krankheit, Fortbildung) are deliberately left
  * without an Employeeorder here: they are marked {@code standard=true} so that logging in as
@@ -55,6 +58,14 @@ public class E2ETestData {
   public static final String SUBORDER_INITECH_SUPPORT_SIGN = "INITECH-SUPPORT";
   public static final String SUBORDER_INITECH_MIGRATION_SIGN = "INITECH-MIGRATION";
 
+  /**
+   * Public holidays for the daily view's target calculation (#857). Deliberately in October 2026,
+   * a month no other E2E class looks at - a holiday changes the working time target of its whole
+   * month, and the E2E database is shared.
+   */
+  public static final LocalDate HOLIDAY_ON_WEEKDAY = LocalDate.of(2026, 10, 5);
+  public static final LocalDate HOLIDAY_ON_WEEKEND = LocalDate.of(2026, 10, 10);
+
   private static final LocalDate PAST = LocalDate.of(2020, 1, 1);
 
   /**
@@ -73,12 +84,16 @@ public class E2ETestData {
       EmployeecontractRepository employeecontractRepository,
       EmployeeorderRepository employeeorderRepository,
       SalatUserRepository salatUserRepository,
-      VacationRepository vacationRepository) {
+      VacationRepository vacationRepository,
+      PublicholidayRepository publicholidayRepository) {
 
     if (customerRepository.findAllVisibleOrderByShortnameIgnoreCase().stream()
         .anyMatch(c -> CUSTOMER_HBT_SHORTNAME.equalsIgnoreCase(c.getShortname()))) {
       return;
     }
+
+    publicholidayRepository.save(new Publicholiday(HOLIDAY_ON_WEEKDAY, "E2E-Feiertag am Werktag"));
+    publicholidayRepository.save(new Publicholiday(HOLIDAY_ON_WEEKEND, "E2E-Feiertag am Wochenende"));
 
     Customer hbt = customer(customerRepository, "HBT GmbH", CUSTOMER_HBT_SHORTNAME);
 

--- a/src/test/java/org/tb/e2e/PlaywrightE2ETestBase.java
+++ b/src/test/java/org/tb/e2e/PlaywrightE2ETestBase.java
@@ -28,6 +28,7 @@ import org.tb.auth.persistence.SalatUserRepository;
 import org.tb.common.test.FixedClock;
 import org.tb.common.util.ClockProvider;
 import org.tb.customer.persistence.CustomerRepository;
+import org.tb.dailyreport.persistence.PublicholidayRepository;
 import org.tb.employee.persistence.EmployeeRepository;
 import org.tb.employee.persistence.EmployeecontractRepository;
 import org.tb.employee.persistence.VacationRepository;
@@ -100,6 +101,8 @@ public abstract class PlaywrightE2ETestBase {
   private SalatUserRepository salatUserRepository;
   @Autowired
   private VacationRepository vacationRepository;
+  @Autowired
+  private PublicholidayRepository publicholidayRepository;
 
   // no SMTP server is available in the E2E environment; release/acceptance/sharing flows send
   // mail as a side effect, so the sender is stubbed out rather than left to fail with a raw
@@ -119,7 +122,7 @@ public abstract class PlaywrightE2ETestBase {
     ClockProvider.useFixedClock(LocalDateTime.parse(FIXED_NOW));
     E2ETestData.seedIfNeeded(customerRepository, customerorderRepository, suborderRepository,
         employeeRepository, employeecontractRepository, employeeorderRepository, salatUserRepository,
-        vacationRepository);
+        vacationRepository, publicholidayRepository);
   }
 
   @AfterAll

--- a/src/test/java/org/tb/e2e/dailyreport/DailyTargetOnNonWorkingDaysE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/DailyTargetOnNonWorkingDaysE2ETest.java
@@ -14,8 +14,9 @@ import org.tb.e2e.PlaywrightE2ETestBase;
 
 /**
  * The daily view used to show the contract's daily working time as the target of every day, so a
- * Saturday claimed a target of 8 hours, a progress bar that can never fill and a quitting time
- * that does not exist (#857). On a day without a target only the booked value remains.
+ * Saturday claimed a target of 8 hours and a progress bar that can never fill (#857). On a day
+ * without a target the booked value and the quitting time remain - both follow from what has been
+ * booked rather than from a target.
  */
 @FixedClock(DailyTargetOnNonWorkingDaysE2ETest.NOW)
 class DailyTargetOnNonWorkingDaysE2ETest extends PlaywrightE2ETestBase {
@@ -31,7 +32,7 @@ class DailyTargetOnNonWorkingDaysE2ETest extends PlaywrightE2ETestBase {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
-  void a_saturday_has_no_target_no_bar_and_no_quitting_time(E2EBrowser browser) {
+  void a_saturday_has_no_target_and_no_progress_bar(E2EBrowser browser) {
     runAsUser(browser, EMPLOYEE, dailyView(SATURDAY), page -> assertNoTargetShown(page));
   }
 
@@ -84,13 +85,13 @@ class DailyTargetOnNonWorkingDaysE2ETest extends PlaywrightE2ETestBase {
     });
   }
 
-  /** The booked value stays - only the target, the bar and the quitting time are gone. */
+  /** The booked value and the quitting time stay - only the target and its bar are gone. */
   private void assertNoTargetShown(Page page) {
     var progress = progress(page);
     assertThat(progress).isVisible();
     assertThat(progress).containsText("Gebucht");
     assertThat(progress).not().containsText("von");
-    assertThat(progress).not().containsText("Feierabend");
+    assertThat(progress).containsText("Feierabend");
     assertThat(progress.locator(".progress-bar")).hasCount(0);
   }
 

--- a/src/test/java/org/tb/e2e/dailyreport/DailyTargetOnNonWorkingDaysE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/DailyTargetOnNonWorkingDaysE2ETest.java
@@ -1,0 +1,119 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import java.time.LocalDate;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.tb.common.test.FixedClock;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * The daily view used to show the contract's daily working time as the target of every day, so a
+ * Saturday claimed a target of 8 hours, a progress bar that can never fill and a quitting time
+ * that does not exist (#857). On a day without a target only the booked value remains.
+ */
+@FixedClock(DailyTargetOnNonWorkingDaysE2ETest.NOW)
+class DailyTargetOnNonWorkingDaysE2ETest extends PlaywrightE2ETestBase {
+
+  /** Explicit because {@code @FixedClock} is not inherited from the base class. */
+  static final String NOW = "2026-10-20T14:00:00";
+
+  private static final String EMPLOYEE = E2ETestData.EMPLOYEE_MA_SIGN;
+  /** October 2026 is the month the seeded public holidays live in, see E2ETestData. */
+  private static final LocalDate SATURDAY = LocalDate.parse("2026-10-17");
+  private static final LocalDate WEEKDAY = LocalDate.parse("2026-10-06");
+  private static final String COMMENT = "E2E-Wochenendarbeit";
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void a_saturday_has_no_target_no_bar_and_no_quitting_time(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, dailyView(SATURDAY), page -> assertNoTargetShown(page));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void a_public_holiday_on_a_weekday_has_no_target_either(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, dailyView(E2ETestData.HOLIDAY_ON_WEEKDAY),
+        page -> assertNoTargetShown(page));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void a_public_holiday_on_a_weekend_behaves_like_a_weekend(E2EBrowser browser) {
+    // the holiday must not be subtracted a second time on a day that has no target anyway
+    runAsUser(browser, EMPLOYEE, dailyView(E2ETestData.HOLIDAY_ON_WEEKEND),
+        page -> assertNoTargetShown(page));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void a_normal_weekday_still_shows_target_bar_and_quitting_time(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, dailyView(WEEKDAY), page -> {
+      var progress = progress(page);
+      assertThat(progress).containsText("8:00 h");
+      assertThat(progress).containsText("Feierabend");
+      assertThat(progress.locator(".progress-bar")).hasCount(1);
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void a_booking_on_a_saturday_stays_visible_after_an_out_of_band_refresh(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, "/dailyreport/timereports/new?date=" + SATURDAY, page -> {
+      page.fill("#durationTime", "02:00");
+      selectTomSelectOption(page, "suborderId", E2ETestData.SUBORDER_ALPHA_DEV_SIGN);
+      page.fill("#commentField", COMMENT);
+      page.click("#timereportMainForm button[type=submit]");
+      page.waitForLoadState();
+
+      page.navigate(urlWithLogin(dailyView(SATURDAY), EMPLOYEE));
+      assertThat(progress(page)).containsText("2:00 h");
+      assertNoTargetShown(page);
+
+      // the inline duration edit answers with an out-of-band refresh of the progress block, which
+      // must arrive without target, bar and quitting time just like the initial render
+      editDurationInline(page, "03:00");
+
+      assertThat(progress(page)).containsText("3:00 h");
+      assertNoTargetShown(page);
+    });
+  }
+
+  /** The booked value stays - only the target, the bar and the quitting time are gone. */
+  private void assertNoTargetShown(Page page) {
+    var progress = progress(page);
+    assertThat(progress).isVisible();
+    assertThat(progress).containsText("Gebucht");
+    assertThat(progress).not().containsText("von");
+    assertThat(progress).not().containsText("Feierabend");
+    assertThat(progress.locator(".progress-bar")).hasCount(0);
+  }
+
+  private Locator progress(Page page) {
+    return page.locator("#daily-progress");
+  }
+
+  private String dailyView(LocalDate date) {
+    return "/dailyreport/daily?mode=daily&date=" + date;
+  }
+
+  /** The row of the booking this test created - the E2E database is shared (#846). */
+  private void editDurationInline(Page page, String value) {
+    Locator row = page.locator("#daily-bookings-area tr")
+        .filter(new Locator.FilterOptions().setHasText(COMMENT))
+        .first();
+    row.locator("span.inline-edit-display").click();
+    Locator input = row.locator("input[name=duration]");
+    input.fill(value);
+    // Enter blurs the field, which is what triggers the hx-post
+    input.press("Enter");
+    page.waitForLoadState();
+    page.waitForTimeout(1500);
+  }
+
+}

--- a/src/test/java/org/tb/e2e/dailyreport/DailyTargetOnNonWorkingDaysE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/DailyTargetOnNonWorkingDaysE2ETest.java
@@ -85,13 +85,17 @@ class DailyTargetOnNonWorkingDaysE2ETest extends PlaywrightE2ETestBase {
     });
   }
 
-  /** The booked value and the quitting time stay - only the target and its bar are gone. */
+  /**
+   * The booked value and the quitting time stay, the target is gone - and the progress track stays
+   * as an empty hint so the block keeps the height it has on a working day.
+   */
   private void assertNoTargetShown(Page page) {
     var progress = progress(page);
     assertThat(progress).isVisible();
     assertThat(progress).containsText("Gebucht");
     assertThat(progress).not().containsText("von");
     assertThat(progress).containsText("Feierabend");
+    assertThat(progress.locator(".progress")).hasCount(1);
     assertThat(progress.locator(".progress-bar")).hasCount(0);
   }
 


### PR DESCRIPTION
## Summary

Die Einzelübersicht (`/dailyreport/daily`) hat das Tagessoll ohne jede Kalenderprüfung direkt aus dem Vertrag abgeleitet und deshalb auch an Samstagen, Sonntagen und Feiertagen 8 Stunden angezeigt — mit einem Fortschrittsbalken, der sich nie füllen kann. Seit #856 war das immer sichtbar statt nur an Tagen mit gespeicherter Tageszeile.

`buildDailyView` bestimmt das Tagessoll jetzt über die kanonische Rechnung `OvertimeService.calculateWorkingTimeTarget(ec, tag, tag)` — dieselbe, die diese Ansicht für die Monatssumme (`buildListView`) längst benutzt: nur Montag bis Freitag, minus Feiertage auf Werktagen, begrenzt auf die Vertragsgültigkeit.

An einem Tag ohne Soll bleiben die gebuchte Zeit und der Feierabend sichtbar; das Tagessoll entfällt. Der Fortschrittsbalken wird nicht entfernt, sondern nur noch angedeutet: die leere Spur bleibt abgeschwächt und ohne Füllung stehen, damit die Anzeige an Wochenenden und Feiertagen dieselbe Höhe behält wie an einem Arbeitstag und die Karte zwischen den Tagen nicht springt. Dafür war das bisher einzige `hasTarget` aufzuteilen:

- `hasTarget` — der Vertrag rechnet überhaupt mit einem Soll (hat eine Tagesarbeitszeit). Steuert wie bisher, ob die Fortschrittsanzeige überhaupt erscheint; für Verträge ohne Tagesarbeitszeit ändert sich nichts.
- `hasDayTarget` — *dieser* Tag hat ein Soll. Steuert "von X h" und die Füllung des Balkens.

**Abweichung von den Akzeptanzkriterien:** das Ticket wollte an einem Tag ohne Soll auch den Feierabend entfernen. Der Feierabend ergibt sich aber aus Tagesbeginn plus Pause plus gebuchter Zeit (`calculateQuittingTime`) und nicht aus einem Soll — er ist damit auch an einem Samstag hilfreich und bleibt stehen. Nur `targetEndTime` ("wann wäre der Tag zu Ende, wenn das volle Soll gebucht wäre") hängt am Soll und entfällt ohne eines; das Feld wird derzeit von keinem Template gelesen.

Initiales Rendering und OOB-Refresh teilen sich weiterhin das Fragment `dailyProgressContent`, die Aufteilung gilt damit für beide Pfade.

## Test plan

- [x] `jenv exec ./mvnw verify` — 338 Tests, grün
- [x] `jenv exec ./mvnw test -Pe2e -De2e.browsers=chrome` — komplette E2E-Suite, 44 Tests, grün
- [x] Neu: `OvertimeServiceWorkingTimeTargetTest` — Tagessoll für Werktag, Samstag, Sonntag, Feiertag am Werktag, Feiertag am Wochenende (wird nicht doppelt abgezogen), vor Vertragsbeginn, nach Vertragsende
- [x] Neu: `DailyTargetOnNonWorkingDaysE2ETest` — Samstag, Werktagsfeiertag und Wochenendfeiertag ohne Soll und ohne Balkenfüllung, aber mit leerer Balkenspur, gebuchter Zeit und Feierabend; normaler Werktag unverändert mit Soll, Balken und Feierabend; eine Buchung am Samstag, die auch nach dem OOB-Refresh der Fortschrittsanzeige sichtbar bleibt
- [x] Gegenprobe: mit gestashten `src/main`-Änderungen fallen 4 der 5 E2E-Fälle um (nur der Werktags-Kontrollfall bleibt grün)
- [x] `DailyProgressUnitE2ETest` (#831) bleibt grün und deckt weiter "an normalen Werktagen unverändert" ab

Die E2E-Testdaten enthalten jetzt zwei Feiertage (`E2ETestData.HOLIDAY_ON_WEEKDAY` / `HOLIDAY_ON_WEEKEND`), bewusst im Oktober 2026 — ein Feiertag verschiebt das Soll seines gesamten Monats, und die E2E-Datenbank ist geteilt (#846). Kein anderer E2E-Test schaut in diesen Monat; die vollständige Suite ist grün.

## Zur offenen Frage im Ticket

`calculateWorkingTimeTarget` kennt nur "Montag bis Freitag minus Feiertage" mal einer einzigen Tagesarbeitszeit. Verträge mit abweichender Wochenverteilung (Teilzeit ohne Freitag) würden damit weiterhin falsch gerechnet — genauso wie bisher schon in der Monatssumme und im Überstundensaldo. Dieser PR übernimmt die bestehende Rechnung unverändert und macht das Problem nicht größer; eine korrekte Wochenverteilung wäre ein eigenes, größeres Thema.

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #857
