### PR TITLE
Release Notes nach Issue-Type gruppieren

### DIFF
--- a/.github/workflows/label-from-issue-type.yml
+++ b/.github/workflows/label-from-issue-type.yml
@@ -1,0 +1,144 @@
+name: Label PRs from Issue Type
+
+# Release notes are grouped by the labels of a pull request (see .github/release.yml), but pull
+# requests here are practically never labelled by hand - so almost everything ended up in "Other
+# Changes". The linked issue does carry a reliable classification: its issue type. This workflow
+# copies that type onto the pull request as the matching label, which is the signal release.yml
+# already knows how to read.
+#
+# The issue type is also the more accurate of the two: #855 was typed "Bug" while carrying the
+# label "enhancement".
+#
+# It runs after the merge rather than on the open pull request. The label only has to be in place
+# by the time a release is drafted, and a push to main is a trusted trigger with a writable token -
+# labelling the open pull request would need pull_request_target, which buys nothing here and is a
+# trigger this repository's zizmor audit rightly rejects.
+
+on:
+  push:
+    branches: [main]
+  # pull requests merged before this workflow existed carry no label at all, so they would still
+  # land in "Other Changes". Run it by hand with a number to fix those up one at a time.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to label (leave empty when triggered by a push)
+        required: false
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  label:
+    name: Apply the label of the linked issue type
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # add labels to the merged pull request
+    steps:
+      - name: Copy the issue type onto the merged pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          PR_INPUT: ${{ inputs.pr }}
+        run: |
+          set -euo pipefail
+
+          owner="${REPO%/*}"
+          name="${REPO#*/}"
+
+          # both paths emit the same "<pr number> <comma separated issue types>" lines.
+          # closingIssuesReferences holds the issues a pull request closes, which is what the
+          # closing keywords and the "Development" sidebar both feed.
+          types_jq='[.closingIssuesReferences.nodes[].issueType | select(. != null) | .name]
+                    | unique | join(",")'
+
+          if [ -n "${PR_INPUT:-}" ]; then
+            echo "Labelling pull request #$PR_INPUT on request."
+            pr_data=$(gh api graphql \
+              -f query='
+                query($owner: String!, $name: String!, $pr: Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $pr) {
+                      number
+                      closingIssuesReferences(first: 20) {
+                        nodes { number issueType { name } }
+                      }
+                    }
+                  }
+                }' \
+              -F owner="$owner" -F name="$name" -F pr="$PR_INPUT" \
+              --jq ".data.repository.pullRequest | \"\\(.number) \\($types_jq)\"")
+          else
+            # associatedPullRequests resolves the merge commit back to its pull request
+            pr_data=$(gh api graphql \
+              -f query='
+                query($owner: String!, $name: String!, $sha: GitObjectID!) {
+                  repository(owner: $owner, name: $name) {
+                    object(oid: $sha) {
+                      ... on Commit {
+                        associatedPullRequests(first: 5) {
+                          nodes {
+                            number
+                            closingIssuesReferences(first: 20) {
+                              nodes { number issueType { name } }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }' \
+              -F owner="$owner" -F name="$name" -F sha="$SHA" \
+              --jq ".data.repository.object.associatedPullRequests.nodes[]
+                    | \"\\(.number) \\($types_jq)\"")
+          fi
+
+          if [ -z "$pr_data" ]; then
+            echo "No pull request to label for ${PR_INPUT:-$SHA}."
+            exit 0
+          fi
+
+          # extend here when a new issue type should show up as its own release-notes category
+          label_for_type() {
+            case "$1" in
+              Bug)     echo bug ;;
+              Feature) echo enhancement ;;
+              *)       echo "" ;;
+            esac
+          }
+
+          while read -r pr types; do
+            [ -n "$pr" ] || continue
+
+            # dependabot and other pull requests without a linked issue land here
+            if [ -z "${types:-}" ]; then
+              echo "PR #$pr: no linked issue with an issue type - nothing to label."
+              continue
+            fi
+
+            labels=""
+            IFS=',' read -ra type_list <<< "$types"
+            for type in "${type_list[@]}"; do
+              [ -n "$type" ] || continue
+              label=$(label_for_type "$type")
+              if [ -z "$label" ]; then
+                echo "PR #$pr: issue type '$type' has no label mapped - skipping it."
+                continue
+              fi
+              echo "PR #$pr: issue type '$type' maps to label '$label'."
+              labels="${labels:+$labels,}$label"
+            done
+
+            if [ -z "$labels" ]; then
+              echo "PR #$pr: no linked issue type that maps to a label."
+              continue
+            fi
+
+            # only ever adds: a label somebody set by hand stays untouched
+            gh pr edit "$pr" --repo "$REPO" --add-label "$labels"
+          done <<< "$pr_data"


### PR DESCRIPTION
## Beschreibung

Ziel: die Release Notes sollen nach Issue-Type (Bug / Feature) gruppiert werden statt nach den Labels des Pull Requests.

**Das geht nicht in `.github/release.yml` selbst.** Das Schema kennt ausschließlich `labels` — es gibt keinen Typ-Schlüssel. Und kategorisiert werden Pull Requests, die überhaupt keinen Issue-Type tragen können; Typen sind eine Eigenschaft von Issues. Ein `types:`-Eintrag würde stillschweigend ignoriert.

Dabei kam ein zweiter Befund heraus: **die heutige Konfiguration läuft schon jetzt fast leer.** Von den letzten zwölf gemergten PRs trug genau einer Labels — `#853`, von Dependabot. Menschlich erstellte PRs werden hier nicht gelabelt, fallen also alle über `"*"` in „🔀 Other Changes". Die Kategorien `bug`, `enhancement` und `documentation` greifen praktisch nie.

Der Issue-Type ist tatsächlich das bessere Signal, und zwar in beide Richtungen — er ist vorhanden *und* genauer:

| PR | Label am PR | Verlinktes Issue → Type |
|---|---|---|
| #865 | – | #857 → `Bug` |
| #858 | – | #833 → `Feature` |
| #862 | – | #824 → `Bug` |
| #866 | – | #855 → `Bug` (Label am Issue: `enhancement`) |

## Änderung

Ein Workflow überträgt nach dem Merge den Type des verlinkten Issues als passendes Label auf den PR: `Bug` → `bug`, `Feature` → `enhancement`. Beide Labels existieren und werden von `release.yml` schon referenziert, **die Datei bleibt daher unverändert**.

Warum nach dem Merge und nicht am offenen PR: das Label muss erst stehen, wenn ein Release gezogen wird, und ein Push auf `main` ist ein vertrauenswürdiger Trigger mit schreibfähigem Token. Am offenen PR bräuchte es `pull_request_target` — das bringt hier keinen Vorteil und wird vom zizmor-Audit dieses Repos zu Recht als `dangerous-triggers` abgelehnt. Der Workflow checkt nichts aus und spricht nur die API.

Der Type kommt aus `closingIssuesReferences`, was sowohl die Closing-Keywords als auch die „Development"-Seitenleiste füllt. Gesetzt wird nur hinzugefügt, nie entfernt — manuell gepflegte Labels wie `needs-ops-action` bleiben unberührt und behalten ihre Priorität in `release.yml`.

Per `workflow_dispatch` mit einer PR-Nummer lassen sich die bereits gemergten PRs von 5.0.6 nachträglich labeln. Ohne das blieben die Release Notes dieses Milestones trotz Workflow unvollständig, weil diese PRs nie ein Label bekommen haben.

## Akzeptanzkriterien / Testplan

- [x] `zizmor --persona pedantic` über alle Workflows: keine Findings, keine Unterdrückung nötig
- [x] Beide GraphQL-Pfade gegen echte Daten geprüft — Push-Pfad über die Merge-Commits von `#865`, `#864`, Dispatch-Pfad über `#865` (`Bug`), `#858` (`Feature`), `#853` und `#866` (kein verlinktes Issue)
- [x] Shell-Logik gegen alle Randfälle geprüft: einzelner Type, mehrere Types, kein verlinktes Issue, nicht abgebildeter Type (`Task`), gemischt abgebildet/nicht, mehrere PRs pro Commit, leere Eingabe. Getestet unter bash 3.2, also strenger als das bash 5 der Runner — ein `read -ra` auf leerer Eingabe brach dabei unter `set -u` ab (der Dependabot-Fall) und ist jetzt abgefangen
- [ ] Erster echter Lauf nach dem Merge auf `main` — der `push`-Trigger lässt sich aus einem PR heraus nicht auslösen

## Operations / Deployment Notes

Keine. Der Workflow braucht nur `pull-requests: write` aus dem `GITHUB_TOKEN`, keine Secrets.

## Nebenbefunde

- **`Closes` statt `Behebt`:** #866 hatte „Behebt #855" im Body — kein GitHub-Keyword, also kein verlinktes Issue und damit auch kein Type. Ich habe das auf `Closes #855` korrigiert, das Issue ist jetzt verlinkt. Die Repo-Konvention ist ohnehin `Closes #N`. Falls das häufiger vorkommt, wäre ein Hinweis im `pull_request_template.md` sinnvoll — habe ich hier nicht angefasst.
- **Toter Eintrag in `release.yml`:** die Kategorie „✨ New Features" listet neben `enhancement` auch ein Label `Feature`, das es im Repo nicht gibt. Harmlos, aber wirkungslos. Ebenfalls nicht angefasst, um die Datei unverändert zu lassen.