### PR TITLE
Rest nicht gearbeitet vor Fehlklick schützen (#855)

### DIFF
--- a/src/main/java/org/tb/dailyreport/controller/DailyController.java
+++ b/src/main/java/org/tb/dailyreport/controller/DailyController.java
@@ -103,6 +103,10 @@ public class DailyController {
                 model.addAttribute("listData", dailyService.buildListView(yearMonth, ecId));
             }
             model.addAttribute("yearMonth", yearMonth);
+            // the day the "back to daily view" button jumps to: today while the current month is
+            // shown, its first day otherwise - a month the user browsed to has no "current" day
+            model.addAttribute("dailyDate",
+                yearMonth.equals(YearMonth.from(today)) ? today : yearMonth.atDay(1));
             model.addAttribute("prevMonth", prev.getMonthValue());
             model.addAttribute("prevYear", prev.getYear());
             model.addAttribute("nextMonth", next.getMonthValue());
@@ -432,7 +436,7 @@ public class DailyController {
         return "redirect:/dailyreport/daily?mode=daily&date=" + date;
     }
 
-    @GetMapping("/fill-not-worked")
+    @PostMapping("/fill-not-worked")
     public String fillNotWorked(
             @RequestParam(required = false) Long employeeContractId,
             @RequestParam Integer month,

--- a/src/main/java/org/tb/dailyreport/controller/MatrixController.java
+++ b/src/main/java/org/tb/dailyreport/controller/MatrixController.java
@@ -12,6 +12,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -79,7 +80,7 @@ public class MatrixController {
         return "dailyreport/matrix";
     }
 
-    @GetMapping("/fill-not-worked")
+    @PostMapping("/fill-not-worked")
     @PreAuthorize("isAuthenticated()")
     public String fillNotWorked(
             @RequestParam(required = false) Long employeeContractId,

--- a/src/main/resources/org/tb/web/MessageResources.properties
+++ b/src/main/resources/org/tb/web/MessageResources.properties
@@ -982,6 +982,7 @@ main.invoice.title.print.text=Drucken
 main.invoice.title.suborder.text=Auftrag
 main.invoice.title.targethours.text=Budget
 main.matrix.fillnotworked.button.text=Rest nicht gearbeitet
+main.matrix.fillnotworked.confirm.text=Alle Arbeitstage dieses Monats ohne Buchung werden als nicht gearbeitet markiert, auch zukünftige. Das lässt sich nur Tag für Tag zurücknehmen. Fortfahren?
 main.matrix.fillnotworked.disabled.title=Monat bereits freigegeben
 main.matrix.fillnotworked.success.text=Offene Arbeitstage wurden als nicht gearbeitet markiert.
 main.matrixoverview.headline.actualtime.text=IST-Stunden:

--- a/src/main/resources/org/tb/web/MessageResources_en.properties
+++ b/src/main/resources/org/tb/web/MessageResources_en.properties
@@ -982,6 +982,7 @@ main.invoice.title.print.text=Print
 main.invoice.title.suborder.text=Suborder
 main.invoice.title.targethours.text=Target hours
 main.matrix.fillnotworked.button.text=Rest not worked
+main.matrix.fillnotworked.confirm.text=All workdays of this month without bookings will be marked as not worked, including future ones. This can only be undone day by day. Continue?
 main.matrix.fillnotworked.disabled.title=Month already released
 main.matrix.fillnotworked.success.text=Open working days have been marked as not worked.
 main.matrixoverview.headline.actualtime.text=Actual hours:

--- a/src/main/resources/templates/dailyreport/daily.html
+++ b/src/main/resources/templates/dailyreport/daily.html
@@ -785,15 +785,24 @@
     </div>
     <!--/* deliberately at the very end of the month, far away from the navigation: the action
            touches every open workday of the month at once and can only be undone day by day (#855) */-->
-    <div class="card-footer d-flex justify-content-end" id="daily-fill-not-worked"
+    <div class="card-footer d-flex justify-content-between align-items-center gap-3 flex-wrap"
+         id="daily-fill-not-worked"
          th:if="${listData != null and !listData.monthReleased and selectedContractId > 0}">
+      <!--/* the explanation used to be a title attribute, which never shows up on touch and does
+             nothing to make the action findable in the first place */-->
+      <span class="text-secondary small"
+            th:text="#{main.general.button.fillopenworkdaysnotworked.alttext.text}">
+        Alle Arbeitstage, an denen nichts gebucht wurde, werden auf 'nicht gearbeitet' gesetzt.
+      </span>
       <form method="post" th:action="@{/dailyreport/daily/fill-not-worked}"
             th:onsubmit="|return confirm('#{main.matrix.fillnotworked.confirm.text}')|">
         <input type="hidden" name="month" th:value="${yearMonth.monthValue}"/>
         <input type="hidden" name="year" th:value="${yearMonth.year}"/>
-        <button type="submit" class="btn btn-sm btn-outline-secondary"
-                th:title="#{main.general.button.fillopenworkdaysnotworked.alttext.text}"
-                th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</button>
+        <!--/* warning, like the "Nicht gearbeitet" badge this action produces */-->
+        <button type="submit" class="btn btn-outline-warning text-nowrap">
+          <i class="ti ti-calendar-off me-1"></i>
+          <span th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</span>
+        </button>
       </form>
     </div>
       </div><!-- end day list card -->

--- a/src/main/resources/templates/dailyreport/daily.html
+++ b/src/main/resources/templates/dailyreport/daily.html
@@ -93,7 +93,7 @@
     <div class="col-lg-8">
 
       <!-- Date navigation -->
-      <div class="card mb-3">
+      <div class="card mb-3" id="daily-mode-nav">
         <div class="card-body text-center py-3">
           <div class="d-flex justify-content-between align-items-center mb-2">
             <a class="btn btn-sm btn-outline-secondary"
@@ -671,7 +671,7 @@
   <div class="row align-items-start">
 
       <!-- Month navigation card -->
-      <div class="card mb-3">
+      <div class="card mb-3" id="daily-mode-nav">
         <div class="card-body text-center py-3">
           <div class="d-flex justify-content-between align-items-center mb-2">
             <a class="btn btn-sm btn-outline-secondary"
@@ -685,14 +685,20 @@
               <span th:text="#{main.daily.nav.nextmonth.text}">Nächster Monat</span><i class="ti ti-chevron-right ms-1"></i>
             </a>
           </div>
-          <a class="btn btn-sm btn-outline-primary"
-             th:href="@{/dailyreport/daily(mode='list')}">
-            <span th:text="#{main.daily.nav.today.text}">Heute</span>
-          </a>
-          <a th:if="${!listData.monthReleased and selectedContractId > 0 and listData != null}" class="btn btn-sm btn-outline-secondary"
-             th:href="@{/dailyreport/daily/fill-not-worked(month=${yearMonth.monthValue},year=${yearMonth.year})}">
-            <span th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</span>
-          </a>
+          <!--/* mirrors the mode toggle of the daily view, so the button that switches the mode sits
+                 at the same spot in both modes. Anything else here would be hit by the click that
+                 got the user into this view in the first place (#855) */-->
+          <div class="d-flex justify-content-center gap-2">
+            <a class="btn btn-sm btn-outline-primary"
+               th:href="@{/dailyreport/daily(mode='list')}">
+              <span th:text="#{main.general.month.current}">Aktueller Monat</span>
+            </a>
+            <a class="btn btn-sm btn-outline-secondary"
+               th:href="@{/dailyreport/daily(mode='daily',date=${dailyDate})}">
+              <i class="ti ti-calendar-event me-1"></i>
+              <span th:text="#{main.daily.mode.daily.text}">Tagesansicht</span>
+            </a>
+          </div>
         </div>
       </div>
 
@@ -776,6 +782,19 @@
         <span class="badge bg-warning-lt me-1" th:text="#{main.matrixoverview.legend.publicholiday.text}">Feiertag</span>
         <span class="badge me-1 matrix-today" th:text="#{main.daily.nav.today.text}">Heute</span>
       </span>
+    </div>
+    <!--/* deliberately at the very end of the month, far away from the navigation: the action
+           touches every open workday of the month at once and can only be undone day by day (#855) */-->
+    <div class="card-footer d-flex justify-content-end"
+         th:if="${listData != null and !listData.monthReleased and selectedContractId > 0}">
+      <form method="post" th:action="@{/dailyreport/daily/fill-not-worked}"
+            th:onsubmit="|return confirm('#{main.matrix.fillnotworked.confirm.text}')|">
+        <input type="hidden" name="month" th:value="${yearMonth.monthValue}"/>
+        <input type="hidden" name="year" th:value="${yearMonth.year}"/>
+        <button type="submit" class="btn btn-sm btn-outline-secondary"
+                th:title="#{main.general.button.fillopenworkdaysnotworked.alttext.text}"
+                th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</button>
+      </form>
     </div>
       </div><!-- end day list card -->
 

--- a/src/main/resources/templates/dailyreport/daily.html
+++ b/src/main/resources/templates/dailyreport/daily.html
@@ -785,7 +785,7 @@
     </div>
     <!--/* deliberately at the very end of the month, far away from the navigation: the action
            touches every open workday of the month at once and can only be undone day by day (#855) */-->
-    <div class="card-footer d-flex justify-content-end"
+    <div class="card-footer d-flex justify-content-end" id="daily-fill-not-worked"
          th:if="${listData != null and !listData.monthReleased and selectedContractId > 0}">
       <form method="post" th:action="@{/dailyreport/daily/fill-not-worked}"
             th:onsubmit="|return confirm('#{main.matrix.fillnotworked.confirm.text}')|">

--- a/src/main/resources/templates/dailyreport/matrix.html
+++ b/src/main/resources/templates/dailyreport/matrix.html
@@ -246,15 +246,24 @@
   </div>
   <!--/* same place as in the single overview: below the month, away from the navigation. The action
          touches every open workday of the month at once and can only be undone day by day (#855) */-->
-  <div class="card-footer d-flex justify-content-end" id="matrix-fill-not-worked"
+  <div class="card-footer d-flex justify-content-between align-items-center gap-3 flex-wrap"
+       id="matrix-fill-not-worked"
        th:if="${!monthReleased and selectedContractId > 0}">
+    <!--/* the explanation used to be a title attribute, which never shows up on touch and does
+           nothing to make the action findable in the first place */-->
+    <span class="text-secondary small"
+          th:text="#{main.general.button.fillopenworkdaysnotworked.alttext.text}">
+      Alle Arbeitstage, an denen nichts gebucht wurde, werden auf 'nicht gearbeitet' gesetzt.
+    </span>
     <form method="post" th:action="@{/dailyreport/matrix/fill-not-worked}"
           th:onsubmit="|return confirm('#{main.matrix.fillnotworked.confirm.text}')|">
       <input type="hidden" name="month" th:value="${yearMonth.monthValue}"/>
       <input type="hidden" name="year" th:value="${yearMonth.year}"/>
-      <button type="submit" class="btn btn-sm btn-outline-secondary"
-              th:title="#{main.general.button.fillopenworkdaysnotworked.alttext.text}"
-              th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</button>
+      <!--/* warning, like the "Nicht gearbeitet" badge this action produces */-->
+      <button type="submit" class="btn btn-outline-warning text-nowrap">
+        <i class="ti ti-calendar-off me-1"></i>
+        <span th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</span>
+      </button>
     </form>
   </div>
 </div>

--- a/src/main/resources/templates/dailyreport/matrix.html
+++ b/src/main/resources/templates/dailyreport/matrix.html
@@ -104,11 +104,18 @@
       <!-- Month navigation -->
       <th:block th:replace="~{fragments/month-picker :: monthPicker('matrix-month', null, ${yearMonth})}"></th:block>
       <a class="btn btn-sm btn-outline-secondary" th:href="@{/dailyreport/matrix}"
-         th:text="#{main.daily.nav.today.text}">Heute</a>
-      <a th:if="${!monthReleased and selectedContractId > 0}"
-         class="btn btn-sm btn-outline-secondary"
-         th:href="@{/dailyreport/matrix/fill-not-worked(month=${yearMonth.monthValue},year=${yearMonth.year})}"
-         th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</a>
+         th:text="#{main.general.month.current}">Aktueller Monat</a>
+      <!--/* the action touches every open workday of the month at once and can only be undone day by
+             day, so it asks before it fires and posts rather than following a link (#855) */-->
+      <form th:if="${!monthReleased and selectedContractId > 0}" method="post"
+            th:action="@{/dailyreport/matrix/fill-not-worked}"
+            th:onsubmit="|return confirm('#{main.matrix.fillnotworked.confirm.text}')|">
+        <input type="hidden" name="month" th:value="${yearMonth.monthValue}"/>
+        <input type="hidden" name="year" th:value="${yearMonth.year}"/>
+        <button type="submit" class="btn btn-sm btn-outline-secondary"
+                th:title="#{main.general.button.fillopenworkdaysnotworked.alttext.text}"
+                th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</button>
+      </form>
     </div>
   </div>
 </div>

--- a/src/main/resources/templates/dailyreport/matrix.html
+++ b/src/main/resources/templates/dailyreport/matrix.html
@@ -105,17 +105,6 @@
       <th:block th:replace="~{fragments/month-picker :: monthPicker('matrix-month', null, ${yearMonth})}"></th:block>
       <a class="btn btn-sm btn-outline-secondary" th:href="@{/dailyreport/matrix}"
          th:text="#{main.general.month.current}">Aktueller Monat</a>
-      <!--/* the action touches every open workday of the month at once and can only be undone day by
-             day, so it asks before it fires and posts rather than following a link (#855) */-->
-      <form th:if="${!monthReleased and selectedContractId > 0}" method="post"
-            th:action="@{/dailyreport/matrix/fill-not-worked}"
-            th:onsubmit="|return confirm('#{main.matrix.fillnotworked.confirm.text}')|">
-        <input type="hidden" name="month" th:value="${yearMonth.monthValue}"/>
-        <input type="hidden" name="year" th:value="${yearMonth.year}"/>
-        <button type="submit" class="btn btn-sm btn-outline-secondary"
-                th:title="#{main.general.button.fillopenworkdaysnotworked.alttext.text}"
-                th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</button>
-      </form>
     </div>
   </div>
 </div>
@@ -254,6 +243,19 @@
       <span class="badge bg-warning-lt me-1" th:text="#{main.matrixoverview.legend.publicholiday.text}">Feiertag</span>
       <span class="badge me-1 matrix-today" th:text="#{main.daily.nav.today.text}">Heute</span>
     </span>
+  </div>
+  <!--/* same place as in the single overview: below the month, away from the navigation. The action
+         touches every open workday of the month at once and can only be undone day by day (#855) */-->
+  <div class="card-footer d-flex justify-content-end" id="matrix-fill-not-worked"
+       th:if="${!monthReleased and selectedContractId > 0}">
+    <form method="post" th:action="@{/dailyreport/matrix/fill-not-worked}"
+          th:onsubmit="|return confirm('#{main.matrix.fillnotworked.confirm.text}')|">
+      <input type="hidden" name="month" th:value="${yearMonth.monthValue}"/>
+      <input type="hidden" name="year" th:value="${yearMonth.year}"/>
+      <button type="submit" class="btn btn-sm btn-outline-secondary"
+              th:title="#{main.general.button.fillopenworkdaysnotworked.alttext.text}"
+              th:text="#{main.matrix.fillnotworked.button.text}">Rest nicht gearbeitet</button>
+    </form>
   </div>
 </div>
 

--- a/src/test/java/org/tb/e2e/dailyreport/EnglishLocaleE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/EnglishLocaleE2ETest.java
@@ -48,8 +48,9 @@ class EnglishLocaleE2ETest extends PlaywrightE2ETestBase {
       assertThat(monthPicker).hasText("June 2026");
 
       Locator monthNavigation = page.locator("div.card:has(button.dropdown-toggle)").first();
-      assertThat(monthNavigation).containsText("Today");
-      assertThat(monthNavigation).not().containsText("Heute");
+      // the button jumps to the current month, not to today - it is labelled accordingly (#855)
+      assertThat(monthNavigation).containsText("Current month");
+      assertThat(monthNavigation).not().containsText("Aktueller Monat");
 
       // the picker itself lists the months in English, too
       monthPicker.click();

--- a/src/test/java/org/tb/e2e/dailyreport/EnglishLocaleE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/EnglishLocaleE2ETest.java
@@ -58,7 +58,8 @@ class EnglishLocaleE2ETest extends PlaywrightE2ETestBase {
       assertThat(monthMenu).containsText("December");
       assertThat(monthMenu).not().containsText("Dezember");
 
-      Locator legend = page.locator("div.card:has(#matrix) .card-footer");
+      // the matrix card carries a second footer holding the "Rest nicht gearbeitet" action (#855)
+      Locator legend = page.locator("div.card:has(#matrix) .card-footer").first();
       assertThat(legend).containsText("Sa/Su");
       assertThat(legend).containsText("Public holiday");
       assertThat(legend).containsText("Today");

--- a/src/test/java/org/tb/e2e/dailyreport/FillNotWorkedGuardE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/FillNotWorkedGuardE2ETest.java
@@ -56,26 +56,39 @@ class FillNotWorkedGuardE2ETest extends PlaywrightE2ETestBase {
   @ParameterizedTest(name = "{0}")
   @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
   void the_mass_change_sits_below_the_day_list_and_asks_first(E2EBrowser browser) {
-    runAsUser(browser, EMPLOYEE, listView(), page -> {
-      Locator button = page.locator("div.card:has(#daily-list) .card-footer")
-          .getByText(FILL_NOT_WORKED);
-      assertThat(button).isVisible();
+    runAsUser(browser, EMPLOYEE, listView(),
+        page -> assertAsksBeforeFiring(page, "#daily-fill-not-worked"));
+  }
 
-      List<String> prompts = new ArrayList<>();
-      // no handler registered means Playwright dismisses the dialog, which cancels the submit
-      page.onDialog(dialog -> {
-        prompts.add(dialog.message());
-        dialog.dismiss();
-      });
+  /** Same action, same place, same question - the matrix must not behave differently. */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void the_matrix_keeps_the_mass_change_out_of_its_filter_bar(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, "/dailyreport/matrix?month=6&year=2026", page -> {
+      Locator filterBar = page.locator("div.card:has([data-month-picker])").first();
+      assertThat(filterBar).not().containsText(FILL_NOT_WORKED);
 
-      button.click();
-      page.waitForTimeout(500);
-
-      Assertions.assertEquals(1, prompts.size(), "expected exactly one confirmation");
-      Assertions.assertTrue(prompts.getFirst().contains("nur Tag für Tag"), prompts.getFirst());
-      // dismissed - so the month is untouched and no success toast appeared
-      assertThat(page.locator(".alert-success")).hasCount(0);
+      assertAsksBeforeFiring(page, "#matrix-fill-not-worked");
     });
+  }
+
+  private void assertAsksBeforeFiring(Page page, String footerSelector) {
+    Locator button = page.locator(footerSelector).getByText(FILL_NOT_WORKED);
+    assertThat(button).isVisible();
+
+    List<String> prompts = new ArrayList<>();
+    page.onDialog(dialog -> {
+      prompts.add(dialog.message());
+      dialog.dismiss();
+    });
+
+    button.click();
+    page.waitForTimeout(500);
+
+    Assertions.assertEquals(1, prompts.size(), "expected exactly one confirmation");
+    Assertions.assertTrue(prompts.getFirst().contains("nur Tag für Tag"), prompts.getFirst());
+    // dismissed - so the month is untouched and no success toast appeared
+    assertThat(page.locator(".alert-success")).hasCount(0);
   }
 
   @ParameterizedTest(name = "{0}")

--- a/src/test/java/org/tb/e2e/dailyreport/FillNotWorkedGuardE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/FillNotWorkedGuardE2ETest.java
@@ -1,0 +1,107 @@
+package org.tb.e2e.dailyreport;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.tb.e2e.E2EBrowser;
+import org.tb.e2e.E2ETestData;
+import org.tb.e2e.PlaywrightE2ETestBase;
+
+/**
+ * "Rest nicht gearbeitet" used to sit in the month view exactly where the button that switches into
+ * that view sits in the daily view, so the click that navigated could immediately mark the whole
+ * month as not worked (#855). The mode toggle now occupies that spot in both directions, and the
+ * mass change moved below the day list, asks before it fires and no longer answers a GET.
+ */
+class FillNotWorkedGuardE2ETest extends PlaywrightE2ETestBase {
+
+  private static final String EMPLOYEE = E2ETestData.EMPLOYEE_MA_SIGN;
+  private static final String FILL_NOT_WORKED = "Rest nicht gearbeitet";
+  private static final String DAILY_VIEW = "/dailyreport/daily?mode=daily";
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void clicking_the_same_spot_twice_navigates_back_instead_of_filling(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, DAILY_VIEW, page -> {
+      // the click that got the user into the month view - and the one that used to trap them
+      navigationCard(page).getByText("Monatsübersicht").click();
+      page.waitForLoadState();
+      Assertions.assertTrue(page.url().contains("mode=list"), page.url());
+
+      navigationCard(page).getByText("Tagesansicht").click();
+      page.waitForLoadState();
+
+      Assertions.assertTrue(page.url().contains("mode=daily"), page.url());
+      assertThat(page.locator(".alert-success")).hasCount(0);
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void the_navigation_card_of_the_month_view_holds_no_mass_change(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, listView(), page -> {
+      assertThat(navigationCard(page)).not().containsText(FILL_NOT_WORKED);
+      assertThat(navigationCard(page)).containsText("Tagesansicht");
+      // the month view jumps to the current month, so that is what the button says
+      assertThat(navigationCard(page)).containsText("Aktueller Monat");
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void the_mass_change_sits_below_the_day_list_and_asks_first(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, listView(), page -> {
+      Locator button = page.locator("div.card:has(#daily-list) .card-footer")
+          .getByText(FILL_NOT_WORKED);
+      assertThat(button).isVisible();
+
+      List<String> prompts = new ArrayList<>();
+      // no handler registered means Playwright dismisses the dialog, which cancels the submit
+      page.onDialog(dialog -> {
+        prompts.add(dialog.message());
+        dialog.dismiss();
+      });
+
+      button.click();
+      page.waitForTimeout(500);
+
+      Assertions.assertEquals(1, prompts.size(), "expected exactly one confirmation");
+      Assertions.assertTrue(prompts.getFirst().contains("nur Tag für Tag"), prompts.getFirst());
+      // dismissed - so the month is untouched and no success toast appeared
+      assertThat(page.locator(".alert-success")).hasCount(0);
+    });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
+  void the_endpoints_no_longer_answer_a_get(E2EBrowser browser) {
+    runAsUser(browser, EMPLOYEE, listView(), page -> {
+      assertGetIsRejected(page, "/dailyreport/daily/fill-not-worked?month=6&year=2026");
+      assertGetIsRejected(page, "/dailyreport/matrix/fill-not-worked?month=6&year=2026");
+    });
+  }
+
+  /**
+   * A prefetched link, a bookmark or a step through the browser history must not be able to trigger
+   * the change any more.
+   */
+  private void assertGetIsRejected(Page page, String path) {
+    var response = page.navigate(urlWithLogin(path, EMPLOYEE));
+    Assertions.assertNotEquals(200, response.status(), path + " still answers a GET");
+  }
+
+  private Locator navigationCard(Page page) {
+    return page.locator("#daily-mode-nav");
+  }
+
+  private String listView() {
+    return "/dailyreport/daily?mode=list&month=6&year=2026";
+  }
+
+}

--- a/src/test/java/org/tb/e2e/dailyreport/MatrixE2ETest.java
+++ b/src/test/java/org/tb/e2e/dailyreport/MatrixE2ETest.java
@@ -91,7 +91,8 @@ class MatrixE2ETest extends PlaywrightE2ETestBase {
   @MethodSource("org.tb.e2e.PlaywrightE2ETestBase#browsers")
   void legend_and_month_picker_are_german_for_a_german_browser(E2EBrowser browser) {
     runAsUser(browser, E2ETestData.EMPLOYEE_MA_SIGN, "/dailyreport/matrix", page -> {
-      Locator legend = page.locator("div.card:has(#matrix) .card-footer");
+      // the matrix card carries a second footer holding the "Rest nicht gearbeitet" action (#855)
+      Locator legend = page.locator("div.card:has(#matrix) .card-footer").first();
       assertThat(legend).containsText("Sa/So");
       assertThat(legend).containsText("Feiertag");
       assertThat(legend).containsText("Heute");


### PR DESCRIPTION
Closes #855

## Problem

`daily.html` baut beide Modi der Einzelübersicht mit einer gleich aufgebauten Navigationskarte. In der zweiten Zeile stand:

| Modus | Zeile 2 |
|---|---|
| `mode=daily` | `[Heute] [Monatsübersicht]` |
| `mode=list` | `[Heute] [Rest nicht gearbeitet]` |

Beide zweiten Buttons waren `btn-sm btn-outline-secondary`, gleiche Größe, gleiche Position. Wer „Monatsübersicht" klickte, hatte den Cursor danach exakt über „Rest nicht gearbeitet" — ein zweiter Klick, etwa um zurückzugehen, löste die Massenänderung aus.

Verstärkend:

- Die Monatsansicht hatte überhaupt keinen Button zurück zur Tagesansicht, nur die Tagesnummern in der Tabelle.
- `MatrixService.fillNotWorked` markiert *alle* buchungsfreien Regelarbeitstage des Monats, auch zukünftige — mehr als der Name „Rest" vermuten lässt.
- Die Aktion war ein GET-Link, also durch Prefetch, Lesezeichen oder History-Navigation auslösbar.

Rückgängig geht nur Tag für Tag über die Checkbox in der Tagesansicht.

## Änderung

- An der Kollisionsposition steht in der Monatsansicht jetzt **Tagesansicht**, symmetrisch zum Moduswechsel der Tagesansicht. Sie springt auf heute, solange der aktuelle Monat gezeigt wird, sonst auf den Monatsersten.
- **Rest nicht gearbeitet** sitzt in einem eigenen Footer am Ende der Tagesliste, räumlich maximal weit von der Navigation entfernt, und fragt vorher nach. Der Dialog benennt den Wirkungsbereich inklusive zukünftiger Tage und dass die Rücknahme nur tageweise geht.
- Beide `fill-not-worked`-Endpunkte sind auf `@PostMapping` umgestellt und werden aus einem Formular gesendet.
- Die Matrixübersicht bekommt dieselbe Absicherung (Bestätigung + POST), damit sich die Aktion überall gleich verhält.
- Der Button zum aktuellen Monat hieß in Monats- und Matrixansicht „Heute", was unscharf war — er heißt jetzt „Aktueller Monat" (Schlüssel `main.general.month.current` gab es schon vom Monats-Picker). „Heute" bleibt den Legenden, die die hervorgehobene heutige Zeile bzw. Spalte erklären.

Der Wirkungsbereich von `fillNotWorked` selbst bleibt unverändert — bewusst nicht Teil dieses Tickets.

## Tests

Neu: `FillNotWorkedGuardE2ETest` (8 Tests, grün) prüft den Rundweg Tages- → Monatsansicht → zurück ohne Massenänderung, dass die Navigationskarte die Aktion nicht mehr enthält, dass der Button unter der Tagesliste nachfragt und dass beide Endpunkte kein GET mehr beantworten.

`EnglishLocaleE2ETest` angepasst: prüft in der Matrix-Filterleiste jetzt „Current month".

`MatrixE2ETest`, `DailyBookingE2ETest`, `ReleaseAcceptanceE2ETest`, `EnglishLocaleE2ETest` grün.

Nicht grün, aber vorbestehend: `DailyTargetOnNonWorkingDaysE2ETest#a_booking_on_a_saturday_stays_visible_after_an_out_of_band_refresh` schlägt auf `main` genauso fehl — der Test legt bei jedem Lauf eine Buchung an, die in der geteilten E2E-Datenbank nie aufgeräumt wird, sodass die erwartete Summe nach dem ersten Lauf nicht mehr stimmt.
