### PR TITLE
Profil local-qa für belastbare lokale Performancemessungen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,23 @@ redirect(registry, "/old-path", "/new-path");
 - On macOS, prefix every `./mvnw` call with `jenv exec` so the correct JDK is on `PATH`: `jenv exec ./mvnw <goal>`.
   - If `jenv` is not installed and `java` is not found, prompt the user to install jenv (`brew install jenv`) and add the required JDK version before continuing.
 
+## Spring Profiles
+
+| Profile | Purpose |
+|---|---|
+| `local` | Daily local development: dev login via `?login-name=<sign>`, local datasource, devtools active |
+| `local-qa` | Local response-time measurement; pulls in `local` via profile group and overrides only performance-relevant settings with their production values (→ ADR-0020) |
+| `sqltrace` | Diagnostic overlay on top of `local-qa`: logs every SQL statement with its execution time |
+| `localeasyauth` | Local run against Azure Easy Auth |
+| `staging`, `production` | Deployed environments |
+| `unittest` | Test execution (set by the Surefire/Failsafe `argLine`) |
+
+**Parity rule for `local-qa`:** every entry in `application-local-qa.yaml` under `server`,
+`spring` and `salat` mirrors `application-production.yaml` exactly. When a PR changes a
+performance-relevant setting in `application-production.yaml`, it must change
+`application-local-qa.yaml` in the same PR. Deviations require a comment in the profile
+stating why (currently: actuator `metrics` exposure, Azure auth).
+
 ## GitHub Workflow
 - **Branch naming**: `feature/<issue-number>-<short-description>` (e.g. `feature/606-move-fromDBtimeToString-to-DurationUtils`)
 - **One issue per branch / PR**: do not bundle unrelated changes.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,48 @@ To start only the local database, without the Salat application:
 ⚠️ Be sure to remove existing docker containers before by running `docker-compose down` if you had the application running before.
 
 
+### Measuring response times locally (`local-qa` profile)
+
+The `local` profile runs on the base configuration, which differs from production in exactly
+the settings that determine response time (asset caching, Thymeleaf template cache, the
+authorization rule cache expiry). Response times measured under `local` are therefore not
+transferable to production.
+
+Use the `local-qa` profile instead. It keeps the local dev login and the local datasource,
+and overrides only the performance-relevant settings with their production values
+(see [ADR-0020](docs/adr/0020-local-qa-profil-fuer-performancemessungen.md)):
+
+    ./mvnw spring-boot:run -Dspring-boot.run.profiles=local-qa \
+      -Dspring-boot.run.jvmArguments="-Dspring.devtools.restart.enabled=false"
+
+`spring.devtools.restart.enabled` has to be passed as a JVM argument — it is evaluated before
+the configuration files are read, so setting it in a profile has no effect. All other devtools
+property defaults are switched off by the profile itself.
+
+Per-endpoint timings are then available at
+
+    http://localhost:8080/actuator/metrics/http.server.requests?tag=uri:/dailyreport/dashboard&login-name=<sign>
+
+The endpoint sits behind the authenticated filter chain, so it needs a valid `login-name`
+(or the `salat_dev_login` cookie) just like any page. It reports `COUNT`, `TOTAL_TIME` and
+`MAX`; the mean is `TOTAL_TIME / COUNT`. Percentiles are configured as histogram buckets and
+become readable once a scraping registry (e.g. Prometheus) is added — the `/actuator/metrics`
+endpoint itself does not render them.
+
+Two things `local-qa` cannot fix, which matter a lot when you have imported a production
+data dump into your local MySQL:
+
+- **InnoDB buffer pool.** The `testdb` container runs `mysql:8` with defaults, i.e.
+  `innodb_buffer_pool_size=128M`. With a production-sized dataset this alone dominates every
+  measurement. Start the database with a realistic value:
+
+      docker-compose -f docker-compose-infra.yml up -d
+      # then, for measurement runs, restart the db container with:
+      #   command: --lower_case_table_names=1 --innodb-buffer-pool-size=2G
+
+- **JVM warm-up.** The first requests measure JIT compilation, not the application. Discard
+  them and repeat the request a dozen times before reading the percentiles.
+
 ### Troubleshooting
 
 #### Missing bean buildProperties

--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ Two things `local-qa` cannot fix, which matter a lot when you have imported a pr
 data dump into your local MySQL:
 
 - **InnoDB buffer pool.** The `testdb` container runs `mysql:8` with defaults, i.e.
-  `innodb_buffer_pool_size=128M`. With a production-sized dataset this alone dominates every
-  measurement. Start the database with a realistic value:
+  `innodb_buffer_pool_size=128M`, while production runs `536870912` (512 MB). With a
+  production-sized dataset the local default alone dominates every measurement. For
+  measurement runs, start the db container with the production value — **not more**, or local
+  becomes faster than production and the parity rule is broken:
 
-      docker-compose -f docker-compose-infra.yml up -d
-      # then, for measurement runs, restart the db container with:
-      #   command: --lower_case_table_names=1 --innodb-buffer-pool-size=2G
+      # docker-compose-infra.yml, service db:
+      #   command: --lower_case_table_names=1 --innodb-buffer-pool-size=512M
 
 - **JVM warm-up.** The first requests measure JIT compilation, not the application. Discard
   them and repeat the request a dozen times before reading the percentiles.

--- a/docs/adr/0020-local-qa-profil-fuer-performancemessungen.md
+++ b/docs/adr/0020-local-qa-profil-fuer-performancemessungen.md
@@ -1,0 +1,85 @@
+# ADR-0020 Profil `local-qa` für Performancemessungen
+
+Date: 2026-08-22
+Status: Proposed
+
+## Context and Problem Statement
+
+Antwortzeitprobleme werden lokal reproduziert — meist mit einem Abzug der Produktionsdaten
+in der lokalen MySQL. Das Ergebnis solcher Messungen war bisher nicht auf Produktion
+übertragbar, weil das Profil `local` und das Profil `production` in genau den
+Einstellungen auseinanderlaufen, die die Antwortzeit bestimmen:
+
+| Einstellung | `local` | `production` |
+|---|---|---|
+| `spring.web.resources.cache.period` | *(nicht gesetzt)* | `1d` |
+| `server.tomcat.resource.allow-caching` / `cache-ttl` | *(nicht gesetzt)* | `true` / `1d` |
+| `salat.auth-service.cache-expiry` | `1s` | `1h` |
+| devtools auf dem Classpath | ja | nein |
+
+Es gibt keine `application-local.yaml`; `local` läuft auf der Basiskonfiguration.
+Dadurch werden lokal alle Webjars (plotly, tabler, bootstrap, jquery, htmx, tom-select)
+ohne Cache-Header und ohne Tomcat-Resource-Cache bei jedem Seitenaufruf neu ausgeliefert,
+devtools deaktiviert zusätzlich den Thymeleaf-Template-Cache, und der Autorisierungs-Cache
+in `AuthService.ensureUpToDateCache()` wird im Sekundentakt statt stündlich neu aufgebaut.
+
+Beide Fehlerrichtungen sind schädlich: Lokal sichtbare Langsamkeit existiert in Produktion
+teilweise gar nicht (Fehlalarm), und umgekehrt wird echter Produktionsaufwand von lokalem
+Rauschen überdeckt (blinder Fleck).
+
+## Considered Options
+
+* Beim Messen die Einstellungen ad hoc per JVM-Argumenten überschreiben
+* `application-local.yaml` anlegen und `local` selbst produktionsnah machen
+* Eigenes Profil `local-qa`, das `local` per Profilgruppe mitzieht und nur die
+  performancerelevanten Produktionswerte überschreibt
+
+## Decision Outcome
+
+Chosen: **eigenes Profil `local-qa`**, weil ad-hoc-JVM-Argumente nicht reproduzierbar sind
+und nicht reviewt werden, und weil ein produktionsnahes `local` die tägliche Entwicklung
+verschlechtern würde (kein Template-Reload, gecachte Assets).
+
+`local-qa` wird über eine Profilgruppe in `application.yaml` aktiviert und zieht `local` mit.
+Dev-Login und lokale Datasource bleiben damit unverändert; überschrieben wird ausschließlich,
+was die Antwortzeit beeinflusst.
+
+Aktivierung: `-Dspring.profiles.active=local-qa`
+
+### Parity-Regel
+
+Jeder Eintrag in `application-local-qa.yaml` unter `server`, `spring` und `salat` **spiegelt
+exakt** `application-production.yaml`. Werte dort werden nicht isoliert getunt. Ändert sich
+eine performancerelevante Einstellung in Produktion, wird `application-local-qa.yaml`
+im selben PR mitgezogen.
+
+Zwei bewusste Ausnahmen, beide im Profil kommentiert:
+
+1. **Actuator `metrics`** ist zusätzlich exponiert. Das ist das Messinstrument
+   (`http.server.requests` pro URI mit Perzentilen). Produktion exponiert nur `health` —
+   eine Entscheidung über die Angriffsfläche, keine Performance-Einstellung; die Timer
+   selbst laufen in Produktion ebenfalls mit.
+2. **Azure Easy Auth / OAuth2** wird nicht gespiegelt, weil es lokal keinen Azure-Login gibt.
+   Die für die Antwortzeit relevante Eigenschaft des Auth-Pfads ist aber in beiden Profilen
+   dieselbe: `SessionCreationPolicy.STATELESS`, also Re-Authentifizierung samt
+   `AuthenticationSuccessEvent`-Kaskade bei jedem Request.
+
+### Was `local-qa` nicht abdeckt
+
+* **Zweite Cache-Ebene**: `hibernate.cache.use_second_level_cache` ist in beiden Profilen
+  `false` — bewusst nicht in `local-qa` eingeschaltet, sonst wäre lokal schneller als Produktion.
+* **JVM-Warmlauf**: die ersten Requests messen JIT, nicht die Anwendung.
+* **MySQL**: der lokale Container (`testdb`, `mysql:8`) läuft mit Defaults, u. a.
+  `innodb_buffer_pool_size=128M`. Mit einem Produktionsdatenabzug ist das der dominierende
+  lokale Verfälschungsfaktor. Siehe README.
+* **devtools-Restart-Classloader**: `spring.devtools.restart.enabled` wird ausgewertet, bevor
+  Config-Dateien geladen sind, und muss als JVM-Argument gesetzt werden. Siehe README.
+
+### Consequences
+
+* Good: lokal gemessene Antwortzeiten sind auf Produktion übertragbar
+* Good: die Abweichungen zwischen lokal und Produktion stehen an einer Stelle und sind reviewbar
+* Good: `local` bleibt für die tägliche Entwicklung unangetastet (Template-Reload, kein Asset-Cache)
+* Bad: eine weitere Datei, die bei Produktionsänderungen mitgepflegt werden muss — die
+  Parity-Regel oben ist der Gegenmechanismus
+* Neutral: `local-qa` ersetzt keine Lastmessung; es macht Einzelrequest-Messungen belastbar

--- a/docs/adr/0020-local-qa-profil-fuer-performancemessungen.md
+++ b/docs/adr/0020-local-qa-profil-fuer-performancemessungen.md
@@ -70,8 +70,10 @@ Zwei bewusste Ausnahmen, beide im Profil kommentiert:
   `false` — bewusst nicht in `local-qa` eingeschaltet, sonst wäre lokal schneller als Produktion.
 * **JVM-Warmlauf**: die ersten Requests messen JIT, nicht die Anwendung.
 * **MySQL**: der lokale Container (`testdb`, `mysql:8`) läuft mit Defaults, u. a.
-  `innodb_buffer_pool_size=128M`. Mit einem Produktionsdatenabzug ist das der dominierende
-  lokale Verfälschungsfaktor. Siehe README.
+  `innodb_buffer_pool_size=128M`; Produktion läuft mit `536870912` (512 MB). Mit einem
+  Produktionsdatenabzug ist das der dominierende lokale Verfälschungsfaktor. Die Parity-Regel
+  gilt hier sinngemäß: für Messläufe den Produktionswert setzen, nicht mehr — sonst ist lokal
+  schneller als Produktion. Siehe README.
 * **devtools-Restart-Classloader**: `spring.devtools.restart.enabled` wird ausgewertet, bevor
   Config-Dateien geladen sind, und muss als JVM-Argument gesetzt werden. Siehe README.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,3 +33,4 @@ Format: [MADR](https://adr.github.io/madr/) — Markdown Any Decision Records.
 | [0017](0017-viewhelper-fuer-darstellungslogik.md) | ViewHelper-Klassen für darstellungsspezifische Aufbereitung | Accepted | 2026-06-22 |
 | [0018](0018-csrf-schutz-mit-cookie-tokenrepository.md) | CSRF-Schutz mit CookieCsrfTokenRepository und CsrfTokenRequestAttributeHandler | Accepted | 2026-06-28 |
 | [0019](0019-direkter-repository-zugriff-in-services.md) | Direkter Repository-Zugriff in Services (kein DAO für neue Module) | Accepted | 2026-07-05 |
+| [0020](0020-local-qa-profil-fuer-performancemessungen.md) | Profil `local-qa` für Performancemessungen | Proposed | 2026-08-22 |

--- a/src/main/resources/application-local-qa.yaml
+++ b/src/main/resources/application-local-qa.yaml
@@ -1,0 +1,54 @@
+# Profil "local-qa" — lokale Umgebung mit produktionsnahen Performance-Einstellungen.
+#
+# Zweck: Antwortzeiten lokal so messen, dass die Zahlen auf Produktion übertragbar sind.
+#
+# Aktivierung:  -Dspring.profiles.active=local-qa
+#   Die Profilgruppe in application.yaml aktiviert zusätzlich "local", d. h. Dev-Login
+#   (LocalDevSecurityConfiguration) und lokale Datasource bleiben unverändert.
+#
+# Regel (ADR-0020): Alle Einträge unter server/spring/salat spiegeln exakt
+# application-production.yaml. Werte hier nicht isoliert tunen — ändert sich eine
+# performancerelevante Einstellung in Produktion, wird diese Datei mitgezogen.
+#
+# Bewusst NICHT gespiegelt: Azure-Easy-Auth/OAuth2 (lokal gibt es keinen Azure-Login)
+# und die Produktions-Mailabsenderadresse.
+
+server:
+  tomcat:
+    resource:
+      allow-caching: true
+      cache-ttl: 1d
+    # keine Performance-Einstellung, aber ohne sie schlagen Massenformulare
+    # (Matrix, Massenänderung) lokal mit HTTP 400 fehl und sind nicht messbar
+    max-parameter-count: 2000
+spring:
+  devtools:
+    # devtools setzt sonst spring.thymeleaf.cache=false und spring.web.resources.cache.period=0
+    # und verfälscht damit jede Messung. Greift aus dieser Datei, weil
+    # DevToolsPropertyDefaultsPostProcessor kein Ordered implementiert und daher
+    # nach dem Laden der Config-Dateien läuft.
+    add-properties: false
+  web:
+    resources:
+      cache:
+        period: 1d
+salat:
+  auth-service:
+    # Produktion: 1h. Mit dem Default von 1s wird der Regel-Cache in
+    # AuthService.ensureUpToDateCache() im Sekundentakt komplett neu aufgebaut.
+    cache-expiry: 1h
+
+# Bewusste Abweichung von Produktion: Messinstrument.
+# Produktion exponiert nur "health" — das ist eine Entscheidung über die Angriffsfläche,
+# keine Performance-Einstellung. Die Timer selbst laufen in Produktion ebenfalls mit.
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      percentiles:
+        http.server.requests: 0.5,0.95,0.99

--- a/src/main/resources/application-sqltrace.yaml
+++ b/src/main/resources/application-sqltrace.yaml
@@ -1,0 +1,23 @@
+# Profil "sqltrace" — Diagnose-Overlay: protokolliert jedes SQL-Statement mit Laufzeit
+# und je Hibernate-Session eine Kennzahlen-Zusammenfassung.
+#
+# Aktivierung (immer als Overlay, nie allein):
+#   -Dspring.profiles.active=local-qa,sqltrace
+#
+# ACHTUNG: p6spy hängt sich in jeden JDBC-Aufruf ein und verfälscht die absoluten
+# Antwortzeiten. Aussagekräftig sind hier die Anzahl der Statements und ihre
+# Verteilung — für Antwortzeiten das Profil local-qa ohne dieses Overlay verwenden.
+#
+# Die URL muss dupliziert werden, weil p6spy über ein URL-Präfix aktiviert wird.
+# Ist die Umgebungsvariable SPRING_DATASOURCE_URL gesetzt, gewinnt diese und p6spy
+# bleibt still wirkungslos — dann die Variable für den Messlauf entfernen.
+
+spring:
+  datasource:
+    driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+    url: jdbc:p6spy:mysql://localhost:3306/salat?useUnicode=true&useJDBCCompliantTimezoneShift=true&serverTimezone=Europe/Berlin&useLegacyDatetimeCode=false&autoReconnect=true
+  jpa:
+    properties:
+      hibernate:
+        # loggt je Session eine "Session Metrics"-Zeile (Statements, JDBC-Zeit, Cache-Zugriffe)
+        generate_statistics: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,6 +50,10 @@ server:
 spring:
   profiles:
     default: local
+    group:
+      # "local-qa" zieht "local" mit: Dev-Login und lokale Datasource bleiben unverändert,
+      # application-local-qa.yaml überschreibt nur performancerelevante Einstellungen (ADR-0020).
+      local-qa: local
   messages:
     basename: org/tb/web/MessageResources
     encoding: UTF-8

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -3,9 +3,10 @@ realdriver=com.mysql.cj.jdbc.Driver
 execute=true
 appender=com.p6spy.engine.spy.appender.Slf4JLogger
 logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
-customLogMessageFormat=%(category);%(sqlSingleLine);%(effectiveSqlSingleLine);
+customLogMessageFormat=%(executionTime);%(category);%(effectiveSqlSingleLine);
 log4j2.format=true
 filter=true
 #excludecategories=error, info, batch, debug, statement, commit, rollback, result, resultset
-excludecategories=commit,rollback,batch
+# result/resultset wuerden eine Zeile pro Ergebniszeile erzeugen
+excludecategories=commit,rollback,batch,result,resultset
 #includecategories=statement,result, resultset


### PR DESCRIPTION
## Summary

Antwortzeiten werden lokal mit einem Produktionsdatenabzug reproduziert, sind aber nicht auf Produktion übertragbar. Das Profil `local` läuft auf der Basiskonfiguration und weicht genau in den Einstellungen von `production` ab, die die Antwortzeit bestimmen. Eine `application-local.yaml` existiert nicht.

| Einstellung | `local` | `production` |
|---|---|---|
| `spring.web.resources.cache.period` | *(nicht gesetzt)* | `1d` |
| `server.tomcat.resource.allow-caching` / `cache-ttl` | *(nicht gesetzt)* | `true` / `1d` |
| `salat.auth-service.cache-expiry` | `1s` | `1h` |
| devtools auf dem Classpath | ja | nein |

- **Profil `local-qa`** zieht `local` per Profilgruppe mit und überschreibt ausschließlich die performancerelevanten Produktionswerte. Dev-Login und lokale Datasource bleiben unverändert, damit das Profil im Alltag benutzbar bleibt.
- **Diagnose-Overlay `sqltrace`**: p6spy mit Laufzeit je Statement plus Hibernate Session Metrics. Bewusst getrennt, weil p6spy die absoluten Antwortzeiten verfälscht — für Zeitmessungen `local-qa` ohne Overlay verwenden.
- **ADR-0020** hält die Parity-Regel fest: ändert ein PR eine performancerelevante Einstellung in `application-production.yaml`, zieht er `application-local-qa.yaml` im selben PR nach.
- `spy.properties`: Ausführungszeit ins Logformat aufgenommen, `result`/`resultset` ausgeschlossen (sonst eine Logzeile pro Ergebniszeile).

Zwei bewusste Abweichungen von der Produktionskonfiguration, beide im Profil kommentiert: Actuator `metrics` ist zusätzlich exponiert (das Messinstrument; Produktion beschränkt sich aus Gründen der Angriffsfläche auf `health`, nicht aus Performance-Gründen), und Azure Easy Auth wird nicht gespiegelt, weil es lokal keinen Azure-Login gibt.

Nicht abgedeckt und in ADR und README dokumentiert: `innodb_buffer_pool_size` des `testdb`-Containers (128 MB bei ~485 MB Daten), JVM-Warmlauf, sowie `spring.devtools.restart.enabled`, das als JVM-Argument gesetzt werden muss, weil es vor dem Laden der Config-Dateien ausgewertet wird.

## Test plan

- [x] `jenv exec ./mvnw verify` — 338 Tests, 0 Failures, BUILD SUCCESS
- [x] `-Dspring.profiles.active=local-qa` aktiviert beide Profile: `The following 2 profiles are active: "local-qa", "local"`
- [x] Statische Ressourcen liefern `Cache-Control: max-age=86400` — belegt, dass die Profileinstellung die devtools-Defaults schlägt
- [x] Actuator exponiert 2 Endpunkte (`health`, `metrics`); `/actuator/metrics` liefert 200 mit gültigem `login-name`
- [x] `local-qa,sqltrace` startet, p6spy protokolliert Statements mit Laufzeit

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #868