### PR TITLE
Retention für etl_execution_history

### DIFF
--- a/src/main/java/org/tb/common/SalatProperties.java
+++ b/src/main/java/org/tb/common/SalatProperties.java
@@ -18,6 +18,7 @@ public class SalatProperties {
   private AuthService authService;
   private UiState uiState = new UiState();
   private Notifications notifications = new Notifications();
+  private Etl etl = new Etl();
 
   @Data
   public static class Auth {
@@ -59,6 +60,16 @@ public class SalatProperties {
   public static class Notifications {
     private int retentionDays = 30;
     private int bellLimit = 10;
+  }
+
+  @Data
+  public static class Etl {
+    private History history = new History();
+
+    @Data
+    public static class History {
+      private int retentionDays = 14;
+    }
   }
 
 }

--- a/src/main/java/org/tb/etl/persistence/ETLExecutionHistoryRepository.java
+++ b/src/main/java/org/tb/etl/persistence/ETLExecutionHistoryRepository.java
@@ -1,8 +1,22 @@
 package org.tb.etl.persistence;
 
-import org.tb.etl.domain.ETLExecutionHistory;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.tb.etl.domain.ETLExecutionHistory;
 
 public interface ETLExecutionHistoryRepository extends JpaRepository<ETLExecutionHistory, Long> {
+
+  /**
+   * @return Anzahl der gelöschten Einträge
+   */
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("""
+      DELETE FROM ETLExecutionHistory h
+      WHERE h.executedAt < :cutoff
+      """)
+  int deleteExecutedBefore(@Param("cutoff") LocalDateTime cutoff);
 
 }

--- a/src/main/java/org/tb/etl/service/ETLExecutionHistoryCleanupService.java
+++ b/src/main/java/org/tb/etl/service/ETLExecutionHistoryCleanupService.java
@@ -1,0 +1,37 @@
+package org.tb.etl.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tb.common.SalatProperties;
+import org.tb.common.util.ClockProvider;
+import org.tb.etl.persistence.ETLExecutionHistoryRepository;
+
+/**
+ * Löscht abgelaufene Einträge aus {@code etl_execution_history}.
+ *
+ * <p>Die Tabelle wuchs unbegrenzt: jeder nächtliche ETL-Lauf schreibt eine Zeile pro Definition
+ * und Referenzperiode, jede mit dem vollständigen SQL-Text im {@code message}-Feld (~6 KB).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ETLExecutionHistoryCleanupService {
+
+  private final ETLExecutionHistoryRepository repository;
+  private final SalatProperties salatProperties;
+
+  // läuft nach dem nächtlichen ETL (0 0 2) und dem Notification-Cleanup (0 30 2)
+  @Scheduled(cron = "0 45 2 * * *")
+  @Transactional
+  public void deleteExpiredExecutionHistory() {
+    int retentionDays = salatProperties.getEtl().getHistory().getRetentionDays();
+    var cutoff = ClockProvider.now().minusDays(retentionDays);
+    int deleted = repository.deleteExecutedBefore(cutoff);
+    log.info("Deleted {} ETL execution history entries older than {} days (before {})",
+        deleted, retentionDays, cutoff);
+  }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,6 +24,13 @@ salat:
   cache:
     max-entries: 1000                # env: SALAT_CACHE_MAX_ENTRIES
     expiry-tti: 10                   # env: SALAT_CACHE_EXPIRY_TTI
+  etl:
+    history:
+      # env: SALAT_ETL_HISTORY_RETENTION_DAYS — days to keep ETL execution history before auto-delete.
+      # Jeder nächtliche Lauf schreibt eine Zeile pro Definition und Referenzperiode, jede davon
+      # mit dem vollständigen SQL-Text im message-Feld (~6 KB). Ohne Retention wächst die Tabelle
+      # unbegrenzt weiter, während die Nutzdaten das nicht tun.
+      retention-days: 14
   locale-cookie-name: SALAT_LOCALE    # env: SALAT_LOCALE_COOKIE_NAME — name of the browser cookie used to persist the user's language preference
   notifications:
     retention-days: 30               # env: SALAT_NOTIFICATIONS_RETENTION_DAYS — days to keep notifications before auto-delete

--- a/src/test/java/org/tb/etl/service/ETLExecutionHistoryCleanupServiceTest.java
+++ b/src/test/java/org/tb/etl/service/ETLExecutionHistoryCleanupServiceTest.java
@@ -1,0 +1,105 @@
+package org.tb.etl.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.tb.common.SalatProperties;
+import org.tb.common.util.ClockProvider;
+import org.tb.etl.domain.ETLExecutionHistory;
+import org.tb.etl.persistence.ETLExecutionHistoryRepository;
+
+@DataJpaTest
+@Import({ ETLExecutionHistoryCleanupService.class, SalatProperties.class })
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ETLExecutionHistoryCleanupServiceTest {
+
+  private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 22, 3, 0);
+
+  @Autowired
+  private ETLExecutionHistoryCleanupService cleanupService;
+
+  @Autowired
+  private ETLExecutionHistoryRepository repository;
+
+  @Autowired
+  private SalatProperties salatProperties;
+
+  @BeforeEach
+  void setUp() {
+    ClockProvider.useFixedClock(NOW);
+    repository.deleteAll();
+    salatProperties.getEtl().getHistory().setRetentionDays(14);
+  }
+
+  @AfterEach
+  void tearDown() {
+    ClockProvider.reset();
+  }
+
+  @Test
+  void deletes_only_entries_older_than_the_retention_period() {
+    save(NOW.minusDays(15));
+    save(NOW.minusDays(200));
+    var withinRetention = save(NOW.minusDays(13));
+    var today = save(NOW);
+
+    cleanupService.deleteExpiredExecutionHistory();
+
+    assertThat(repository.findAll())
+        .extracting(ETLExecutionHistory::getId)
+        .containsExactlyInAnyOrder(withinRetention.getId(), today.getId());
+  }
+
+  @Test
+  void respects_a_changed_retention_period() {
+    salatProperties.getEtl().getHistory().setRetentionDays(90);
+    save(NOW.minusDays(91));
+    var kept = save(NOW.minusDays(89));
+
+    cleanupService.deleteExpiredExecutionHistory();
+
+    assertThat(repository.findAll())
+        .extracting(ETLExecutionHistory::getId)
+        .containsExactly(kept.getId());
+  }
+
+  @Test
+  void removes_a_large_backlog_in_one_statement() {
+    for (int i = 0; i < 1200; i++) {
+      save(NOW.minusDays(100));
+    }
+    save(NOW);
+
+    cleanupService.deleteExpiredExecutionHistory();
+
+    assertThat(repository.count()).isEqualTo(1);
+  }
+
+  @Test
+  void does_nothing_when_no_entry_is_expired() {
+    save(NOW.minusDays(1));
+
+    cleanupService.deleteExpiredExecutionHistory();
+
+    assertThat(repository.count()).isEqualTo(1);
+  }
+
+  private ETLExecutionHistory save(LocalDateTime executedAt) {
+    return repository.save(ETLExecutionHistory.builder()
+        .etlId(1L)
+        .etlName("test-etl")
+        .executedAt(executedAt)
+        .success(true)
+        .message("Execute SQL: select 1")
+        .build());
+  }
+
+}


### PR DESCRIPTION
## Summary

`etl_execution_history` belegte **236,8 MB von 484,7 MB Gesamtgrösse der Datenbank — 49 %** bei rund 40.000 Zeilen. Jeder nächtliche ETL-Lauf schreibt eine Zeile pro Definition und Referenzperiode, jede mit dem vollständigen SQL-Text im `message`-Feld (~6 KB, `ETLService.java:139-186`). Eine Retention gab es nicht: die Tabelle wuchs unbegrenzt, während die Nutzdaten das nicht tun.

Übernimmt das Muster aus dem `notification`-Modul — konfigurierbarer Aufbewahrungszeitraum plus geplanter Cleanup:

- `salat.etl.history.retention-days`, Default **14 Tage**, überschreibbar via `SALAT_ETL_HISTORY_RETENTION_DAYS`
- `ETLExecutionHistoryCleanupService`, täglich um 02:45 — nach dem ETL-Lauf (02:00) und dem Notification-Cleanup (02:30)
- Bulk-Delete per JPQL, ein Statement

## Wirkung

Auf dem Produktionsdatenabzug (40.596 Zeilen aus 6,6 Monaten):

| | Zeilen | Tabelle | Datenbank gesamt |
|---|---|---|---|
| vorher | 40.596 | ~237 MB | 484,7 MB |
| nach dem ersten Lauf | 2.107 | ~12 MB | ~260 MB |

Der erste Lauf räumt 38.489 Zeilen ab, danach hält sich die Tabelle bei rund zwei Wochen Historie.

## Zur Umsetzung

Der erste Entwurf löste den Rückstand in Chargen von 1000 auf (IDs per `Pageable` lesen, dann `deleteAllByIdInBatch`), um eine grosse Einzeltransaktion zu vermeiden. Das kostete zwei Statements und eine 1000-elementige `IN`-Liste pro Charge. Ein Bulk-Delete per JPQL erledigt dasselbe mit einem Statement und entspricht dem bestehenden `NotificationRepository.deleteByCreatedBefore`; der Entwurf wurde entsprechend ersetzt.

Damit läuft der einmalige Rückstand von 38.489 Zeilen in einer Transaktion. InnoDB sperrt dabei zeilenweise, nicht die Tabelle, und der Lauf liegt um 02:45 — die gelöschten Zeilen liegen ausserdem ausserhalb des Bereichs, in den der ETL-Lauf schreibt. Sollte das unerwünscht sein, lässt sich der Rückstand einmalig manuell in Chargen abräumen; ab dem zweiten Lauf sind es nur noch die Zeilen eines Tages.

`@Modifying(flushAutomatically = true, clearAutomatically = true)`, damit der Persistence Context nach dem Bulk-Delete keine gelöschten Entities mehr vorhält.

## Nicht enthalten

Das im Issue erwähnte Begrenzen der `message`-Länge bzw. das Speichern des vollständigen SQL-Texts nur im Fehlerfall. Das würde die Ursache statt der Symptome adressieren, ändert aber das Verhalten des Audit-Trails und gehört in ein eigenes Issue.

Randnotiz für später: `ETLExecutionHistory.message` ist als `length = 4000` deklariert, die tatsächlichen Zeilen sind im Schnitt ~6 KB gross. Die Spalte ist in der Datenbank offenbar weiter gefasst, `ddl-auto: validate` schlägt darauf nicht an.

## Test plan

- [x] `jenv exec ./mvnw verify` — 342 Tests, 0 Failures, BUILD SUCCESS
- [x] Löscht nur Einträge älter als der Aufbewahrungszeitraum (Grenzfälle 13/15 Tage)
- [x] Berücksichtigt einen geänderten Aufbewahrungszeitraum
- [x] Räumt einen Rückstand oberhalb von 1000 Zeilen ab
- [x] Tut nichts, wenn kein Eintrag abgelaufen ist

Reviewed AGENTS.md; changes comply with architecture, view, and security guidelines.

Closes #872