### PR TITLE
HikariCP: Verbindungspool an die verfügbaren Datenbankressourcen anpassen

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -62,8 +62,17 @@ spring:
     username: salattest                # env: SPRING_DATASOURCE_USERNAME
     password: salattest                # env: SPRING_DATASOURCE_PASSWORD
     hikari:
-      connection-timeout: 1000
-      minimum-idle: 0
+      # Wartezeit auf eine freie Verbindung. Wird sie überschritten, wirft HikariCP eine
+      # Exception, statt weiter zu warten — der Benutzer bekommt dann HTTP 500 statt einer
+      # langsamen Seite. Tomcat läuft mit 200 Request-Threads gegen 20 Verbindungen, es können
+      # also viele Threads gleichzeitig warten. Der frühere Wert von 1s liess dafür zu wenig
+      # Reserve (gemessen: 708 ms Maximalwartezeit unter Last).
+      connection-timeout: 10000       # env: SPRING_DATASOURCE_HIKARI_CONNECTION_TIMEOUT
+      # minimum-idle wird bewusst nicht gesetzt: HikariCP setzt es dann auf maximum-pool-size
+      # und hält den Pool auf fester Grösse. Mit minimum-idle=0 schrumpfte der Pool nach
+      # idleTimeout auf null, und die ersten Requests nach einer Ruhephase bezahlten den
+      # Verbindungsaufbau. Produktions-MySQL erlaubt max_connections=171, dauerhaft gehaltene
+      # 20 Verbindungen sind dort unkritisch.
       maximum-pool-size: 20           # env: SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE
   jpa:
     generate-ddl: false


### PR DESCRIPTION
## Summary

Produktions-MySQL erlaubt `max_connections=171`, und ausser der Anwendung verbinden sich nur wenige Admin-Benutzer — rund 150 Verbindungen stehen ungenutzt zur Verfügung. Der Pool war trotzdem so eingestellt, als wäre Verbindungsknappheit das Problem.

**`connection-timeout: 1000` → `10000`.** Tomcat läuft mit dem Default von 200 Request-Threads gegen 20 Verbindungen; bis zu 180 Threads können gleichzeitig auf eine Verbindung warten. Wird die Grenze überschritten, wirft HikariCP eine Exception, statt weiter zu warten — der Benutzer bekommt HTTP 500 statt einer langsamen Seite. 10 s ist lang genug, um Lastspitzen abzufedern, und kurz genug, um vor üblichen Proxy-Timeouts zu greifen.

**`minimum-idle: 0` entfernt.** HikariCP setzt `minimumIdle` dann auf `maximumPoolSize` und hält den Pool auf fester Grösse — die ausdrückliche Empfehlung des Projekts. Vorher schrumpfte der Pool nach `idleTimeout` (Default 10 Minuten) auf null, und die ersten Requests nach einer Ruhephase, praktisch also die ersten Benutzer am Morgen, bezahlten den Verbindungsaufbau auf dem Request-Pfad.

**`maximum-pool-size: 20` unverändert.** Mehr Verbindungen helfen nicht, wenn die Datenbank der Engpass ist. Das Missverhältnis lag zwischen 200 Tomcat-Threads und einem Ein-Sekunden-Budget, nicht bei der Poolgrösse.

Beide Werte sind im Profil kommentiert, damit die Begründung nicht verloren geht.

## Messung

Lokaler Lasttest, 360 Requests auf `/dailyreport/dashboard` bei Concurrency 10/30/60:

| | vorher | nachher |
|---|---|---|
| HTTP-Fehler | 0 | 0 |
| Pool-Timeouts | 0 | 0 |
| Maximale Wartezeit auf eine Verbindung | 708 ms | 552 ms |
| Poolgrösse nach Start (im Leerlauf) | 0 | 20 |
| Reserve bis zur Fehlerschwelle | 29 % | 94 % |

Ausschlaggebend ist nicht die Verbesserung der Wartezeit — die liegt im Rauschen —, sondern der Abstand zur Fehlerschwelle. Vorher lagen wir bei moderater Nebenläufigkeit auf einem einzelnen Rechner bereits bei einem Drittel des Limits.

**Einschränkung:** gemessen auf einem Laptop, auf dem Anwendung und MySQL gemeinsam laufen, mit dem lokalen Buffer Pool von 128 MB statt der 512 MB in Produktion. Produktion ist schneller, die absoluten Wartezeiten reproduzieren sich dort vermutlich nicht. Der strukturelle Punkt bleibt: eine Sekunde ist ein knappes Budget, und ein Überschreiten äussert sich als Fehler statt als Verzögerung.

## Annahme, die geprüft gehört

20 dauerhaft gehaltene Verbindungen sind gegenüber `max_connections=171` unkritisch, solange nicht mehr als etwa sechs Instanzen gegen dieselbe Datenbank laufen. Trifft das nicht zu, gehört `maximum-pool-size` überprüft.

## Abgrenzung

Kein Beitrag zur Antwortzeit eines einzelnen Requests (dafür #869) — hier geht es ausschliesslich um das Verhalten unter Last.

## Test plan

- [x] `jenv exec ./mvnw verify` — 338 Tests, 0 Failures, BUILD SUCCESS
- [x] Pool steht nach dem Start sofort auf 20 Verbindungen statt auf 0
- [x] Lasttest bis Concurrency 60: keine HTTP-Fehler, keine Pool-Timeouts
- [x] Nach dem Deployment `hikaricp.connections.timeout` und `hikaricp.connections.acquire` in Produktion gegenprüfen — nur dort lässt sich beurteilen, wie nahe die reale Last der Schwelle kommt

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #873