### PR TITLE
Dashboard: N+1-Abfragen und Schreibzugriffe auf GET-Requests beseitigen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,11 @@ A feature or fix is considered done when **all** of the following are true:
 ## Documentation
 - Keep this document updated when architectural rules evolve.
 - Align feature work and code reviews with the rules above.
+- [`docs/performance-tips.md`](docs/performance-tips.md) collects measured performance rules —
+  consult it when adding JPA mappings, `AttributeConverter`s, repository queries or view helpers.
+  Most notably: **a class mapped via `AttributeConverter` must implement `equals`/`hashCode`**,
+  otherwise Hibernate treats the entity as dirty on every flush and emits UPDATEs on read-only
+  requests.
 
 ## Architecture Decision Records
 - ADRs live in [`docs/adr/`](docs/adr/README.md) (format: MADR).

--- a/docs/performance-tips.md
+++ b/docs/performance-tips.md
@@ -1,0 +1,106 @@
+# Performance Tips
+
+Praxisregeln aus konkreten Messungen an Salat. Jeder Abschnitt beschreibt ein Muster, das
+auf Testdaten unsichtbar ist und erst mit Produktionsdatenmengen auffällt.
+
+Wie gemessen wird: Profil `local-qa` (produktionsnahe Antwortzeiten) und das Overlay
+`sqltrace` (jedes Statement mit Laufzeit) — siehe [ADR-0020](adr/0020-local-qa-profil-fuer-performancemessungen.md)
+und den Abschnitt „Measuring response times locally" in der [README](../README.md).
+
+Faustregel für die Interpretation: **Nicht die Dauer einzelner Statements zählt, sondern ihre
+Anzahl.** Ein Request mit 768 Statements, von denen keines länger als 20 ms braucht, ist
+langsam wegen der 768 Roundtrips — kein Index und kein `OPTIMIZE TABLE` behebt das.
+
+---
+
+## 1. Konvertierte Attribute brauchen `equals`/`hashCode`
+
+**Regel:** Jede Klasse, die über einen `AttributeConverter` auf eine Spalte gemappt wird, muss
+`equals` und `hashCode` mit Wertesemantik implementieren.
+
+Hibernate entscheidet per `equals` gegen eine Kopie des Ladezustands, ob eine Entity schmutzig
+ist. Fehlt die Wertesemantik, greift Identitätsvergleich, der Vergleich schlägt immer fehl, und
+die Entity gilt bei **jedem** Flush als geändert.
+
+Gemessener Fall: `UserPreference.settings` ist per `@Convert(UserPreferenceConverter.class)` auf
+`UserPreferenceMap` gemappt. Die Klasse war unveränderlich, hatte aber kein `equals`. Folge:
+**90 `UPDATE`-Statements pro GET-Request auf das Dashboard**, ohne dass irgendetwas geändert
+wurde. Nach Ergänzen von `equals`/`hashCode`: 0.
+
+Verschärfend kommt hinzu: Mit `open-in-view: true` lebt der Persistence Context über das
+komplette Rendering, und jede Query in einer nicht-`readOnly`-Transaktion löst einen Auto-Flush
+aus. Eine dauerhaft „schmutzige" Entity erzeugt damit ein UPDATE pro Query im Request.
+
+**Prüfen:** Neue `AttributeConverter` immer zusammen mit `equals`/`hashCode` auf dem Domain-Typ
+einführen. Ein fehlendes `equals` bricht keinen Test — es kostet nur stillschweigend Schreibzugriffe.
+
+## 2. `@ManyToOne` über `@JoinTable` ist EAGER und erzeugt N+1
+
+`@ManyToOne` ist ohne `fetch`-Angabe **EAGER**. Geht die Assoziation über eine `@JoinTable`,
+löst Hibernate sie nicht per Join auf, sondern mit einem Sekundär-Select **pro Zeile**.
+
+Gemessener Fall: `Employee.salatUser` (`@ManyToOne` + `@JoinTable`). Ein `findAll()` über 194
+Mitarbeiter erzeugte 194 zusätzliche `select … from salat_user where id=?`. Bei zwei Aufrufen
+pro Request: 389 Statements.
+
+**Lösung:** Repository-Methode mit explizitem Join-Fetch statt `findAll()`:
+
+```java
+@Query("SELECT e FROM Employee e LEFT JOIN FETCH e.salatUser")
+List<Employee> findAllWithSalatUser();
+```
+
+`LEFT JOIN FETCH` statt `JOIN FETCH`, sonst fallen Zeilen ohne Assoziation stillschweigend raus —
+das ist eine Verhaltensänderung, kein Performance-Fix.
+
+Die Assoziation stattdessen auf `LAZY` zu stellen hilft **nicht**, wenn der Code sie ohnehin für
+jede Zeile dereferenziert: dann entstehen dieselben N Selects, nur später.
+
+## 3. Autorisierung nicht nach dem Laden in Java filtern
+
+Muster: alle Zeilen laden, danach per Java-Stream auf die sichtbaren filtern
+(`findAll().stream().filter(auth::isAuthorized)`). Die Datenbank liefert Zeilen, die verworfen
+werden, und wenn das Autorisierungsprädikat eine Assoziation dereferenziert, kommt N+1 dazu
+(siehe 2.).
+
+Zu finden u. a. in `EmployeeService.getLoginEmployees`, `EmployeecontractDAO`, `EmployeeDAO`,
+`EmployeeorderDAO`, `TimereportDAO`. Neue Abfragen sollten das Prädikat in die Query ziehen.
+
+## 4. ViewHelper werden pro Render mehrfach aufgerufen
+
+Thymeleaf ruft dieselbe Getter-Methode während eines Renders beliebig oft auf. Ein ViewHelper
+ohne Puffer macht daraus ebenso viele Queries.
+
+Gemessener Fall: `EmployeeContractSelectorViewHelper.getSelectedContractId()` löste 90
+`getCurrentContract`-Queries pro Request aus. Die Nachbarmethode `getViewableContracts()`
+pufferte bereits — der Puffer fehlte nur an einer Stelle.
+
+**Regel:** ViewHelper sind `@Scope(SCOPE_REQUEST)`; jeder DB-Zugriff darin gehört in ein
+Feld gepuffert. Dabei nur den teuren Zugriff puffern, nicht die gesamte Methode, damit
+Vorrangregeln (z. B. `UiState` vor DB-Fallback) erhalten bleiben.
+
+## 5. Was Datenbank-Wartung nicht behebt
+
+`ANALYZE TABLE` und `OPTIMIZE TABLE` wurden auf dem Produktionsdatenabzug gemessen:
+
+| | Statements | SQL-Zeit | Antwortzeit (n=30) |
+|---|---|---|---|
+| Ausgangslage | 768 | 828 ms | 1,654 s ± 0,075 |
+| nach `ANALYZE` + `OPTIMIZE` | 768 | 622 ms | 1,654 s ± 0,075 (keine Änderung) |
+| nach den Code-Fixes 1–4 | 205 | 272 ms | **0,558 s ± 0,028** |
+
+`OPTIMIZE TABLE` senkte die reine SQL-Zeit, bewegte die Antwortzeit aber **nicht** — der Request
+hing nicht daran, wie schnell MySQL antwortet, sondern an der Anzahl der Roundtrips. Erst die
+Code-Änderungen wirkten.
+
+Kleine Stichproben täuschen: Bei einer Streuung von sd ≈ 0,4 s sind 12 Messungen zu wenig, um
+eine Verbesserung von 6 % von Rauschen zu unterscheiden. Mindestens 30 Messungen nach Warmlauf,
+und Mittelwert immer mit Standardfehler angeben.
+
+## 6. Lokale Verfälschungsfaktoren
+
+* Der `testdb`-Container läuft mit `innodb_buffer_pool_size=128M` — bei ~485 MB
+  Produktionsdaten der größte lokale Störfaktor.
+* Ohne Profil `local-qa` fehlen Asset-Caching und Thymeleaf-Template-Cache, und der
+  Autorisierungs-Cache läuft im Sekundentakt statt stündlich ab.
+* Die ersten Requests nach dem Start messen JIT-Compilation, nicht die Anwendung.

--- a/src/main/java/org/tb/dailyreport/viewhelper/EmployeeContractSelectorViewHelper.java
+++ b/src/main/java/org/tb/dailyreport/viewhelper/EmployeeContractSelectorViewHelper.java
@@ -26,6 +26,8 @@ public class EmployeeContractSelectorViewHelper {
     private final AuthorizedEmployee authorizedEmployee;
 
     private List<Employeecontract> cachedContracts;
+    private Long cachedCurrentContractId;
+    private boolean currentContractIdResolved;
 
     public List<Employeecontract> getViewableContracts() {
         if (cachedContracts == null) {
@@ -40,9 +42,17 @@ public class EmployeeContractSelectorViewHelper {
 
     public Long getSelectedContractId() {
         var id = uiState.getLongValue(EMPLOYEE_CONTRACT_ID);
-        return id != null ? id : employeecontractService.getCurrentContract(authorizedEmployee.getEmployeeId())
-                .map(AuditedEntity::getId)
-                .orElse(null);
+        if (id != null) return id;
+        // Nur der DB-Fallback wird gepuffert; UiState wird weiterhin bei jedem Aufruf gelesen,
+        // damit eine Änderung während des Requests weiterhin Vorrang behält. Das Template ruft
+        // diese Methode pro Render mehrfach auf.
+        if (!currentContractIdResolved) {
+            cachedCurrentContractId = employeecontractService.getCurrentContract(authorizedEmployee.getEmployeeId())
+                    .map(AuditedEntity::getId)
+                    .orElse(null);
+            currentContractIdResolved = true;
+        }
+        return cachedCurrentContractId;
     }
 
     public Employeecontract getSelectedContract() {

--- a/src/main/java/org/tb/employee/persistence/EmployeeRepository.java
+++ b/src/main/java/org/tb/employee/persistence/EmployeeRepository.java
@@ -1,5 +1,6 @@
 package org.tb.employee.persistence;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -17,5 +18,14 @@ public interface EmployeeRepository extends PagingAndSortingRepository<Employee,
 
   @Query("SELECT e FROM Employee e WHERE e.salatUser.loginname = :loginname")
   Optional<Employee> findByLoginname(@Param("loginname") String loginname);
+
+  /**
+   * Wie {@code findAll()}, lädt den {@link org.tb.auth.domain.SalatUser} aber im selben
+   * Statement mit. {@code Employee.salatUser} ist ein {@code @ManyToOne} über eine
+   * {@code @JoinTable} und damit EAGER; ohne Join-Fetch löst Hibernate die Assoziation
+   * mit einem Sekundär-Select pro Zeile auf (N+1).
+   */
+  @Query("SELECT e FROM Employee e LEFT JOIN FETCH e.salatUser")
+  List<Employee> findAllWithSalatUser();
 
 }

--- a/src/main/java/org/tb/employee/service/EmployeeService.java
+++ b/src/main/java/org/tb/employee/service/EmployeeService.java
@@ -11,7 +11,6 @@ import static org.tb.common.exception.ServiceFeedbackMessage.error;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -64,9 +63,7 @@ public class EmployeeService {
   }
 
   public List<Employee> getLoginEmployees() {
-    var employees = StreamSupport
-        .stream(employeeRepository.findAll().spliterator(), false).toList();
-    return employees.stream()
+    return employeeRepository.findAllWithSalatUser().stream()
         .filter(e -> employeeAuthorization.isAuthorized(e, LOGIN))
         .toList();
   }

--- a/src/main/java/org/tb/settings/domain/UserPreferenceMap.java
+++ b/src/main/java/org/tb/settings/domain/UserPreferenceMap.java
@@ -2,7 +2,15 @@ package org.tb.settings.domain;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
+/**
+ * Unveränderlicher Wertetyp. {@code equals}/{@code hashCode} sind zwingend erforderlich:
+ * Das Attribut {@code UserPreference.settings} wird über einen {@link UserPreferenceConverter}
+ * gemappt, und Hibernate entscheidet per {@code equals} gegen eine Kopie des Ladezustands,
+ * ob die Entity schmutzig ist. Ohne Wertesemantik gilt sie bei jedem Flush als geändert und
+ * erzeugt ein UPDATE — auch bei reinen GET-Requests.
+ */
 public final class UserPreferenceMap {
 
   private final Map<String, Map<String, Object>> modules;
@@ -27,6 +35,18 @@ public final class UserPreferenceMap {
 
   public Map<String, Map<String, Object>> asRawMap() {
     return modules;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof UserPreferenceMap other)) return false;
+    return modules.equals(other.modules);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(modules);
   }
 
 }


### PR DESCRIPTION
## Summary

Ein Aufruf von `/dailyreport/dashboard` setzte mit Produktionsdaten **768 SQL-Statements** ab. Kein einzelnes Statement dauerte länger als 20 ms — die Antwortzeit entstand allein durch die Anzahl der Roundtrips. Drei Ursachen erzeugten 569 davon.

**1. N+1 auf `Employee.salatUser` (389 → 3 Statements).** Die Assoziation ist `@ManyToOne` ohne `fetch`-Angabe, also EAGER, und geht über eine `@JoinTable`; Hibernate löst sie nicht per Join auf, sondern mit einem Sekundär-Select pro Zeile. `getLoginEmployees()` lädt per `findAll()` alle 194 Mitarbeiter und filtert danach in Java, und die Methode läuft zweimal pro Request. Ersetzt durch eine Repository-Methode mit `LEFT JOIN FETCH`.

`LEFT` statt `INNER`: aktuell haben alle 194 Mitarbeiter einen `salat_user`, beide Varianten liefern also dasselbe. `INNER` würde Zeilen ohne Assoziation aber stillschweigend verwerfen — das wäre eine Verhaltensänderung, kein Performance-Fix.

Die Assoziation stattdessen auf `LAZY` zu stellen hilft nicht: das Autorisierungsprädikat dereferenziert `getSalatUser()` für jede Zeile, es entstünden dieselben N Selects. Ausserdem würde das jede andere `Employee`-Ladestelle betreffen.

**2. `update user_preference` auf einem GET-Request (90 → 0).** `UserPreference.settings` ist per `@Convert` auf `UserPreferenceMap` gemappt; die Klasse ist unveränderlich, implementierte aber kein `equals`/`hashCode`. Hibernates Dirty-Check vergleicht daher per Identität gegen eine Kopie des Ladezustands, kommt immer zu „geändert" und schreibt bei jedem Auto-Flush ein UPDATE — obwohl nichts geändert wurde. Mit `open-in-view: true` lebt der Persistence Context über das komplette Rendering, jede Query in einer nicht-`readOnly`-Transaktion löst einen Auto-Flush aus.

Unabhängig von der Performance ein Defekt: ein lesender Request schrieb in die Datenbank.

**3. Ungepufferter ViewHelper (90 → 3).** `EmployeeContractSelectorViewHelper.getSelectedContractId()` rief `getCurrentContract()` bei jedem der ~90 Template-Aufrufe neu auf; die Nachbarmethode `getViewableContracts()` pufferte bereits. Gepuffert wird nur der DB-Fallback, nicht das Methodenergebnis, damit `UiState` weiterhin bei jedem Aufruf gelesen wird und seinen Vorrang behält.

Ursachen 2 und 3 hängen zusammen: die 90 UPDATEs waren Auto-Flushes, ausgelöst durch die 90 Queries. Nur die Query-Anzahl zu senken hätte den Dirty-Check-Defekt verdeckt statt behoben.

## Messung

Profil `local-qa` (#868) auf einem Produktionsdatenabzug, n=30 nach Warmlauf:

| | Statements | SQL-Zeit | Antwortzeit |
|---|---|---|---|
| Ausgangslage | 768 | 828 ms | 1,654 s ± 0,075 |
| nach diesem PR | **205** | **272 ms** | **0,558 s ± 0,028** |

`ANALYZE TABLE` und `OPTIMIZE TABLE` über alle 65 Tabellen wurden vorab gemessen: die reine SQL-Zeit sank auf 622 ms, die Antwortzeit blieb unverändert bei 1,654 s. Der Request hing nicht daran, wie schnell MySQL antwortet.

## Dokumentation

Neu: `docs/performance-tips.md` mit den gemessenen Mustern, verlinkt aus AGENTS.md. Wichtigste Regel: **eine per `AttributeConverter` gemappte Klasse muss `equals`/`hashCode` implementieren** — ein fehlendes `equals` bricht keinen Test, es kostet nur stillschweigend Schreibzugriffe. Deshalb steht die Regel zusätzlich als Javadoc an `UserPreferenceMap`.

## Bekannt, nicht Teil dieses PRs

- `EmployeeAuthorization` dereferenziert `employee.getSalatUser().getLoginname()` ungeprüft (Zeilen 30 und 36), während `Employee` selbst überall auf `null` prüft. Aktuell kein NPE, weil alle Mitarbeiter einen `salat_user` haben — eigenes Issue wert.
- Das Muster „alles laden, danach in Java filtern" besteht in weiteren DAOs fort; es dominiert die Antwortzeit nur nicht mehr.
- Die `AuthenticationSuccessEvent`-Kaskade läuft weiterhin bei jedem Request, auch in Produktion (beide Filter-Chains sind `STATELESS`).

## Test plan

- [x] `jenv exec ./mvnw verify` — 338 Tests, 0 Failures, BUILD SUCCESS
- [x] Dashboard mit Produktionsdaten: 768 → 205 Statements, per p6spy verifiziert
- [x] `update user_preference` auf GET: 90 → 0
- [x] `salat_user`-Selects: 389 → 3; `Employeecontract`-Selects: 90 → 3
- [x] Antwortzeit n=30 nach Warmlauf: 1,654 s → 0,558 s
- [ ] Gegenprüfung durch Reviewer, dass die Auswahl des Employeecontracts im Dashboard unverändert funktioniert (UiState-Vorrang vor DB-Fallback)

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #869